### PR TITLE
feat: encode tracker announce URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,8 +87,8 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "itoa",
  "matchit",
@@ -98,7 +98,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -113,13 +113,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -173,12 +173,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
@@ -207,9 +201,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -553,35 +547,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.11.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http",
  "indexmap 2.11.0",
  "slab",
  "tokio",
@@ -622,17 +597,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -644,23 +608,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -671,8 +624,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -696,30 +649,6 @@ checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -728,9 +657,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -742,12 +671,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -756,15 +700,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.32",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -773,19 +720,24 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.7.0",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -934,7 +886,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -988,7 +940,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "libc",
 ]
 
@@ -1145,7 +1097,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1366,7 +1318,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
 ]
 
 [[package]]
@@ -1399,42 +1351,56 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1449,7 +1415,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1457,12 +1423,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1498,7 +1488,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1656,6 +1646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,15 +1664,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1691,20 +1684,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1825,6 +1818,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,11 +1862,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.12",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -1907,9 +1910,28 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2002,6 +2024,12 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2188,12 +2216,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2221,21 +2269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2273,12 +2306,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2291,12 +2318,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2306,12 +2327,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2339,12 +2354,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2354,12 +2363,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2375,12 +2378,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2393,12 +2390,6 @@ checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -2408,16 +2399,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -2495,6 +2476,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = "0.3"
 thiserror = "2.0.9"
 indicatif = "0.17.7"
 flume = { version = "0.11.0", default-features = false, features = ["async", "select"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 byteorder = "1.4.3"
 serde_bencode = "0.2.3"
 serde_bytes = "0.11.12"

--- a/crates/bit_rev/src/file.rs
+++ b/crates/bit_rev/src/file.rs
@@ -3,10 +3,11 @@ use serde::Serialize;
 use serde_bencode::de;
 use serde_bencode::ser;
 use serde_bytes::ByteBuf;
-use std::fmt::Write;
 use std::io::Read;
 
 use anyhow::Result;
+
+const URL_UNRESERVED_HEX: &[u8; 16] = b"0123456789ABCDEF";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Node(String, i64);
@@ -105,45 +106,230 @@ pub fn from_filename(filename: &str) -> Result<TorrentMeta> {
     Ok(TorrentMeta::new(torrent))
 }
 
-pub fn url_encode_bytes(content: &[u8]) -> Result<String> {
-    let mut out: String = String::new();
+/// RFC 3986 unreserved set `A-Z a-z 0-9 - . _ ~` stays literal; every other byte is `%XX`.
+/// Encodes raw bytes; never interprets the input as UTF-8.
+pub fn url_encode_bytes(content: &[u8]) -> String {
+    let mut out = String::with_capacity(content.len() * 3);
 
-    for byte in content.iter() {
-        match *byte as char {
-            '0'..='9' | 'a'..='z' | 'A'..='Z' | '.' | '-' | '_' | '~' => out.push(*byte as char),
-            _ => write!(&mut out, "%{:02X}", byte)?,
-        };
+    for &byte in content {
+        match byte {
+            b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(URL_UNRESERVED_HEX[(byte >> 4) as usize] as char);
+                out.push(URL_UNRESERVED_HEX[(byte & 0x0f) as usize] as char);
+            }
+        }
     }
 
-    Ok(out)
+    out
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnnounceEvent {
+    Started,
+    Stopped,
+    Completed,
+}
+
+impl AnnounceEvent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Started => "started",
+            Self::Stopped => "stopped",
+            Self::Completed => "completed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnnounceParams {
+    pub uploaded: u64,
+    pub downloaded: u64,
+    pub left: u64,
+    pub port: u16,
+    pub event: Option<AnnounceEvent>,
+    pub numwant: u32,
+    pub key: u32,
+}
+
+impl AnnounceParams {
+    pub const DEFAULT_NUMWANT: u32 = 50;
+}
+
+fn push_encoded_pair(url: &mut String, key: &str, value: &[u8]) {
+    if !url.ends_with('?') && !url.ends_with('&') {
+        let separator = if url.contains('?') { '&' } else { '?' };
+        url.push(separator);
+    }
+    url.push_str(key);
+    url.push('=');
+    url.push_str(&url_encode_bytes(value));
 }
 
 pub fn build_tracker_url(
     torrent_meta: &TorrentMeta,
     peer_id: &[u8],
-    port: u16,
     tracker_url: &str,
-) -> Result<String> {
-    // let announce_url = torrent_meta.torrent_file.announce.as_ref().unwrap();
-    let info_hash_encoded = url_encode_bytes(torrent_meta.info_hash.as_ref())?;
-    let peer_id_encoded = url_encode_bytes(peer_id)?;
-    // let info_hash_encoded = urlencoding::encode_binary(&torrent_meta.info_hash);
-    // let peer_id_encoded = urlencoding::encode_binary(&peer_id);
+    params: &AnnounceParams,
+) -> String {
+    let mut url = String::from(tracker_url);
 
-    let total_length = if let Some(length) = torrent_meta.torrent_file.info.length {
-        length
-    } else if let Some(files) = &torrent_meta.torrent_file.info.files {
-        files.iter().map(|f| f.length).sum()
-    } else {
-        return Err(anyhow::anyhow!(
-            "Invalid torrent file: missing length information"
-        ));
-    };
+    push_encoded_pair(&mut url, "info_hash", torrent_meta.info_hash.as_ref());
+    push_encoded_pair(&mut url, "peer_id", peer_id);
+    push_encoded_pair(&mut url, "port", params.port.to_string().as_bytes());
+    push_encoded_pair(&mut url, "uploaded", params.uploaded.to_string().as_bytes());
+    push_encoded_pair(
+        &mut url,
+        "downloaded",
+        params.downloaded.to_string().as_bytes(),
+    );
+    push_encoded_pair(&mut url, "left", params.left.to_string().as_bytes());
+    push_encoded_pair(&mut url, "compact", b"1");
+    if let Some(event) = params.event {
+        push_encoded_pair(&mut url, "event", event.as_str().as_bytes());
+    }
+    push_encoded_pair(&mut url, "numwant", params.numwant.to_string().as_bytes());
+    push_encoded_pair(&mut url, "key", params.key.to_string().as_bytes());
 
-    Ok(format!(
-        // "{}?info_hash={}&peer_id={}&port={}&uploaded=0&downloaded=0&compact=1&left={}&event=started?supportcrypto=1&numwant=80&key=DF45C574",
-        "{}?info_hash={}&peer_id={}&port={}&uploaded=0&downloaded=0&compact=1&left={}",
-        tracker_url, info_hash_encoded, peer_id_encoded, port, total_length
-    )
-    .to_string())
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const INFO_HASH_FIXTURE: [u8; 20] = [
+        0x00, 0x20, 0xFF, b'A', b'z', b'0', b'-', b'.', b'_', b'~', 0x01, 0x7F, 0x80, b'/', b'?',
+        b'&', b'=', b'+', 0x0A, 0x0D,
+    ];
+    const INFO_HASH_ENCODED: &str = "%00%20%FFAz0-._~%01%7F%80%2F%3F%26%3D%2B%0A%0D";
+
+    const PEER_ID: [u8; 20] = [
+        b'-', b'B', b'R', 0x00, 0xFF, b' ', b'~', b'_', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    ];
+    const PEER_ID_ENCODED: &str = "-BR%00%FF%20~_%01%02%03%04%05%06%07%08%09%0A%0B%0C";
+
+    fn test_meta(info_hash: [u8; 20]) -> TorrentMeta {
+        TorrentMeta {
+            torrent_file: TorrentFile {
+                info: Info {
+                    name: "test".into(),
+                    pieces: ByteBuf::from(info_hash.to_vec()),
+                    piece_length: 16384,
+                    md5sum: None,
+                    length: Some(1_000_000),
+                    files: None,
+                    private: None,
+                    path: None,
+                    root_hash: None,
+                },
+                announce: Some("http://tracker.example/announce".into()),
+                nodes: None,
+                encoding: None,
+                httpseeds: None,
+                announce_list: None,
+                creation_date: None,
+                comment: None,
+                created_by: None,
+            },
+            info_hash,
+            piece_hashes: vec![info_hash],
+        }
+    }
+
+    fn sample_params(event: Option<AnnounceEvent>) -> AnnounceParams {
+        AnnounceParams {
+            uploaded: 100,
+            downloaded: 200,
+            left: 300,
+            port: 6881,
+            event,
+            numwant: AnnounceParams::DEFAULT_NUMWANT,
+            key: 0xDF45_C574,
+        }
+    }
+
+    #[test]
+    fn url_encode_bytes_encodes_binary_info_hash() {
+        assert_eq!(url_encode_bytes(&INFO_HASH_FIXTURE), INFO_HASH_ENCODED);
+    }
+
+    #[test]
+    fn url_encode_bytes_keeps_unreserved_set() {
+        assert_eq!(
+            url_encode_bytes(b"ABCXYZabcxyz0123456789-._~"),
+            "ABCXYZabcxyz0123456789-._~"
+        );
+    }
+
+    #[test]
+    fn build_tracker_url_appends_question_mark_when_no_query() {
+        let url = build_tracker_url(
+            &test_meta(INFO_HASH_FIXTURE),
+            &PEER_ID,
+            "http://tracker.example/announce",
+            &sample_params(Some(AnnounceEvent::Started)),
+        );
+        assert!(url.starts_with("http://tracker.example/announce?info_hash="));
+    }
+
+    #[test]
+    fn build_tracker_url_appends_ampersand_when_query_present() {
+        let url = build_tracker_url(
+            &test_meta(INFO_HASH_FIXTURE),
+            &PEER_ID,
+            "http://tracker.example/announce?passkey=x",
+            &sample_params(Some(AnnounceEvent::Started)),
+        );
+        assert!(url.starts_with("http://tracker.example/announce?passkey=x&info_hash="));
+        assert_eq!(url.chars().filter(|&c| c == '?').count(), 1);
+    }
+
+    #[test]
+    fn build_tracker_url_includes_all_encoded_params() {
+        let url = build_tracker_url(
+            &test_meta(INFO_HASH_FIXTURE),
+            &PEER_ID,
+            "http://tracker.example/announce",
+            &sample_params(Some(AnnounceEvent::Started)),
+        );
+        let expected = format!(
+            "http://tracker.example/announce?info_hash={INFO_HASH_ENCODED}&peer_id={PEER_ID_ENCODED}&port=6881&uploaded=100&downloaded=200&left=300&compact=1&event=started&numwant=50&key=3745891700"
+        );
+        assert_eq!(url, expected);
+    }
+
+    #[test]
+    fn build_tracker_url_omits_event_when_none() {
+        let url = build_tracker_url(
+            &test_meta(INFO_HASH_FIXTURE),
+            &PEER_ID,
+            "http://tracker.example/announce",
+            &sample_params(None),
+        );
+        assert!(!url.contains("event="));
+        assert!(url.contains("&compact=1&numwant=50&key=3745891700"));
+    }
+
+    #[test]
+    fn build_tracker_url_encodes_completed_and_stopped_events() {
+        let completed = build_tracker_url(
+            &test_meta(INFO_HASH_FIXTURE),
+            &PEER_ID,
+            "http://tracker.example/announce",
+            &sample_params(Some(AnnounceEvent::Completed)),
+        );
+        assert!(completed.contains("&event=completed&"));
+
+        let stopped = build_tracker_url(
+            &test_meta(INFO_HASH_FIXTURE),
+            &PEER_ID,
+            "http://tracker.example/announce",
+            &sample_params(Some(AnnounceEvent::Stopped)),
+        );
+        assert!(stopped.contains("&event=stopped&"));
+    }
 }

--- a/crates/bit_rev/src/peer_connection.rs
+++ b/crates/bit_rev/src/peer_connection.rs
@@ -36,6 +36,22 @@ impl TorrentDownloadedState {
             .all(|pw| pw.downloaded.load(std::sync::atomic::Ordering::Relaxed))
     }
 
+    pub fn downloaded_bytes(&self) -> u64 {
+        self.pieces
+            .iter()
+            .filter(|pw| pw.downloaded.load(std::sync::atomic::Ordering::Relaxed))
+            .map(|pw| u64::from(pw.piece_work.length))
+            .sum()
+    }
+
+    pub fn left_bytes(&self) -> u64 {
+        self.pieces
+            .iter()
+            .filter(|pw| !pw.downloaded.load(std::sync::atomic::Ordering::Relaxed))
+            .map(|pw| u64::from(pw.piece_work.length))
+            .sum()
+    }
+
     pub fn missing_pieces(&self) -> Vec<u32> {
         self.pieces
             .iter()
@@ -185,7 +201,7 @@ impl PieceWorkState {
         let mut chuncks = self.chuncks.lock().unwrap();
         let mut buf = vec![];
         // sort by start
-        chuncks.sort_by(|a, b| a.start.cmp(&b.start));
+        chuncks.sort_by_key(|a| a.start);
         for chunk in chuncks.iter() {
             buf.extend(chunk.buf.iter());
         }

--- a/crates/bit_rev/src/tracker_peers.rs
+++ b/crates/bit_rev/src/tracker_peers.rs
@@ -1,10 +1,14 @@
+use rand::Rng;
 use serde_bencode::de;
-use std::sync::{atomic::AtomicBool, Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use tokio::{select, sync::Semaphore, time::sleep};
 use tracing::{debug, error};
 
 use crate::{
-    file::{self, TorrentMeta},
+    file::{self, AnnounceEvent, AnnounceParams, TorrentMeta},
     peer::BencodeResponse,
     peer_connection::{
         FullPiece, PeerConnection, PeerHandler, PieceWorkState, TorrentDownloadedState,
@@ -24,6 +28,7 @@ pub struct TrackerPeers {
     pub pr_rx: flume::Receiver<PieceResult>,
     pub have_broadcast: Arc<tokio::sync::broadcast::Sender<u32>>,
     pub download_state: Arc<Mutex<DownloadState>>,
+    announce_key: u32,
 }
 
 impl TrackerPeers {
@@ -46,6 +51,7 @@ impl TrackerPeers {
             peer_states,
             have_broadcast,
             download_state,
+            announce_key: rand::thread_rng().gen(),
         }
     }
 
@@ -95,6 +101,9 @@ impl TrackerPeers {
         let piece_tx = self.piece_tx.clone();
         let have_broadcast = self.have_broadcast.clone();
         let download_state = self.download_state.clone();
+        let announce_key = self.announce_key;
+        let sent_started = Arc::new(AtomicBool::new(false));
+        let sent_completed = Arc::new(AtomicBool::new(false));
         let torrent_downloaded_state = Arc::new(TorrentDownloadedState {
             semaphore: Semaphore::new(1),
             pieces: pieces_of_work
@@ -116,6 +125,31 @@ impl TrackerPeers {
                 } {
                     sleep(std::time::Duration::from_millis(100)).await;
                 }
+
+                // TODO(#8): wire uploaded from the session upload counter once seeding exists
+                let uploaded = 0u64;
+                let downloaded = torrent_downloaded_state.downloaded_bytes();
+                let left = torrent_downloaded_state.left_bytes();
+                let event = if torrent_downloaded_state.is_complete()
+                    && sent_started.load(Ordering::Relaxed)
+                    && !sent_completed.swap(true, Ordering::Relaxed)
+                {
+                    Some(AnnounceEvent::Completed)
+                } else if !sent_started.swap(true, Ordering::Relaxed) {
+                    Some(AnnounceEvent::Started)
+                } else {
+                    None
+                };
+                let announce_params = AnnounceParams {
+                    uploaded,
+                    downloaded,
+                    left,
+                    port: 6881,
+                    event,
+                    numwant: AnnounceParams::DEFAULT_NUMWANT,
+                    key: announce_key,
+                };
+
                 // Handle TCP trackers
                 for tracker in tcp_trackers.clone() {
                     let torrent_meta = torrent_meta.clone();
@@ -124,13 +158,14 @@ impl TrackerPeers {
                     let have_broadcast = have_broadcast.clone();
                     let torrent_downloaded_state = torrent_downloaded_state.clone();
                     let download_state = download_state.clone();
+                    let announce_params = announce_params.clone();
                     tokio::spawn(async move {
-                        let url = file::build_tracker_url(&torrent_meta, &peer_id, 6881, &tracker)
-                            .map_err(|e| {
-                                error!("Failed to build tracker URL for {}: {}", tracker, e);
-                                e
-                            })
-                            .unwrap();
+                        let url = file::build_tracker_url(
+                            &torrent_meta,
+                            &peer_id,
+                            &tracker,
+                            &announce_params,
+                        );
 
                         match request_peers(&url).await {
                             Ok(request_peers_res) => {


### PR DESCRIPTION
Closes #15

Announce URLs are now built from `AnnounceParams` instead of a hardcoded query string.

- Append `&` when the announce URL already has a query, `?` otherwise, so passkey-style trackers stay valid
- Percent-encode every value with RFC 3986 unreserved bytes left literal, including raw `info_hash` and `peer_id`
- Send `uploaded`, `downloaded`, `left`, `event`, `numwant` (default 50), and a session-stable `key`
- `downloaded` / `left` come from completed vs remaining piece lengths; `uploaded` stays 0 until seeding (#8)

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` pass.