### PR TITLE
feat: identify the client with BEP-0020 peer id and User-Agent

### DIFF
--- a/crates/bit_rev/src/identity.rs
+++ b/crates/bit_rev/src/identity.rs
@@ -1,0 +1,73 @@
+/// Product name used in HTTP User-Agent and the BEP-0010 handshake `v` field.
+pub const CLIENT_NAME: &str = "bitrev";
+
+/// Azureus-style two-character client code (BEP-0020).
+pub const CLIENT_CODE: [u8; 2] = *b"BR";
+
+pub const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// HTTP User-Agent, e.g. `bitrev/0.1.0`.
+pub fn user_agent() -> String {
+    format!("{CLIENT_NAME}/{CLIENT_VERSION}")
+}
+
+/// BEP-0010 handshake `v` value, e.g. `bitrev 0.1.0`.
+pub fn extension_version() -> String {
+    format!("{CLIENT_NAME} {CLIENT_VERSION}")
+}
+
+/// Azureus-style 8-byte peer id prefix: `-BRxyzw-`.
+pub fn peer_id_prefix() -> [u8; 8] {
+    let version = azureus_version(CLIENT_VERSION);
+    [
+        b'-',
+        CLIENT_CODE[0],
+        CLIENT_CODE[1],
+        version[0],
+        version[1],
+        version[2],
+        version[3],
+        b'-',
+    ]
+}
+
+/// Azureus xyzw: 1-digit major, minor, patch, then 0. 0.1.0 -> 0100.
+pub fn azureus_version(version: &str) -> [u8; 4] {
+    let core = version.split(['-', '+']).next().unwrap_or(version);
+    let mut parts = core.split('.');
+    let major = parse_component(parts.next());
+    let minor = parse_component(parts.next());
+    let patch = parse_component(parts.next());
+    [
+        b'0' + (major % 10) as u8,
+        b'0' + (minor % 10) as u8,
+        b'0' + (patch % 10) as u8,
+        b'0',
+    ]
+}
+
+fn parse_component(part: Option<&str>) -> u32 {
+    part.unwrap_or("0").parse().unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_strings_share_name_and_version() {
+        assert_eq!(user_agent(), format!("{CLIENT_NAME}/{CLIENT_VERSION}"));
+        assert_eq!(
+            extension_version(),
+            format!("{CLIENT_NAME} {CLIENT_VERSION}")
+        );
+        assert_eq!(&peer_id_prefix(), b"-BR0100-");
+    }
+
+    #[test]
+    fn azureus_version_encodes_major_minor_patch() {
+        assert_eq!(azureus_version("0.1.0"), *b"0100");
+        assert_eq!(azureus_version("1.2.3"), *b"1230");
+        assert_eq!(azureus_version("0.1.0-alpha"), *b"0100");
+    }
+}

--- a/crates/bit_rev/src/lib.rs
+++ b/crates/bit_rev/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bitfield;
 pub mod file;
 pub mod handshake;
+pub mod identity;
 pub mod message;
 pub mod peer;
 pub mod peer_connection;

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -39,6 +39,7 @@ pub struct State {
 pub struct Session {
     pub streams: DashMap<[u8; 20], TrackerPeers>,
     pub download_state: Arc<Mutex<DownloadState>>,
+    peer_id: [u8; 20],
 }
 
 pub struct AddTorrentOptions {
@@ -79,6 +80,7 @@ impl Session {
         Self {
             streams: DashMap::new(),
             download_state: Arc::new(Mutex::new(DownloadState::Init)),
+            peer_id: utils::generate_peer_id(),
         }
     }
 
@@ -149,12 +151,10 @@ impl Session {
         let (pr_tx, pr_rx) = flume::bounded::<PieceResult>(torrent.piece_hashes.len());
         let have_broadcast = Arc::new(tokio::sync::broadcast::channel(128).0);
         let peer_states = Arc::new(PeerStates::default());
-        let random_peers = utils::generate_peer_id();
-
         let tracker_stream = TrackerPeers::new(
             torrent_meta.clone(),
             15,
-            random_peers,
+            self.peer_id,
             peer_states,
             have_broadcast.clone(),
             pr_rx.clone(),

--- a/crates/bit_rev/src/tracker.rs
+++ b/crates/bit_rev/src/tracker.rs
@@ -50,7 +50,7 @@ pub fn build_http_client() -> reqwest::Client {
         .redirect(reqwest::redirect::Policy::limited(REDIRECT_LIMIT))
         .gzip(true)
         .http1_only()
-        // TODO(#16): set User-Agent to bitrev/<version>
+        .user_agent(crate::identity::user_agent())
         .build()
         .expect("failed to build tracker HTTP client")
 }

--- a/crates/bit_rev/src/utils.rs
+++ b/crates/bit_rev/src/utils.rs
@@ -35,12 +35,10 @@ pub fn check_integrity(hash: &[u8], buf: &[u8]) -> bool {
 }
 
 pub fn generate_peer_id() -> [u8; 20] {
-    let mut rng = rand::prelude::ThreadRng::default();
-    (0..20)
-        .map(|_| rng.gen())
-        .collect::<Vec<u8>>()
-        .try_into()
-        .unwrap()
+    let mut id = [0u8; 20];
+    id[..8].copy_from_slice(&crate::identity::peer_id_prefix());
+    rand::thread_rng().fill(&mut id[8..]);
+    id
 }
 
 #[derive(Debug, Clone)]
@@ -82,4 +80,29 @@ pub fn get_full_file_path(torrent: &Torrent, file_info: &TorrentFileInfo) -> std
         path.push(component);
     }
     path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity;
+
+    #[test]
+    fn peer_id_matches_bep20_for_current_version() {
+        let id = generate_peer_id();
+        assert_eq!(id.len(), 20);
+        assert_eq!(&id[..8], b"-BR0100-");
+        assert_eq!(&id[..8], &identity::peer_id_prefix());
+        assert_eq!(id[0], b'-');
+        assert_eq!(&id[1..3], b"BR");
+        assert_eq!(id[7], b'-');
+    }
+
+    #[test]
+    fn peer_ids_differ_in_random_suffix() {
+        let a = generate_peer_id();
+        let b = generate_peer_id();
+        assert_eq!(&a[..8], &b[..8]);
+        assert_ne!(&a[8..], &b[8..]);
+    }
 }

--- a/crates/bit_rev/tests/tracker_http.rs
+++ b/crates/bit_rev/tests/tracker_http.rs
@@ -10,12 +10,13 @@ use std::{
 
 use bit_rev::{
     file::{Info, TorrentFile, TorrentMeta},
+    identity,
     peer_connection::{PieceWorkState, TorrentDownloadedState},
     peer_state::PeerStates,
     session::{DownloadState, PieceWork},
     tracker::{
-        self, announce, build_http_client, run_http_announce_loop, HttpAnnounceContext,
-        TrackerError,
+        self, announce, build_http_client, http_client, run_http_announce_loop,
+        HttpAnnounceContext, TrackerError,
     },
 };
 use serde::Serialize;
@@ -254,6 +255,7 @@ fn announce_ctx(url: String, download: Arc<TorrentDownloadedState>) -> HttpAnnou
 
 fn test_http_client() -> reqwest::Client {
     reqwest::Client::builder()
+        .user_agent(identity::user_agent())
         .redirect(reqwest::redirect::Policy::limited(tracker::REDIRECT_LIMIT))
         .gzip(true)
         .http1_only()
@@ -271,6 +273,27 @@ async fn settle_io() {
     for _ in 0..16 {
         tokio::task::yield_now().await;
     }
+}
+
+#[tokio::test]
+async fn announce_sends_bitrev_user_agent() {
+    let (url, mut rx, handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 200,
+        body: ok_announce(1800, None, None),
+    }])
+    .await;
+
+    announce(&http_client(), &url).await.unwrap();
+    let request = rx.recv().await.expect("announce request");
+    assert_eq!(
+        request.headers.get("user-agent"),
+        Some(&identity::user_agent())
+    );
+    assert_eq!(
+        request.headers.get("user-agent").map(String::as_str),
+        Some("bitrev/0.1.0")
+    );
+    handle.abort();
 }
 
 #[tokio::test]
@@ -333,6 +356,10 @@ async fn announce_loop_respects_interval_and_echoes_tracker_id() {
     let first = rx.recv().await.expect("started announce");
     assert_eq!(first.path, "/announce");
     assert_eq!(first.query_param("event"), Some("started"));
+    assert_eq!(
+        first.headers.get("user-agent"),
+        Some(&identity::user_agent())
+    );
     assert!(first
         .headers
         .get("accept-encoding")


### PR DESCRIPTION
## Summary

Implements issue #16: identify bitrev to trackers and peers.

- Add `identity` as the single source of truth for client name, version, Azureus peer-id prefix, HTTP User-Agent, and the future BEP-0010 handshake `v` field.
- Generate BEP-0020 Azureus-style peer ids: `-BRxyzw-` plus 12 random bytes. Version mapping is 1-digit major, minor, patch, then `0` (`0.1.0` -> `0100`). Generated once per session.
- Set `User-Agent: bitrev/<version>` on the shared tracker HTTP client instead of leaving the #16 TODO.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- Unit tests cover the current-version prefix, 20-byte length, and distinct random suffixes.
- HTTP mock asserts announce requests send `User-Agent: bitrev/0.1.0`.

Closes #16