### PR TITLE
feat: HTTP/1.1 tracker client and announce loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "async-compression"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +246,23 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -1922,12 +1952,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = "0.3"
 thiserror = "2.0.9"
 indicatif = "0.17.7"
 flume = { version = "0.11.0", default-features = false, features = ["async", "select"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "gzip"] }
 byteorder = "1.4.3"
 serde_bencode = "0.2.3"
 serde_bytes = "0.11.12"

--- a/crates/bit_rev/Cargo.toml
+++ b/crates/bit_rev/Cargo.toml
@@ -22,3 +22,6 @@ sha1_smol.workspace = true
 dashmap.workspace = true
 rand.workspace = true
 tokio-util.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/bit_rev/src/file.rs
+++ b/crates/bit_rev/src/file.rs
@@ -153,6 +153,7 @@ pub struct AnnounceParams {
     pub event: Option<AnnounceEvent>,
     pub numwant: u32,
     pub key: u32,
+    pub tracker_id: Option<Vec<u8>>,
 }
 
 impl AnnounceParams {
@@ -193,6 +194,9 @@ pub fn build_tracker_url(
     }
     push_encoded_pair(&mut url, "numwant", params.numwant.to_string().as_bytes());
     push_encoded_pair(&mut url, "key", params.key.to_string().as_bytes());
+    if let Some(tracker_id) = params.tracker_id.as_deref() {
+        push_encoded_pair(&mut url, "trackerid", tracker_id);
+    }
 
     url
 }
@@ -249,6 +253,7 @@ mod tests {
             event,
             numwant: AnnounceParams::DEFAULT_NUMWANT,
             key: 0xDF45_C574,
+            tracker_id: None,
         }
     }
 
@@ -331,5 +336,18 @@ mod tests {
             &sample_params(Some(AnnounceEvent::Stopped)),
         );
         assert!(stopped.contains("&event=stopped&"));
+    }
+
+    #[test]
+    fn build_tracker_url_echoes_trackerid() {
+        let mut params = sample_params(None);
+        params.tracker_id = Some(b"abc".to_vec());
+        let url = build_tracker_url(
+            &test_meta(INFO_HASH_FIXTURE),
+            &PEER_ID,
+            "http://tracker.example/announce",
+            &params,
+        );
+        assert!(url.ends_with("&trackerid=abc"));
     }
 }

--- a/crates/bit_rev/src/lib.rs
+++ b/crates/bit_rev/src/lib.rs
@@ -9,5 +9,6 @@ pub mod protocol;
 pub mod protocol_udp;
 pub mod session;
 pub mod torrent;
+pub mod tracker;
 pub mod tracker_peers;
 pub mod utils;

--- a/crates/bit_rev/src/peer.rs
+++ b/crates/bit_rev/src/peer.rs
@@ -73,10 +73,11 @@ fn parse_peers_value(value: &Value, out: &mut Vec<PeerAddr>) -> anyhow::Result<(
 }
 
 fn parse_compact_v4(buf: &[u8], out: &mut Vec<PeerAddr>) -> anyhow::Result<()> {
-    if !buf.len().is_multiple_of(6) {
+    let (chunks, remainder) = buf.as_chunks::<6>();
+    if !remainder.is_empty() {
         anyhow::bail!("invalid compact peers length");
     }
-    for chunk in buf.chunks_exact(6) {
+    for chunk in chunks {
         let ip = Ipv4Addr::new(chunk[0], chunk[1], chunk[2], chunk[3]);
         let port = u16::from_be_bytes([chunk[4], chunk[5]]);
         out.push(SocketAddr::new(ip.into(), port));
@@ -85,10 +86,11 @@ fn parse_compact_v4(buf: &[u8], out: &mut Vec<PeerAddr>) -> anyhow::Result<()> {
 }
 
 fn parse_compact_v6(buf: &[u8], out: &mut Vec<PeerAddr>) -> anyhow::Result<()> {
-    if !buf.len().is_multiple_of(18) {
+    let (chunks, remainder) = buf.as_chunks::<18>();
+    if !remainder.is_empty() {
         anyhow::bail!("invalid compact peers6 length");
     }
-    for chunk in buf.chunks_exact(18) {
+    for chunk in chunks {
         let mut octets = [0u8; 16];
         octets.copy_from_slice(&chunk[..16]);
         let ip = Ipv6Addr::from(octets);

--- a/crates/bit_rev/src/peer.rs
+++ b/crates/bit_rev/src/peer.rs
@@ -1,76 +1,166 @@
-use std::net::SocketAddr;
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+};
 
 use serde::{Deserialize, Serialize};
+use serde_bencode::value::Value;
 use serde_bytes::ByteBuf;
 
 pub type PeerAddr = SocketAddr;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct BencodeResponse {
-    pub peers: ByteBuf,
-    pub peers6: ByteBuf,
-    pub interval: u64,
+    #[serde(default)]
+    pub peers: Option<Value>,
+    #[serde(default)]
+    pub peers6: Option<ByteBuf>,
+    #[serde(default)]
+    pub interval: Option<u64>,
+    #[serde(default, rename = "min interval")]
+    pub min_interval: Option<u64>,
+    #[serde(default, rename = "failure reason")]
+    pub failure_reason: Option<ByteBuf>,
+    #[serde(default, rename = "warning message")]
+    pub warning_message: Option<ByteBuf>,
+    #[serde(default, rename = "tracker id")]
+    pub tracker_id: Option<ByteBuf>,
+    #[serde(default)]
+    pub complete: Option<i64>,
+    #[serde(default)]
+    pub incomplete: Option<i64>,
 }
 
 impl BencodeResponse {
-    pub fn get_peers(self) -> anyhow::Result<Vec<PeerAddr>> {
-        // TODO: This is a bit of a mess
-        let peers_bin = self.peers;
-        let peer_size = 6;
-        let peers_bin_length = peers_bin.len();
-        let num_peers = peers_bin_length / peer_size;
-        if !peers_bin_length.is_multiple_of(peer_size) {
-            anyhow::bail!("Received empty peers");
-        }
+    pub fn failure_reason_str(&self) -> Option<String> {
+        self.failure_reason
+            .as_ref()
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+    }
 
-        let peers_bin6 = self.peers6;
-        let peer_size6 = 18;
-        let peers_bin_length6 = peers_bin6.len();
-        let num_peers6 = peers_bin_length6 / peer_size6;
-        if !peers_bin_length6.is_multiple_of(peer_size6) {
-            anyhow::bail!("Received empty peers");
-        }
+    pub fn warning_message_str(&self) -> Option<String> {
+        self.warning_message
+            .as_ref()
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+    }
 
+    pub fn get_peers(&self) -> anyhow::Result<Vec<PeerAddr>> {
         let mut peers = Vec::new();
-        for i in 0..num_peers {
-            let ip_size = 4;
-            let offset = i * peer_size;
-            let ip_bin = &peers_bin[offset..offset + ip_size];
-            let port =
-                u16::from_be_bytes([peers_bin[offset + ip_size], peers_bin[offset + ip_size + 1]]);
-            let ip_array = [ip_bin[0], ip_bin[1], ip_bin[2], ip_bin[3]];
-            let ip = std::net::Ipv4Addr::new(ip_array[0], ip_array[1], ip_array[2], ip_array[3]);
-            let peer = SocketAddr::new(ip.into(), port);
-            peers.push(peer);
+        if let Some(value) = self.peers.as_ref() {
+            parse_peers_value(value, &mut peers)?;
         }
-
-        for i in 0..num_peers6 {
-            let ip_size = 16;
-            let offset = i * peer_size6;
-            let ip_bin = &peers_bin6[offset..offset + ip_size];
-            let port = u16::from_be_bytes([
-                peers_bin6[offset + ip_size],
-                peers_bin6[offset + ip_size + 1],
-            ]);
-            let ip_array = [
-                ip_bin[0], ip_bin[1], ip_bin[2], ip_bin[3], ip_bin[4], ip_bin[5], ip_bin[6],
-                ip_bin[7], ip_bin[8], ip_bin[9], ip_bin[10], ip_bin[11], ip_bin[12], ip_bin[13],
-                ip_bin[14], ip_bin[15],
-            ];
-            let ip = std::net::Ipv6Addr::new(
-                u16::from_be_bytes([ip_array[0], ip_array[1]]),
-                u16::from_be_bytes([ip_array[2], ip_array[3]]),
-                u16::from_be_bytes([ip_array[4], ip_array[5]]),
-                u16::from_be_bytes([ip_array[6], ip_array[7]]),
-                u16::from_be_bytes([ip_array[8], ip_array[9]]),
-                u16::from_be_bytes([ip_array[10], ip_array[11]]),
-                u16::from_be_bytes([ip_array[12], ip_array[13]]),
-                u16::from_be_bytes([ip_array[14], ip_array[15]]),
-            );
-            let peer = SocketAddr::new(ip.into(), port);
-            peers.push(peer);
+        if let Some(peers6) = self.peers6.as_ref() {
+            parse_compact_v6(peers6, &mut peers)?;
         }
-
         Ok(peers)
+    }
+}
+
+fn parse_peers_value(value: &Value, out: &mut Vec<PeerAddr>) -> anyhow::Result<()> {
+    match value {
+        Value::Bytes(buf) => parse_compact_v4(buf, out),
+        Value::List(list) => {
+            for item in list {
+                match item {
+                    Value::Dict(dict) => out.push(peer_from_dict(dict)?),
+                    _ => anyhow::bail!("invalid dictionary peer entry"),
+                }
+            }
+            Ok(())
+        }
+        _ => anyhow::bail!("invalid peers field"),
+    }
+}
+
+fn parse_compact_v4(buf: &[u8], out: &mut Vec<PeerAddr>) -> anyhow::Result<()> {
+    if !buf.len().is_multiple_of(6) {
+        anyhow::bail!("invalid compact peers length");
+    }
+    for chunk in buf.chunks_exact(6) {
+        let ip = Ipv4Addr::new(chunk[0], chunk[1], chunk[2], chunk[3]);
+        let port = u16::from_be_bytes([chunk[4], chunk[5]]);
+        out.push(SocketAddr::new(ip.into(), port));
+    }
+    Ok(())
+}
+
+fn parse_compact_v6(buf: &[u8], out: &mut Vec<PeerAddr>) -> anyhow::Result<()> {
+    if !buf.len().is_multiple_of(18) {
+        anyhow::bail!("invalid compact peers6 length");
+    }
+    for chunk in buf.chunks_exact(18) {
+        let mut octets = [0u8; 16];
+        octets.copy_from_slice(&chunk[..16]);
+        let ip = Ipv6Addr::from(octets);
+        let port = u16::from_be_bytes([chunk[16], chunk[17]]);
+        out.push(SocketAddr::new(ip.into(), port));
+    }
+    Ok(())
+}
+
+fn peer_from_dict(dict: &HashMap<Vec<u8>, Value>) -> anyhow::Result<PeerAddr> {
+    let ip = match dict.get(&b"ip"[..]) {
+        Some(Value::Bytes(bytes)) => String::from_utf8_lossy(bytes)
+            .parse::<IpAddr>()
+            .map_err(|e| anyhow::anyhow!("invalid peer ip: {e}"))?,
+        _ => anyhow::bail!("peer dict missing ip"),
+    };
+    let port = match dict.get(&b"port"[..]) {
+        Some(Value::Int(port)) if *port >= 0 && *port <= i64::from(u16::MAX) => *port as u16,
+        _ => anyhow::bail!("peer dict missing port"),
+    };
+    Ok(SocketAddr::new(ip, port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_bencode::de;
+
+    #[test]
+    fn decodes_failure_reason() {
+        let body = b"d14:failure reason16:unregistered 123e";
+        let decoded = de::from_bytes::<BencodeResponse>(body).unwrap();
+        assert_eq!(
+            decoded.failure_reason_str().as_deref(),
+            Some("unregistered 123")
+        );
+        assert!(decoded.interval.is_none());
+    }
+
+    #[test]
+    fn decodes_warning_and_compact_peers() {
+        let mut body = b"d8:intervali1800e15:warning message7:slow ok5:peers6:".to_vec();
+        body.extend_from_slice(&[127, 0, 0, 1, 0x1A, 0xE1]);
+        body.push(b'e');
+        let decoded = de::from_bytes::<BencodeResponse>(&body).unwrap();
+        assert_eq!(decoded.interval, Some(1800));
+        assert_eq!(decoded.warning_message_str().as_deref(), Some("slow ok"));
+        assert_eq!(
+            decoded.get_peers().unwrap(),
+            vec!["127.0.0.1:6881".parse().unwrap()]
+        );
+    }
+
+    #[test]
+    fn decodes_dictionary_peers_and_min_interval() {
+        let body = b"d8:intervali60e12:min intervali120e5:peersld2:ip9:127.0.0.14:porti51413eeee";
+        let decoded = de::from_bytes::<BencodeResponse>(body).unwrap();
+        assert_eq!(decoded.min_interval, Some(120));
+        assert_eq!(
+            decoded.get_peers().unwrap(),
+            vec!["127.0.0.1:51413".parse().unwrap()]
+        );
+    }
+
+    #[test]
+    fn decodes_tracker_id() {
+        let body = b"d8:intervali60e10:tracker id3:abc5:peers0:e";
+        let decoded = de::from_bytes::<BencodeResponse>(body).unwrap();
+        assert_eq!(
+            decoded.tracker_id.as_ref().map(|id| id.as_ref()),
+            Some(&b"abc"[..])
+        );
+        assert!(decoded.get_peers().unwrap().is_empty());
     }
 }

--- a/crates/bit_rev/src/peer_state.rs
+++ b/crates/bit_rev/src/peer_state.rs
@@ -8,9 +8,14 @@ pub struct PeerStates {
 }
 
 impl PeerStates {
-    pub fn add_if_not_seen(&self, peer: PeerAddr) {
-        if !self.states.contains_key(&peer) {
-            self.states.insert(peer, PeerState::default());
+    pub fn add_if_not_seen(&self, peer: PeerAddr) -> bool {
+        use dashmap::mapref::entry::Entry;
+        match self.states.entry(peer) {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(entry) => {
+                entry.insert(PeerState::default());
+                true
+            }
         }
     }
 }
@@ -29,5 +34,19 @@ impl Default for PeerState {
             peer_interested: true,
             bitfield: Bitfield::new(vec![]),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_if_not_seen_dedups() {
+        let states = PeerStates::default();
+        let peer = "127.0.0.1:6881".parse().unwrap();
+        assert!(states.add_if_not_seen(peer));
+        assert!(!states.add_if_not_seen(peer));
+        assert_eq!(states.states.len(), 1);
     }
 }

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -128,6 +128,18 @@ impl Session {
         self.get_download_state() == DownloadState::Init
     }
 
+    pub fn shutdown(&self) {
+        for entry in self.streams.iter() {
+            entry.value().shutdown();
+        }
+    }
+
+    pub fn remove_torrent(&self, info_hash: &[u8; 20]) {
+        if let Some((_, tracker)) = self.streams.remove(info_hash) {
+            tracker.shutdown();
+        }
+    }
+
     pub async fn add_torrent(
         &self,
         add_torrent: AddTorrentOptions,
@@ -192,6 +204,12 @@ impl Session {
             torrent_meta,
             pr_rx,
         })
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.shutdown();
     }
 }
 

--- a/crates/bit_rev/src/tracker.rs
+++ b/crates/bit_rev/src/tracker.rs
@@ -1,0 +1,373 @@
+use std::{
+    sync::{Arc, Mutex, OnceLock},
+    time::Duration,
+};
+
+use serde_bencode::de;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::{
+    file::{self, AnnounceEvent, AnnounceParams, TorrentMeta},
+    peer::BencodeResponse,
+    peer_connection::TorrentDownloadedState,
+    session::DownloadState,
+};
+
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+pub const REDIRECT_LIMIT: usize = 5;
+pub const STOPPED_TIMEOUT: Duration = Duration::from_secs(5);
+pub const INITIAL_BACKOFF: Duration = Duration::from_secs(15);
+pub const MAX_BACKOFF: Duration = Duration::from_secs(30 * 60);
+pub const DEFAULT_INTERVAL_SECS: u64 = 1800;
+
+static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+#[derive(Debug, Error)]
+pub enum TrackerError {
+    #[error("tracker HTTP status {status}")]
+    HttpStatus { status: u16 },
+    #[error("tracker failure reason: {0}")]
+    FailureReason(String),
+    #[error("tracker request failed: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("invalid tracker response: {0}")]
+    Decode(String),
+    #[error("tracker stopped announce timed out")]
+    StoppedTimeout,
+}
+
+pub fn http_client() -> reqwest::Client {
+    HTTP_CLIENT.get_or_init(build_http_client).clone()
+}
+
+pub fn build_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::limited(REDIRECT_LIMIT))
+        .gzip(true)
+        .http1_only()
+        // TODO(#16): set User-Agent to bitrev/<version>
+        .build()
+        .expect("failed to build tracker HTTP client")
+}
+
+pub fn next_backoff(current: Option<Duration>) -> Duration {
+    match current {
+        None => INITIAL_BACKOFF,
+        Some(delay) => delay.saturating_mul(2).min(MAX_BACKOFF),
+    }
+}
+
+pub fn reannounce_delay(interval_secs: u64, min_interval_secs: Option<u64>) -> Duration {
+    let interval = if interval_secs == 0 {
+        DEFAULT_INTERVAL_SECS
+    } else {
+        interval_secs
+    };
+    let secs = match min_interval_secs {
+        Some(min) => interval.max(min),
+        None => interval,
+    };
+    Duration::from_secs(secs)
+}
+
+pub async fn announce(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<BencodeResponse, TrackerError> {
+    let response = client.get(url).send().await?;
+    let status = response.status();
+    let body = response.bytes().await?;
+
+    if !status.is_success() {
+        return Err(TrackerError::HttpStatus {
+            status: status.as_u16(),
+        });
+    }
+
+    let decoded: BencodeResponse =
+        de::from_bytes(&body).map_err(|e| TrackerError::Decode(e.to_string()))?;
+
+    if let Some(reason) = decoded.failure_reason_str() {
+        return Err(TrackerError::FailureReason(reason));
+    }
+
+    if let Some(warning) = decoded.warning_message_str() {
+        warn!(warning = %warning, "tracker warning message");
+    }
+
+    Ok(decoded)
+}
+
+pub async fn announce_with_timeout(
+    client: &reqwest::Client,
+    url: &str,
+    timeout: Duration,
+) -> Result<BencodeResponse, TrackerError> {
+    tokio::time::timeout(timeout, announce(client, url))
+        .await
+        .map_err(|_| TrackerError::StoppedTimeout)?
+}
+
+pub struct HttpAnnounceContext {
+    pub client: reqwest::Client,
+    pub torrent_meta: TorrentMeta,
+    pub peer_id: [u8; 20],
+    pub tracker_url: String,
+    pub announce_key: u32,
+    pub port: u16,
+    pub download_state: Arc<Mutex<DownloadState>>,
+    pub torrent_downloaded_state: Arc<TorrentDownloadedState>,
+}
+
+enum Wake {
+    IntervalElapsed,
+    Completed,
+    Shutdown,
+}
+
+pub async fn run_http_announce_loop<F, Fut>(
+    ctx: HttpAnnounceContext,
+    shutdown: CancellationToken,
+    mut on_peers: F,
+) where
+    F: FnMut(Vec<std::net::SocketAddr>) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let mut sent_started = false;
+    let mut sent_completed = false;
+    let mut tracker_id: Option<Vec<u8>> = None;
+    let mut backoff: Option<Duration> = None;
+    let mut joined = false;
+
+    loop {
+        if !wait_until_downloading(&ctx.download_state, &shutdown).await {
+            break;
+        }
+
+        let event = next_announce_event(
+            ctx.torrent_downloaded_state.is_complete(),
+            sent_started,
+            sent_completed,
+        );
+        let params = current_announce_params(&ctx, event, tracker_id.clone());
+        let url =
+            file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, &ctx.tracker_url, &params);
+
+        joined = true;
+        let result = announce(&ctx.client, &url).await;
+        if shutdown.is_cancelled() {
+            if let Ok(resp) = result {
+                if let Some(id) = resp.tracker_id.as_ref() {
+                    tracker_id = Some(id.to_vec());
+                }
+            }
+            break;
+        }
+
+        match result {
+            Ok(resp) => {
+                backoff = None;
+                if event == Some(AnnounceEvent::Started) {
+                    sent_started = true;
+                }
+                if event == Some(AnnounceEvent::Completed) {
+                    sent_completed = true;
+                }
+                if let Some(id) = resp.tracker_id.as_ref() {
+                    tracker_id = Some(id.to_vec());
+                }
+                match resp.get_peers() {
+                    Ok(peers) => on_peers(peers).await,
+                    Err(e) => {
+                        debug!(
+                            tracker = %ctx.tracker_url,
+                            error = %e,
+                            "failed to parse peers from HTTP tracker"
+                        );
+                    }
+                }
+                let interval = resp.interval.unwrap_or(DEFAULT_INTERVAL_SECS);
+                let delay = reannounce_delay(interval, resp.min_interval);
+                match wait_reannounce(
+                    delay,
+                    &shutdown,
+                    &ctx.torrent_downloaded_state,
+                    sent_completed,
+                )
+                .await
+                {
+                    Wake::Shutdown => break,
+                    Wake::Completed | Wake::IntervalElapsed => {}
+                }
+            }
+            Err(e) => {
+                debug!(tracker = %ctx.tracker_url, error = %e, "HTTP tracker announce failed");
+                let delay = next_backoff(backoff);
+                backoff = Some(delay);
+                match wait_reannounce(
+                    delay,
+                    &shutdown,
+                    &ctx.torrent_downloaded_state,
+                    sent_completed,
+                )
+                .await
+                {
+                    Wake::Shutdown => break,
+                    Wake::Completed | Wake::IntervalElapsed => {}
+                }
+            }
+        }
+    }
+
+    if joined {
+        send_stopped(&ctx, tracker_id).await;
+    }
+}
+
+fn next_announce_event(
+    is_complete: bool,
+    sent_started: bool,
+    sent_completed: bool,
+) -> Option<AnnounceEvent> {
+    if is_complete && sent_started && !sent_completed {
+        Some(AnnounceEvent::Completed)
+    } else if !sent_started {
+        Some(AnnounceEvent::Started)
+    } else {
+        None
+    }
+}
+
+fn current_announce_params(
+    ctx: &HttpAnnounceContext,
+    event: Option<AnnounceEvent>,
+    tracker_id: Option<Vec<u8>>,
+) -> AnnounceParams {
+    AnnounceParams {
+        // TODO(#8): wire uploaded from the session upload counter once seeding exists
+        uploaded: 0,
+        downloaded: ctx.torrent_downloaded_state.downloaded_bytes(),
+        left: ctx.torrent_downloaded_state.left_bytes(),
+        port: ctx.port,
+        event,
+        numwant: AnnounceParams::DEFAULT_NUMWANT,
+        key: ctx.announce_key,
+        tracker_id,
+    }
+}
+
+async fn send_stopped(ctx: &HttpAnnounceContext, tracker_id: Option<Vec<u8>>) {
+    let params = AnnounceParams {
+        uploaded: 0,
+        downloaded: ctx.torrent_downloaded_state.downloaded_bytes(),
+        left: ctx.torrent_downloaded_state.left_bytes(),
+        port: ctx.port,
+        event: Some(AnnounceEvent::Stopped),
+        numwant: 0,
+        key: ctx.announce_key,
+        tracker_id,
+    };
+    let url = file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, &ctx.tracker_url, &params);
+    if let Err(e) = announce_with_timeout(&ctx.client, &url, STOPPED_TIMEOUT).await {
+        debug!(
+            tracker = %ctx.tracker_url,
+            error = %e,
+            "HTTP tracker stopped announce failed"
+        );
+    }
+}
+
+async fn wait_until_downloading(
+    download_state: &Arc<Mutex<DownloadState>>,
+    shutdown: &CancellationToken,
+) -> bool {
+    loop {
+        if shutdown.is_cancelled() {
+            return false;
+        }
+        if *download_state.lock().unwrap() == DownloadState::Downloading {
+            return true;
+        }
+        tokio::select! {
+            _ = shutdown.cancelled() => return false,
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+    }
+}
+
+async fn wait_reannounce(
+    delay: Duration,
+    shutdown: &CancellationToken,
+    torrent_downloaded_state: &TorrentDownloadedState,
+    sent_completed: bool,
+) -> Wake {
+    if shutdown.is_cancelled() {
+        return Wake::Shutdown;
+    }
+    if delay.is_zero() {
+        return Wake::IntervalElapsed;
+    }
+
+    let sleep = tokio::time::sleep(delay);
+    tokio::pin!(sleep);
+    let mut tick = tokio::time::interval(Duration::from_millis(100));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => return Wake::Shutdown,
+            _ = &mut sleep => return Wake::IntervalElapsed,
+            _ = tick.tick() => {
+                if !sent_completed && torrent_downloaded_state.is_complete() {
+                    return Wake::Completed;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_backoff_doubles_and_caps() {
+        assert_eq!(next_backoff(None), Duration::from_secs(15));
+        assert_eq!(
+            next_backoff(Some(Duration::from_secs(15))),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            next_backoff(Some(Duration::from_secs(15 * 60))),
+            Duration::from_secs(30 * 60)
+        );
+        assert_eq!(
+            next_backoff(Some(Duration::from_secs(30 * 60))),
+            Duration::from_secs(30 * 60)
+        );
+    }
+
+    #[test]
+    fn reannounce_delay_uses_min_interval_as_floor() {
+        assert_eq!(reannounce_delay(60, None), Duration::from_secs(60));
+        assert_eq!(reannounce_delay(60, Some(120)), Duration::from_secs(120));
+        assert_eq!(reannounce_delay(1800, Some(60)), Duration::from_secs(1800));
+        assert_eq!(
+            reannounce_delay(0, None),
+            Duration::from_secs(DEFAULT_INTERVAL_SECS)
+        );
+    }
+
+    #[test]
+    fn http_client_is_reused() {
+        let first = http_client();
+        let second = http_client();
+        drop((first, second));
+        let _ = build_http_client();
+    }
+}

--- a/crates/bit_rev/src/tracker_peers.rs
+++ b/crates/bit_rev/src/tracker_peers.rs
@@ -1,14 +1,11 @@
 use rand::Rng;
-use serde_bencode::de;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-};
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
 use tokio::{select, sync::Semaphore, time::sleep};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 
 use crate::{
-    file::{self, AnnounceEvent, AnnounceParams, TorrentMeta},
+    file::TorrentMeta,
     peer::BencodeResponse,
     peer_connection::{
         FullPiece, PeerConnection, PeerHandler, PieceWorkState, TorrentDownloadedState,
@@ -16,6 +13,7 @@ use crate::{
     peer_state::PeerStates,
     protocol_udp::request_udp_peers,
     session::{DownloadState, PieceResult, PieceWork},
+    tracker::{self, HttpAnnounceContext, TrackerError},
 };
 
 #[derive(Debug, Clone)]
@@ -29,6 +27,7 @@ pub struct TrackerPeers {
     pub have_broadcast: Arc<tokio::sync::broadcast::Sender<u32>>,
     pub download_state: Arc<Mutex<DownloadState>>,
     announce_key: u32,
+    cancel: CancellationToken,
 }
 
 impl TrackerPeers {
@@ -52,7 +51,12 @@ impl TrackerPeers {
             have_broadcast,
             download_state,
             announce_key: rand::thread_rng().gen(),
+            cancel: CancellationToken::new(),
         }
+    }
+
+    pub fn shutdown(&self) {
+        self.cancel.cancel();
     }
 
     pub fn set_download_state(&self, state: DownloadState) {
@@ -102,8 +106,8 @@ impl TrackerPeers {
         let have_broadcast = self.have_broadcast.clone();
         let download_state = self.download_state.clone();
         let announce_key = self.announce_key;
-        let sent_started = Arc::new(AtomicBool::new(false));
-        let sent_completed = Arc::new(AtomicBool::new(false));
+        let cancel = self.cancel.clone();
+        let http_client = tracker::http_client();
         let torrent_downloaded_state = Arc::new(TorrentDownloadedState {
             semaphore: Semaphore::new(1),
             pieces: pieces_of_work
@@ -116,148 +120,118 @@ impl TrackerPeers {
                 })
                 .collect(),
         });
-        tokio::spawn(async move {
-            loop {
-                // Wait while not downloading
-                while {
-                    let state = *download_state.lock().unwrap();
-                    state != DownloadState::Downloading
-                } {
-                    sleep(std::time::Duration::from_millis(100)).await;
-                }
 
-                // TODO(#8): wire uploaded from the session upload counter once seeding exists
-                let uploaded = 0u64;
-                let downloaded = torrent_downloaded_state.downloaded_bytes();
-                let left = torrent_downloaded_state.left_bytes();
-                let event = if torrent_downloaded_state.is_complete()
-                    && sent_started.load(Ordering::Relaxed)
-                    && !sent_completed.swap(true, Ordering::Relaxed)
-                {
-                    Some(AnnounceEvent::Completed)
-                } else if !sent_started.swap(true, Ordering::Relaxed) {
-                    Some(AnnounceEvent::Started)
-                } else {
-                    None
-                };
-                let announce_params = AnnounceParams {
-                    uploaded,
-                    downloaded,
-                    left,
-                    port: 6881,
-                    event,
-                    numwant: AnnounceParams::DEFAULT_NUMWANT,
-                    key: announce_key,
-                };
-
-                // Handle TCP trackers
-                for tracker in tcp_trackers.clone() {
-                    let torrent_meta = torrent_meta.clone();
+        for tracker_url in tcp_trackers {
+            let ctx = HttpAnnounceContext {
+                client: http_client.clone(),
+                torrent_meta: torrent_meta.clone(),
+                peer_id,
+                tracker_url,
+                announce_key,
+                port: 6881,
+                download_state: download_state.clone(),
+                torrent_downloaded_state: torrent_downloaded_state.clone(),
+            };
+            let peer_states = peer_states.clone();
+            let piece_tx = piece_tx.clone();
+            let have_broadcast = have_broadcast.clone();
+            let download_state = download_state.clone();
+            let torrent_downloaded_state = torrent_downloaded_state.clone();
+            let shutdown = cancel.clone();
+            tokio::spawn(async move {
+                tracker::run_http_announce_loop(ctx, shutdown, |new_peers| {
                     let peer_states = peer_states.clone();
                     let piece_tx = piece_tx.clone();
                     let have_broadcast = have_broadcast.clone();
                     let torrent_downloaded_state = torrent_downloaded_state.clone();
                     let download_state = download_state.clone();
-                    let announce_params = announce_params.clone();
-                    tokio::spawn(async move {
-                        let url = file::build_tracker_url(
-                            &torrent_meta,
-                            &peer_id,
-                            &tracker,
-                            &announce_params,
-                        );
+                    async move {
+                        process_peers(
+                            new_peers,
+                            PeerProcessorConfig {
+                                info_hash,
+                                peer_id,
+                                peer_states,
+                                piece_tx,
+                                have_broadcast,
+                                torrent_downloaded_state,
+                                download_state,
+                            },
+                        )
+                        .await;
+                    }
+                })
+                .await;
+            });
+        }
 
-                        match request_peers(&url).await {
-                            Ok(request_peers_res) => {
-                                match request_peers_res.clone().get_peers() {
-                                    Ok(new_peers) => {
-                                        process_peers(
-                                            new_peers,
-                                            PeerProcessorConfig {
-                                                info_hash,
-                                                peer_id,
-                                                peer_states: peer_states.clone(),
-                                                piece_tx: piece_tx.clone(),
-                                                have_broadcast: have_broadcast.clone(),
-                                                torrent_downloaded_state: torrent_downloaded_state
-                                                    .clone(),
-                                                download_state: download_state.clone(),
-                                            },
-                                        )
-                                        .await;
+        if !udp_trackers.is_empty() {
+            let udp_cancel = cancel;
+            tokio::spawn(async move {
+                loop {
+                    if udp_cancel.is_cancelled() {
+                        break;
+                    }
+                    while {
+                        let state = *download_state.lock().unwrap();
+                        state != DownloadState::Downloading
+                    } {
+                        if udp_cancel.is_cancelled() {
+                            return;
+                        }
+                        sleep(std::time::Duration::from_millis(100)).await;
+                    }
 
-                                        //sleep interval
-                                        tokio::time::sleep(std::time::Duration::from_millis(
-                                            request_peers_res.interval,
-                                        ))
-                                        .await;
-                                    }
-                                    Err(e) => debug!(
-                                        "Failed to parse peers from TCP tracker {}: {}",
-                                        tracker, e
-                                    ),
+                    for tracker in udp_trackers.clone() {
+                        let torrent_meta = torrent_meta.clone();
+                        let peer_states = peer_states.clone();
+                        let piece_tx = piece_tx.clone();
+                        let have_broadcast = have_broadcast.clone();
+                        let torrent_downloaded_state = torrent_downloaded_state.clone();
+                        let download_state = download_state.clone();
+                        tokio::spawn(async move {
+                            match request_udp_peers(&tracker, &torrent_meta, &peer_id, 6881).await {
+                                Ok(udp_response) => {
+                                    debug!(
+                                        "Received UDP response from tracker {}: {:?}",
+                                        tracker, udp_response
+                                    );
+                                    let new_peers: Vec<_> = udp_response
+                                        .peers
+                                        .into_iter()
+                                        .map(|p| p.to_socket_addr())
+                                        .collect();
+
+                                    process_peers(
+                                        new_peers,
+                                        PeerProcessorConfig {
+                                            info_hash,
+                                            peer_id,
+                                            peer_states: peer_states.clone(),
+                                            piece_tx: piece_tx.clone(),
+                                            have_broadcast: have_broadcast.clone(),
+                                            torrent_downloaded_state: torrent_downloaded_state
+                                                .clone(),
+                                            download_state: download_state.clone(),
+                                        },
+                                    )
+                                    .await;
                                 }
+                                Err(e) => error!(
+                                    "Failed to request peers from UDP tracker {}: {}",
+                                    tracker, e
+                                ),
                             }
-                            Err(e) => debug!(
-                                "Failed to request peers from TCP tracker {}: {}",
-                                tracker, e
-                            ),
-                        }
-                    });
+                        });
+                    }
+
+                    tokio::select! {
+                        _ = udp_cancel.cancelled() => break,
+                        _ = sleep(std::time::Duration::from_secs(30)) => {}
+                    }
                 }
-
-                // Handle UDP trackers
-                for tracker in udp_trackers.clone() {
-                    let torrent_meta = torrent_meta.clone();
-                    let peer_states = peer_states.clone();
-                    let piece_tx = piece_tx.clone();
-                    let have_broadcast = have_broadcast.clone();
-                    let torrent_downloaded_state = torrent_downloaded_state.clone();
-                    let download_state = download_state.clone();
-                    tokio::spawn(async move {
-                        match request_udp_peers(&tracker, &torrent_meta, &peer_id, 6881).await {
-                            Ok(udp_response) => {
-                                debug!(
-                                    "Received UDP response from tracker {}: {:?}",
-                                    tracker, udp_response
-                                );
-                                let new_peers: Vec<_> = udp_response
-                                    .peers
-                                    .into_iter()
-                                    .map(|p| p.to_socket_addr())
-                                    .collect();
-
-                                process_peers(
-                                    new_peers,
-                                    PeerProcessorConfig {
-                                        info_hash,
-                                        peer_id,
-                                        peer_states: peer_states.clone(),
-                                        piece_tx: piece_tx.clone(),
-                                        have_broadcast: have_broadcast.clone(),
-                                        torrent_downloaded_state: torrent_downloaded_state.clone(),
-                                        download_state: download_state.clone(),
-                                    },
-                                )
-                                .await;
-
-                                //sleep interval
-                                tokio::time::sleep(std::time::Duration::from_secs(
-                                    udp_response.interval as u64,
-                                ))
-                                .await;
-                            }
-                            Err(e) => error!(
-                                "Failed to request peers from UDP tracker {}: {}",
-                                tracker, e
-                            ),
-                        }
-                    });
-                }
-
-                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-            }
-        });
+            });
+        }
     }
 }
 
@@ -282,7 +256,7 @@ async fn process_peers(new_peers: Vec<std::net::SocketAddr>, config: PeerProcess
             continue;
         }
 
-        if config.peer_states.clone().states.contains_key(&peer) {
+        if !config.peer_states.add_if_not_seen(peer) {
             continue;
         }
 
@@ -356,11 +330,6 @@ fn all_trackers(torrent_meta: &TorrentMeta) -> Vec<String> {
     }
 }
 
-pub async fn request_peers(uri: &str) -> anyhow::Result<BencodeResponse> {
-    let client = reqwest::Client::new();
-    let response = client.get(uri).send().await?;
-    let body_bytes = response.bytes().await?;
-
-    let tracker_bencode_decode = de::from_bytes::<BencodeResponse>(&body_bytes)?;
-    Ok(tracker_bencode_decode)
+pub async fn request_peers(uri: &str) -> Result<BencodeResponse, TrackerError> {
+    tracker::announce(&tracker::http_client(), uri).await
 }

--- a/crates/bit_rev/tests/tracker_http.rs
+++ b/crates/bit_rev/tests/tracker_http.rs
@@ -1,0 +1,429 @@
+use std::{
+    collections::HashMap,
+    io::ErrorKind,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+
+use bit_rev::{
+    file::{Info, TorrentFile, TorrentMeta},
+    peer_connection::{PieceWorkState, TorrentDownloadedState},
+    peer_state::PeerStates,
+    session::{DownloadState, PieceWork},
+    tracker::{
+        self, announce, build_http_client, run_http_announce_loop, HttpAnnounceContext,
+        TrackerError,
+    },
+};
+use serde::Serialize;
+use serde_bencode::ser;
+use serde_bytes::ByteBuf;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    sync::{mpsc, Semaphore},
+};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone, Debug)]
+struct RecordedRequest {
+    path: String,
+    query: String,
+    headers: HashMap<String, String>,
+}
+
+impl RecordedRequest {
+    fn query_param(&self, key: &str) -> Option<&str> {
+        self.query.split('&').find_map(|pair| {
+            let (k, v) = pair.split_once('=')?;
+            (k == key).then_some(v)
+        })
+    }
+}
+
+#[derive(Clone)]
+struct MockResponse {
+    status: u16,
+    body: Vec<u8>,
+}
+
+#[derive(Serialize)]
+struct TestAnnounce {
+    interval: i64,
+    #[serde(rename = "min interval", skip_serializing_if = "Option::is_none")]
+    min_interval: Option<i64>,
+    #[serde(rename = "tracker id", skip_serializing_if = "Option::is_none")]
+    tracker_id: Option<ByteBuf>,
+    #[serde(rename = "warning message", skip_serializing_if = "Option::is_none")]
+    warning_message: Option<String>,
+    peers: ByteBuf,
+}
+
+fn compact_peer(ip: [u8; 4], port: u16) -> Vec<u8> {
+    let mut buf = ip.to_vec();
+    buf.extend_from_slice(&port.to_be_bytes());
+    buf
+}
+
+fn ok_announce(interval: i64, min_interval: Option<i64>, tracker_id: Option<&[u8]>) -> Vec<u8> {
+    ser::to_bytes(&TestAnnounce {
+        interval,
+        min_interval,
+        tracker_id: tracker_id.map(ByteBuf::from),
+        warning_message: None,
+        peers: ByteBuf::from(compact_peer([127, 0, 0, 1], 51413)),
+    })
+    .unwrap()
+}
+
+fn failure_announce(reason: &str) -> Vec<u8> {
+    format!("d14:failure reason{}:{reason}e", reason.len()).into_bytes()
+}
+
+fn status_reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        403 => "Forbidden",
+        500 => "Internal Server Error",
+        _ => "Error",
+    }
+}
+
+async fn read_http_request(stream: &mut TcpStream) -> std::io::Result<RecordedRequest> {
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 1024];
+    loop {
+        let n = stream.read(&mut tmp).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "client closed before request completed",
+            ));
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if buf.len() > 64 * 1024 {
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidData,
+                "request too large",
+            ));
+        }
+    }
+
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines = text.split("\r\n");
+    let request_line = lines.next().unwrap_or_default();
+    let mut parts = request_line.split_whitespace();
+    let _method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    let (path, query) = target.split_once('?').unwrap_or((target, ""));
+
+    let mut headers = HashMap::new();
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+
+    Ok(RecordedRequest {
+        path: path.to_string(),
+        query: query.to_string(),
+        headers,
+    })
+}
+
+async fn write_http_response(
+    stream: &mut TcpStream,
+    response: &MockResponse,
+) -> std::io::Result<()> {
+    let header = format!(
+        "HTTP/1.1 {} {}\r\nContent-Length: {}\r\nConnection: close\r\nContent-Type: text/plain\r\n\r\n",
+        response.status,
+        status_reason(response.status),
+        response.body.len()
+    );
+    stream.write_all(header.as_bytes()).await?;
+    stream.write_all(&response.body).await?;
+    stream.shutdown().await
+}
+
+async fn spawn_scripted_tracker(
+    responses: Vec<MockResponse>,
+) -> (
+    String,
+    mpsc::UnboundedReceiver<RecordedRequest>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = mpsc::unbounded_channel();
+    let idx = Arc::new(AtomicUsize::new(0));
+    let responses = Arc::new(responses);
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(_) => break,
+            };
+            let request = match read_http_request(&mut stream).await {
+                Ok(request) => request,
+                Err(_) => continue,
+            };
+            let i = idx.fetch_add(1, Ordering::SeqCst);
+            let response = responses
+                .get(i)
+                .cloned()
+                .or_else(|| responses.last().cloned())
+                .unwrap_or(MockResponse {
+                    status: 200,
+                    body: ok_announce(1800, None, None),
+                });
+            let _ = write_http_response(&mut stream, &response).await;
+            let _ = tx.send(request);
+        }
+    });
+
+    (format!("http://{addr}/announce"), rx, handle)
+}
+
+fn test_meta(announce: String) -> TorrentMeta {
+    TorrentMeta {
+        torrent_file: TorrentFile {
+            info: Info {
+                name: "test".into(),
+                pieces: ByteBuf::from(vec![0u8; 20]),
+                piece_length: 16384,
+                md5sum: None,
+                length: Some(16384),
+                files: None,
+                private: None,
+                path: None,
+                root_hash: None,
+            },
+            announce: Some(announce),
+            nodes: None,
+            encoding: None,
+            httpseeds: None,
+            announce_list: None,
+            creation_date: None,
+            comment: None,
+            created_by: None,
+        },
+        info_hash: [1u8; 20],
+        piece_hashes: vec![[1u8; 20]],
+    }
+}
+
+fn incomplete_download() -> Arc<TorrentDownloadedState> {
+    Arc::new(TorrentDownloadedState {
+        semaphore: Semaphore::new(1),
+        pieces: vec![PieceWorkState {
+            piece_work: PieceWork {
+                index: 0,
+                length: 16384,
+                hash: [1u8; 20],
+            },
+            chuncks: Mutex::new(vec![]),
+            downloaded: AtomicBool::new(false),
+            reserved: Mutex::new(None),
+        }],
+    })
+}
+
+fn announce_ctx(url: String, download: Arc<TorrentDownloadedState>) -> HttpAnnounceContext {
+    HttpAnnounceContext {
+        client: test_http_client(),
+        torrent_meta: test_meta(url.clone()),
+        peer_id: *b"-BR0100-0123456789ab",
+        tracker_url: url,
+        announce_key: 0xDF45_C574,
+        port: 6881,
+        download_state: Arc::new(Mutex::new(DownloadState::Downloading)),
+        torrent_downloaded_state: download,
+    }
+}
+
+fn test_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::limited(tracker::REDIRECT_LIMIT))
+        .gzip(true)
+        .http1_only()
+        .build()
+        .expect("test tracker HTTP client")
+}
+
+async fn settle_io() {
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+    tokio::task::spawn_blocking(|| std::thread::sleep(Duration::from_millis(30)))
+        .await
+        .unwrap();
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+}
+
+#[tokio::test]
+async fn announce_non_2xx_is_typed_error() {
+    let (url, _rx, handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 500,
+        body: b"nope".to_vec(),
+    }])
+    .await;
+
+    let err = announce(&build_http_client(), &url).await.unwrap_err();
+    assert!(matches!(err, TrackerError::HttpStatus { status: 500 }));
+    handle.abort();
+}
+
+#[tokio::test]
+async fn announce_failure_reason_is_typed_error() {
+    let (url, _rx, handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 200,
+        body: failure_announce("unregistered torrent"),
+    }])
+    .await;
+
+    let err = announce(&build_http_client(), &url).await.unwrap_err();
+    match err {
+        TrackerError::FailureReason(reason) => {
+            assert_eq!(reason, "unregistered torrent");
+        }
+        other => panic!("expected FailureReason, got {other}"),
+    }
+    handle.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn announce_loop_respects_interval_and_echoes_tracker_id() {
+    let (url, mut rx, handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 200,
+        body: ok_announce(1800, Some(1800), Some(b"tid")),
+    }])
+    .await;
+
+    let peer_states = Arc::new(PeerStates::default());
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx(url, incomplete_download());
+    let peers_for_loop = peer_states.clone();
+
+    let loop_task = tokio::spawn(async move {
+        run_http_announce_loop(ctx, loop_shutdown, |peers| {
+            let peer_states = peers_for_loop.clone();
+            async move {
+                for peer in peers {
+                    peer_states.add_if_not_seen(peer);
+                }
+            }
+        })
+        .await;
+    });
+
+    let first = rx.recv().await.expect("started announce");
+    assert_eq!(first.path, "/announce");
+    assert_eq!(first.query_param("event"), Some("started"));
+    assert!(first
+        .headers
+        .get("accept-encoding")
+        .is_some_and(|v| v.contains("gzip")));
+    settle_io().await;
+    assert_eq!(peer_states.states.len(), 1);
+
+    tokio::time::advance(Duration::from_secs(1799)).await;
+    settle_io().await;
+    assert!(rx.try_recv().is_err(), "re-announce sent before interval");
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    let second = rx.recv().await.expect("interval re-announce");
+    assert_eq!(second.query_param("event"), None);
+    assert_eq!(second.query_param("trackerid"), Some("tid"));
+
+    shutdown.cancel();
+    settle_io().await;
+    let _ = loop_task.await;
+    handle.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn announce_loop_retries_failure_reason_with_backoff() {
+    let (url, mut rx, handle) = spawn_scripted_tracker(vec![
+        MockResponse {
+            status: 200,
+            body: failure_announce("try again later"),
+        },
+        MockResponse {
+            status: 200,
+            body: ok_announce(1800, None, None),
+        },
+    ])
+    .await;
+
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx(url, incomplete_download());
+    let loop_task = tokio::spawn(async move {
+        run_http_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+    });
+
+    let first = rx.recv().await.expect("failed started announce");
+    assert_eq!(first.query_param("event"), Some("started"));
+    settle_io().await;
+
+    tokio::time::advance(Duration::from_secs(14)).await;
+    settle_io().await;
+    assert!(rx.try_recv().is_err(), "retried before backoff elapsed");
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    let second = rx.recv().await.expect("backoff retry");
+    assert_eq!(second.query_param("event"), Some("started"));
+
+    shutdown.cancel();
+    settle_io().await;
+    let _ = loop_task.await;
+    handle.abort();
+}
+
+#[tokio::test]
+async fn announce_loop_sends_stopped_on_shutdown() {
+    let (url, mut rx, handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 200,
+        body: ok_announce(1800, None, None),
+    }])
+    .await;
+
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx(url, incomplete_download());
+    let loop_task = tokio::spawn(async move {
+        run_http_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+    });
+
+    let first = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("started announce timed out")
+        .expect("started announce");
+    assert_eq!(first.query_param("event"), Some("started"));
+    settle_io().await;
+
+    shutdown.cancel();
+
+    let stopped = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("stopped announce timed out")
+        .expect("stopped announce");
+    assert_eq!(stopped.query_param("event"), Some("stopped"));
+
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_task).await;
+    handle.abort();
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -136,5 +136,8 @@ pub async fn download_file(filename: &str, out_file: Option<String>) -> anyhow::
         file.sync_all().await?;
     }
 
+    session.shutdown();
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implements issue #14: HTTP/1.1 tracker communication with a shared client and a real announce lifecycle.

- Build one shared `reqwest::Client` (keep-alive pooling) with a 10s connect timeout, 30s request timeout, redirect limit of 5, gzip, and HTTP/1.1. User-Agent is left as `TODO(#16)`.
- Treat non-2xx statuses and bencoded `failure reason` as typed errors. Log `warning message` and continue.
- Run a per-HTTP-tracker announce loop: `event=started`, then re-announce every `interval` seconds (`min interval` is the floor), `event=completed` once the torrent finishes, and best-effort `event=stopped` on shutdown or torrent removal.
- Echo `trackerid` when the tracker sent a `tracker id`. New peers go through `PeerStates::add_if_not_seen`.
- Retry failed announces with 15s exponential backoff, capped at 30 minutes, without blocking other torrents.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- In-process HTTP mock covers interval respect (`tokio::time::pause`), `failure reason` retry/backoff, and `event=stopped` on shutdown.

Closes #14