### PR TITLE
test: add unit tests for core modules

### DIFF
--- a/crates/bit_rev/src/bitfield.rs
+++ b/crates/bit_rev/src/bitfield.rs
@@ -79,3 +79,39 @@ fn set_piece_test() {
         assert_eq!(bitfield.bytes, *expected);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_and_set_across_byte_boundaries() {
+        let mut bitfield = Bitfield::new(vec![0, 0]);
+        let last = 15;
+        for index in [0, 7, 8, last] {
+            bitfield.set_piece(index);
+            assert!(bitfield.has_piece(index));
+        }
+        for index in [1, 6, 9, 14] {
+            assert!(!bitfield.has_piece(index));
+        }
+    }
+
+    #[test]
+    fn out_of_range_has_and_set_are_safe() {
+        let mut bitfield = Bitfield::new(vec![0, 0]);
+        assert!(!bitfield.has_piece(100));
+        bitfield.set_piece(100);
+        assert!(!bitfield.has_piece(100));
+        assert!(bitfield.is_empty());
+    }
+
+    #[test]
+    fn is_empty_for_zero_set_and_empty_vec() {
+        let mut bitfield = Bitfield::new(vec![0, 0]);
+        assert!(bitfield.is_empty());
+        bitfield.set_piece(0);
+        assert!(!bitfield.is_empty());
+        assert!(Bitfield::new(vec![]).is_empty());
+    }
+}

--- a/crates/bit_rev/src/file.rs
+++ b/crates/bit_rev/src/file.rs
@@ -83,16 +83,7 @@ impl TorrentMeta {
     }
 
     fn from_validated(torrent_file: TorrentFile, info_hash: [u8; 20]) -> Self {
-        let piece_hashes: Vec<[u8; 20]> = torrent_file
-            .info
-            .pieces
-            .chunks_exact(20)
-            .map(|chunk| {
-                let mut array = [0u8; 20];
-                array.copy_from_slice(chunk);
-                array
-            })
-            .collect();
+        let piece_hashes = torrent_file.info.pieces.as_chunks::<20>().0.to_vec();
 
         Self {
             torrent_file,

--- a/crates/bit_rev/src/file.rs
+++ b/crates/bit_rev/src/file.rs
@@ -73,16 +73,20 @@ pub struct TorrentMeta {
 }
 
 impl TorrentMeta {
-    pub fn new(torrent_file: TorrentFile) -> Self {
-        let file_info_beaconde = &ser::to_bytes(&torrent_file.info).unwrap();
+    pub fn new(torrent_file: TorrentFile) -> Result<Self> {
+        validate_torrent_file(&torrent_file)?;
+        let file_info_bencode = ser::to_bytes(&torrent_file.info)?;
         let mut hasher = sha1_smol::Sha1::new();
-        hasher.update(file_info_beaconde);
+        hasher.update(&file_info_bencode);
         let info_hash = hasher.digest().bytes();
+        Ok(Self::from_validated(torrent_file, info_hash))
+    }
 
+    fn from_validated(torrent_file: TorrentFile, info_hash: [u8; 20]) -> Self {
         let piece_hashes: Vec<[u8; 20]> = torrent_file
             .info
             .pieces
-            .chunks(20)
+            .chunks_exact(20)
             .map(|chunk| {
                 let mut array = [0u8; 20];
                 array.copy_from_slice(chunk);
@@ -98,12 +102,137 @@ impl TorrentMeta {
     }
 }
 
+pub fn from_bytes(content: &[u8]) -> Result<TorrentMeta> {
+    let torrent = de::from_bytes::<TorrentFile>(content)?;
+    validate_torrent_file(&torrent)?;
+    let info_bytes = raw_info_dict(content)?;
+    let mut hasher = sha1_smol::Sha1::new();
+    hasher.update(info_bytes);
+    let info_hash = hasher.digest().bytes();
+    Ok(TorrentMeta::from_validated(torrent, info_hash))
+}
+
 pub fn from_filename(filename: &str) -> Result<TorrentMeta> {
     let mut file = std::fs::File::open(filename)?;
     let mut content = Vec::new();
     file.read_to_end(&mut content)?;
-    let torrent = de::from_bytes::<TorrentFile>(&content)?;
-    Ok(TorrentMeta::new(torrent))
+    from_bytes(&content)
+}
+
+fn validate_torrent_file(torrent_file: &TorrentFile) -> Result<()> {
+    if torrent_file.info.piece_length <= 0 {
+        anyhow::bail!("piece length must be positive");
+    }
+    if torrent_file.info.pieces.len() % 20 != 0 {
+        anyhow::bail!("pieces length must be a multiple of 20");
+    }
+
+    match (
+        torrent_file.info.length.is_some(),
+        torrent_file.info.files.as_ref(),
+    ) {
+        (true, None) => {}
+        (false, Some(files)) => {
+            for file in files {
+                validate_file_path(&file.path)?;
+            }
+        }
+        _ => anyhow::bail!("exactly one of length or files must be present"),
+    }
+
+    Ok(())
+}
+
+fn validate_file_path(path: &[String]) -> Result<()> {
+    if path.is_empty() {
+        anyhow::bail!("file path must not be empty");
+    }
+    for component in path {
+        if !path_component_is_safe(component) {
+            anyhow::bail!("unsafe file path component: {component:?}");
+        }
+    }
+    Ok(())
+}
+
+fn path_component_is_safe(component: &str) -> bool {
+    if component.is_empty() || component == ".." {
+        return false;
+    }
+    if component.starts_with('/') || component.contains('/') || component.contains('\\') {
+        return false;
+    }
+    if component.len() >= 2 && component.as_bytes()[1] == b':' {
+        return false;
+    }
+    true
+}
+
+fn parse_bencode_byte_string(data: &[u8], i: usize) -> Result<(&[u8], usize)> {
+    let colon = data[i..]
+        .iter()
+        .position(|&b| b == b':')
+        .map(|p| i + p)
+        .ok_or_else(|| anyhow::anyhow!("truncated bencode string"))?;
+    let len: usize = std::str::from_utf8(&data[i..colon])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| anyhow::anyhow!("invalid bencode string length"))?;
+    let start = colon + 1;
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("bencode string length overflow"))?;
+    if end > data.len() {
+        anyhow::bail!("truncated bencode string");
+    }
+    Ok((&data[start..end], end))
+}
+
+fn skip_bencode(data: &[u8], i: usize) -> Result<usize> {
+    if i >= data.len() {
+        anyhow::bail!("truncated bencode");
+    }
+    match data[i] {
+        b'i' => {
+            let end = data[i + 1..]
+                .iter()
+                .position(|&b| b == b'e')
+                .map(|p| i + 1 + p)
+                .ok_or_else(|| anyhow::anyhow!("truncated bencode integer"))?;
+            Ok(end + 1)
+        }
+        b'l' | b'd' => {
+            let mut j = i + 1;
+            while j < data.len() && data[j] != b'e' {
+                j = skip_bencode(data, j)?;
+            }
+            if j >= data.len() {
+                anyhow::bail!("truncated bencode list or dict");
+            }
+            Ok(j + 1)
+        }
+        b'0'..=b'9' => {
+            let (_, end) = parse_bencode_byte_string(data, i)?;
+            Ok(end)
+        }
+        _ => anyhow::bail!("invalid bencode"),
+    }
+}
+
+fn raw_info_dict(data: &[u8]) -> Result<&[u8]> {
+    if data.first() != Some(&b'd') {
+        anyhow::bail!("torrent metainfo must be a dict");
+    }
+    let mut i = 1;
+    while i < data.len() && data[i] != b'e' {
+        let (key, after_key) = parse_bencode_byte_string(data, i)?;
+        let value_end = skip_bencode(data, after_key)?;
+        if key == b"info" {
+            return Ok(&data[after_key..value_end]);
+        }
+        i = value_end;
+    }
+    anyhow::bail!("missing info dictionary")
 }
 
 /// RFC 3986 unreserved set `A-Z a-z 0-9 - . _ ~` stays literal; every other byte is `%XX`.

--- a/crates/bit_rev/src/file.rs
+++ b/crates/bit_rev/src/file.rs
@@ -123,7 +123,7 @@ fn validate_torrent_file(torrent_file: &TorrentFile) -> Result<()> {
     if torrent_file.info.piece_length <= 0 {
         anyhow::bail!("piece length must be positive");
     }
-    if torrent_file.info.pieces.len() % 20 != 0 {
+    if !torrent_file.info.pieces.len().is_multiple_of(20) {
         anyhow::bail!("pieces length must be a multiple of 20");
     }
 
@@ -386,6 +386,67 @@ mod tests {
         }
     }
 
+    fn decode_info_hash(hex: &str) -> [u8; 20] {
+        assert_eq!(hex.len(), 40, "info hash hex must be 40 chars");
+        let mut out = [0u8; 20];
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).expect("hex digit");
+        }
+        out
+    }
+
+    fn torrent_file_entry(path: &[&str], length: i64) -> File {
+        File {
+            path: path
+                .iter()
+                .map(|component| (*component).to_string())
+                .collect(),
+            length,
+            md5sum: None,
+        }
+    }
+
+    fn torrent_file(
+        name: &str,
+        piece_length: i64,
+        pieces: Vec<u8>,
+        length: Option<i64>,
+        files: Option<Vec<File>>,
+    ) -> TorrentFile {
+        TorrentFile {
+            info: Info {
+                name: name.into(),
+                pieces: ByteBuf::from(pieces),
+                piece_length,
+                md5sum: None,
+                length,
+                files,
+                private: None,
+                path: None,
+                root_hash: None,
+            },
+            announce: Some("http://tracker.example/announce".into()),
+            nodes: None,
+            encoding: None,
+            httpseeds: None,
+            announce_list: None,
+            creation_date: None,
+            comment: None,
+            created_by: None,
+        }
+    }
+
+    fn encode_torrent(
+        name: &str,
+        piece_length: i64,
+        pieces: Vec<u8>,
+        length: Option<i64>,
+        files: Option<Vec<File>>,
+    ) -> Vec<u8> {
+        ser::to_bytes(&torrent_file(name, piece_length, pieces, length, files))
+            .expect("serialize torrent")
+    }
+
     #[test]
     fn url_encode_bytes_encodes_binary_info_hash() {
         assert_eq!(url_encode_bytes(&INFO_HASH_FIXTURE), INFO_HASH_ENCODED);
@@ -478,5 +539,166 @@ mod tests {
             &params,
         );
         assert!(url.ends_with("&trackerid=abc"));
+    }
+
+    #[test]
+    fn from_filename_parses_debian_sample() {
+        const DEBIAN_SAMPLE: &str = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../samples/debian-13.0.0-amd64-netinst.iso.torrent"
+        );
+        const DEBIAN_INFO_HASH_HEX: &str = "155a51b44b337d3b147c8d93d9764df48705ff89";
+
+        let meta = from_filename(DEBIAN_SAMPLE).expect("parse debian sample");
+        let info = &meta.torrent_file.info;
+
+        assert_eq!(info.name, "debian-13.0.0-amd64-netinst.iso");
+        assert_eq!(info.piece_length, 262144);
+        assert_eq!(meta.piece_hashes.len(), 3016);
+        assert_eq!(info.pieces.len(), 3016 * 20);
+        assert_eq!(info.length, Some(790_626_304));
+        assert!(info.files.is_none());
+        assert_eq!(meta.info_hash, decode_info_hash(DEBIAN_INFO_HASH_HEX));
+        assert_eq!(
+            meta.torrent_file.announce.as_deref(),
+            Some("http://bttracker.debian.org:6969/announce")
+        );
+    }
+
+    #[test]
+    fn from_bytes_parses_multi_file_fixture_and_offsets() {
+        let files = vec![
+            torrent_file_entry(
+                &["images", "LOC_Main_Reading_Room_Highsmith.jpg"],
+                17_614_527,
+            ),
+            torrent_file_entry(&["images", "melk-abbey-library.jpg"], 1_682_177),
+            torrent_file_entry(&["README"], 20),
+        ];
+        let encoded = encode_torrent("test_folder", 32768, vec![0u8; 3 * 20], None, Some(files));
+        let meta = from_bytes(&encoded).expect("parse multi-file fixture");
+        let info = &meta.torrent_file.info;
+
+        assert_eq!(info.name, "test_folder");
+        assert_eq!(info.piece_length, 32768);
+        assert_eq!(meta.piece_hashes.len(), 3);
+
+        let files = info.files.as_ref().expect("multi-file layout");
+        assert_eq!(
+            files[0].path,
+            ["images", "LOC_Main_Reading_Room_Highsmith.jpg"]
+        );
+        assert_eq!(files[0].length, 17_614_527);
+        assert_eq!(files[1].path, ["images", "melk-abbey-library.jpg"]);
+        assert_eq!(files[1].length, 1_682_177);
+        assert_eq!(files[2].path, ["README"]);
+        assert_eq!(files[2].length, 20);
+
+        let torrent = crate::torrent::Torrent::new(&meta).expect("torrent layout");
+        assert_eq!(torrent.files[0].offset, 0);
+        assert_eq!(torrent.files[1].offset, 17_614_527);
+        assert_eq!(torrent.files[2].offset, 17_614_527 + 1_682_177);
+        assert_eq!(torrent.length, 17_614_527 + 1_682_177 + 20);
+    }
+
+    #[test]
+    fn from_bytes_hashes_raw_info_dict() {
+        // SHA-1 of the info dict bytes, not a re-encoded struct.
+        const RAW: &[u8] = b"d8:announce31:http://tracker.example/announce4:infod6:lengthi4e4:name8:tiny.bin12:piece lengthi16384e6:pieces20:01234567890123456789ee";
+        const INFO_HASH_HEX: &str = "fea8fe53535a24b45effde348c0daab127924ff2";
+
+        let meta = from_bytes(RAW).expect("parse tiny fixture");
+        assert_eq!(meta.torrent_file.info.name, "tiny.bin");
+        assert_eq!(meta.torrent_file.info.piece_length, 16384);
+        assert_eq!(meta.torrent_file.info.length, Some(4));
+        assert_eq!(meta.piece_hashes.len(), 1);
+        assert_eq!(meta.info_hash, decode_info_hash(INFO_HASH_HEX));
+    }
+
+    #[test]
+    fn from_bytes_rejects_malformed_inputs() {
+        let valid = encode_torrent("test", 16384, vec![0u8; 20], Some(4), None);
+        let cases: &[(&str, Vec<u8>)] = &[
+            ("empty", b"".to_vec()),
+            ("truncated dict", b"d4:infod".to_vec()),
+            ("truncated valid torrent", valid[..valid.len() / 2].to_vec()),
+            (
+                "pieces not multiple of 20",
+                encode_torrent("test", 16384, vec![0u8; 21], Some(4), None),
+            ),
+            (
+                "both length and files",
+                encode_torrent(
+                    "test",
+                    16384,
+                    vec![0u8; 20],
+                    Some(4),
+                    Some(vec![torrent_file_entry(&["a"], 4)]),
+                ),
+            ),
+            (
+                "neither length nor files",
+                encode_torrent("test", 16384, vec![0u8; 20], None, None),
+            ),
+            (
+                "piece_length zero",
+                encode_torrent("test", 0, vec![0u8; 20], Some(4), None),
+            ),
+            (
+                "piece_length negative",
+                encode_torrent("test", -1, vec![0u8; 20], Some(4), None),
+            ),
+        ];
+
+        for (label, bytes) in cases {
+            assert!(
+                from_bytes(bytes).is_err(),
+                "{label} should be rejected without panicking"
+            );
+        }
+    }
+
+    #[test]
+    fn from_bytes_rejects_unsafe_file_paths() {
+        let cases: &[&[&str]] = &[
+            &["..", "secret"],
+            &["dir", ""],
+            &["/etc", "passwd"],
+            &["foo/bar"],
+            &["foo\\bar"],
+            &["C:windows"],
+        ];
+
+        for path in cases {
+            let files = vec![torrent_file_entry(path, 4)];
+            let encoded = encode_torrent("test", 16384, vec![0u8; 20], None, Some(files));
+            assert!(
+                from_bytes(&encoded).is_err(),
+                "path {path:?} should be rejected"
+            );
+        }
+
+        let empty_path = encode_torrent(
+            "test",
+            16384,
+            vec![0u8; 20],
+            None,
+            Some(vec![torrent_file_entry(&[], 4)]),
+        );
+        assert!(from_bytes(&empty_path).is_err());
+    }
+
+    #[test]
+    fn from_bytes_ignores_unknown_keys() {
+        let raw = b"d8:announce31:http://tracker.example/announce7:unknown7:ignored4:infod6:lengthi4e4:name4:test12:piece lengthi16384e6:pieces20:012345678901234567896:unused3:baree";
+        let meta = from_bytes(raw).expect("unknown keys should be ignored");
+        assert_eq!(meta.torrent_file.info.name, "test");
+        assert_eq!(meta.torrent_file.info.piece_length, 16384);
+        assert_eq!(meta.torrent_file.info.length, Some(4));
+        assert_eq!(meta.piece_hashes.len(), 1);
+        assert_eq!(
+            meta.torrent_file.announce.as_deref(),
+            Some("http://tracker.example/announce")
+        );
     }
 }

--- a/crates/bit_rev/src/handshake.rs
+++ b/crates/bit_rev/src/handshake.rs
@@ -137,4 +137,81 @@ mod tests {
 
         assert_eq!(result, Err(HandshakeError::ProtocolLengthCantBeZero));
     }
+
+    #[test]
+    fn serialize_read_round_trip() {
+        let handshake = Handshake::new(HASH_INFO, PEER_ID);
+        let serialized = handshake.serialize();
+        let protocol_str_len = serialized[0] as usize;
+        let rest = serialized[1..].to_vec();
+        let read = Handshake::read(protocol_str_len, rest).unwrap();
+        assert_eq!(read, handshake);
+    }
+
+    #[test]
+    fn exact_68_byte_layout_for_standard_pstr() {
+        let handshake = Handshake::new(HASH_INFO, PEER_ID);
+        let serialized = handshake.serialize();
+        assert_eq!(serialized.len(), 68);
+        assert_eq!(serialized[0], 19);
+        assert_eq!(&serialized[1..20], b"BitTorrent protocol");
+        assert_eq!(&serialized[20..28], &[0u8; 8]);
+        assert_eq!(&serialized[28..48], &HASH_INFO);
+        assert_eq!(&serialized[48..68], &PEER_ID);
+
+        let mut with_reserved = Handshake::new(HASH_INFO, PEER_ID);
+        with_reserved.set_reserved_bit(0);
+        let serialized = with_reserved.serialize();
+        assert_eq!(serialized.len(), 68);
+        assert_eq!(serialized[20], 0b1000_0000);
+        assert_eq!(&serialized[21..28], &[0u8; 7]);
+    }
+
+    #[test]
+    fn wrong_length_pstr() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"hello");
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(&HASH_INFO);
+        buf.extend_from_slice(&PEER_ID);
+        assert_eq!(buf.len(), 5 + 48);
+        let result = Handshake::read(5, buf).unwrap();
+        assert_eq!(result.pstr, "hello");
+        assert_eq!(result.pstr.len(), 5);
+        assert_eq!(result.info_hash, HASH_INFO);
+        assert_eq!(result.peer_id, PEER_ID);
+
+        let short = vec![0u8; 10];
+        let result = Handshake::read(19, short);
+        assert_eq!(result, Err(HandshakeError::BufferTooShort));
+    }
+
+    #[test]
+    fn reserved_bit_get_set_across_byte_boundaries() {
+        let mut handshake = Handshake::new(HASH_INFO, PEER_ID);
+        for index in [0, 7, 8, 63] {
+            assert!(!handshake.reserved_bit(index));
+        }
+
+        handshake.set_reserved_bit(0);
+        handshake.set_reserved_bit(7);
+        handshake.set_reserved_bit(8);
+        handshake.set_reserved_bit(63);
+
+        assert!(handshake.reserved_bit(0));
+        assert!(handshake.reserved_bit(7));
+        assert!(handshake.reserved_bit(8));
+        assert!(handshake.reserved_bit(63));
+        assert!(!handshake.reserved_bit(1));
+        assert!(!handshake.reserved_bit(6));
+        assert!(!handshake.reserved_bit(9));
+        assert!(!handshake.reserved_bit(62));
+
+        handshake.set_reserved_bit(64);
+        assert!(!handshake.reserved_bit(64));
+
+        assert_eq!(handshake.reserved[0], 0b1000_0001);
+        assert_eq!(handshake.reserved[1], 0b1000_0000);
+        assert_eq!(handshake.reserved[7], 0b0000_0001);
+    }
 }

--- a/crates/bit_rev/src/handshake.rs
+++ b/crates/bit_rev/src/handshake.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Handshake {
     pub pstr: String,
+    pub reserved: [u8; 8],
     pub info_hash: [u8; 20],
     pub peer_id: [u8; 20],
 }
@@ -11,22 +12,43 @@ pub struct Handshake {
 pub enum HandshakeError {
     #[error("Protocol length can't be zero")]
     ProtocolLengthCantBeZero,
+    #[error("Handshake buffer is too short")]
+    BufferTooShort,
 }
 
 impl Handshake {
     pub fn new(info_hash: [u8; 20], peer_id: [u8; 20]) -> Self {
         Self {
             pstr: "BitTorrent protocol".to_string(),
+            reserved: [0u8; 8],
             info_hash,
             peer_id,
         }
+    }
+
+    pub fn reserved_bit(&self, index: usize) -> bool {
+        if index >= 64 {
+            return false;
+        }
+        let byte_index = index / 8;
+        let offset = index % 8;
+        (self.reserved[byte_index] >> (7 - offset)) & 1 != 0
+    }
+
+    pub fn set_reserved_bit(&mut self, index: usize) {
+        if index >= 64 {
+            return;
+        }
+        let byte_index = index / 8;
+        let offset = index % 8;
+        self.reserved[byte_index] |= 1 << (7 - offset);
     }
 
     pub fn serialize(&self) -> Vec<u8> {
         let mut handshake = Vec::new();
         handshake.push(self.pstr.len() as u8);
         handshake.extend(self.pstr.as_bytes());
-        handshake.extend(vec![0u8; 8]);
+        handshake.extend(self.reserved);
         handshake.extend(self.info_hash);
         handshake.extend(self.peer_id);
         handshake
@@ -38,10 +60,28 @@ impl Handshake {
         if protocol_str_len == 0 {
             return Err(HandshakeError::ProtocolLengthCantBeZero);
         }
-        let i = protocol_str_len + 8;
-        let info_hash_buffer = handshake_buf[i..(i + 20)].try_into().unwrap();
-        let peer_id_buffer = handshake_buf[(i + 20)..].try_into().unwrap();
-        Ok(Handshake::new(info_hash_buffer, peer_id_buffer))
+        if handshake_buf.len() < protocol_str_len + 48 {
+            return Err(HandshakeError::BufferTooShort);
+        }
+        let pstr = String::from_utf8_lossy(&handshake_buf[..protocol_str_len]).into_owned();
+        let reserved_start = protocol_str_len;
+        let info_start = reserved_start + 8;
+        let peer_start = info_start + 20;
+        let reserved = handshake_buf[reserved_start..info_start]
+            .try_into()
+            .map_err(|_| HandshakeError::BufferTooShort)?;
+        let info_hash = handshake_buf[info_start..peer_start]
+            .try_into()
+            .map_err(|_| HandshakeError::BufferTooShort)?;
+        let peer_id = handshake_buf[peer_start..peer_start + 20]
+            .try_into()
+            .map_err(|_| HandshakeError::BufferTooShort)?;
+        Ok(Handshake {
+            pstr,
+            reserved,
+            info_hash,
+            peer_id,
+        })
     }
 }
 

--- a/crates/bit_rev/src/message.rs
+++ b/crates/bit_rev/src/message.rs
@@ -225,8 +225,8 @@ pub fn serialize(msg: Option<Message>) -> Vec<u8> {
                 Message::KeepAlive => return vec![0, 0, 0, 0],
             };
 
-            let length = payload.len() + 1;
-            let mut buf = Vec::with_capacity(4 + length);
+            let length = (payload.len() + 1) as u32;
+            let mut buf = Vec::with_capacity(4 + length as usize);
             buf.extend_from_slice(&length.to_be_bytes());
             buf.push(id as u8);
             buf.extend_from_slice(&payload);
@@ -236,42 +236,50 @@ pub fn serialize(msg: Option<Message>) -> Vec<u8> {
 }
 
 pub fn read(length_buf: &[u8], message_buf: &[u8]) -> Option<Message> {
-    let length = u32::from_be_bytes(length_buf.try_into().unwrap());
-    match length {
-        0 => None,
-        _ => {
-            let char_code = &message_buf[0..];
-            let id = char_code[0];
-            let payload = message_buf[1..(length) as usize].into();
-
-            let message_id = match id {
-                0 => MessageId::MsgChoke,
-                1 => MessageId::MsgUnchoke,
-                2 => MessageId::MsgInterested,
-                3 => MessageId::MsgNotInterested,
-                4 => MessageId::MsgHave,
-                5 => MessageId::MsgBitfield,
-                6 => MessageId::MsgRequest,
-                7 => MessageId::MsgPiece,
-                8 => MessageId::MsgCancel,
-                16 => MessageId::MsgReject,
-                21 => MessageId::MsgHashRequest,
-                22 => MessageId::MsgHashes,
-                23 => MessageId::MsgHashReject,
-                _ => {
-                    return None;
-                }
-            };
-
-            Some(
-                (MessageInner {
-                    id: message_id,
-                    payload,
-                })
-                .into(),
-            )
-        }
+    let length_buf: [u8; 4] = length_buf.try_into().ok()?;
+    let length = u32::from_be_bytes(length_buf);
+    if length == 0 {
+        return None;
     }
+    let length = length as usize;
+    if message_buf.is_empty() || message_buf.len() < length {
+        return None;
+    }
+
+    let id = message_buf[0];
+    let payload = message_buf[1..length].to_vec();
+
+    let message_id = match id {
+        0 => MessageId::MsgChoke,
+        1 => MessageId::MsgUnchoke,
+        2 => MessageId::MsgInterested,
+        3 => MessageId::MsgNotInterested,
+        4 => MessageId::MsgHave,
+        5 => MessageId::MsgBitfield,
+        6 => MessageId::MsgRequest,
+        7 => MessageId::MsgPiece,
+        8 => MessageId::MsgCancel,
+        16 => MessageId::MsgReject,
+        21 => MessageId::MsgHashRequest,
+        22 => MessageId::MsgHashes,
+        23 => MessageId::MsgHashReject,
+        _ => return None,
+    };
+
+    match message_id {
+        MessageId::MsgHave if payload.len() < 4 => return None,
+        MessageId::MsgRequest | MessageId::MsgCancel if payload.len() < 12 => return None,
+        MessageId::MsgPiece if payload.len() < 8 => return None,
+        _ => {}
+    }
+
+    Some(
+        (MessageInner {
+            id: message_id,
+            payload,
+        })
+        .into(),
+    )
 }
 
 #[cfg(test)]
@@ -344,8 +352,8 @@ mod tests {
             data: vec![0x00, 0x00, 0x00, 0x04],
         });
         let expected = vec![
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x07, 0x00, 0x00, 0x00, 0x04, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
+            0x00, 0x00, 0x00, 0x0d, 0x07, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x04,
         ];
         let result = serialize(Some(msg));
         assert_eq!(result, expected);

--- a/crates/bit_rev/src/message.rs
+++ b/crates/bit_rev/src/message.rs
@@ -368,4 +368,130 @@ mod tests {
         let result = read(&length_buf, &message_buf);
         assert_eq!(result, Some(expected));
     }
+
+    fn round_trip(msg: Message) -> Option<Message> {
+        let bytes = serialize(Some(msg));
+        read(&bytes[0..4], &bytes[4..])
+    }
+
+    #[test]
+    fn serialize_read_round_trip_all_variants() {
+        let cases = [
+            Message::Choke,
+            Message::Unchoke,
+            Message::Interested,
+            Message::NotInterested,
+            Message::Have(42),
+            Message::Bitfield(vec![0b1010_0001, 0b0000_1111]),
+            Message::Request(vec![
+                0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x02, 0x37, 0x00, 0x00, 0x10, 0xe1,
+            ]),
+            Message::Piece(PieceChunk {
+                index: 7,
+                start: 16384,
+                length: 4,
+                data: vec![0xaa, 0xbb, 0xcc, 0xdd],
+            }),
+            Message::Cancel(vec![
+                0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+            ]),
+            Message::Reject,
+            Message::HashRequest,
+            Message::Hashes(vec![0x01, 0x02, 0x03]),
+            Message::HashReject,
+        ];
+
+        for msg in cases {
+            let expected = msg.clone();
+            assert_eq!(round_trip(msg), Some(expected));
+        }
+
+        // Keep-alive serializes to a zero length prefix. read maps length 0 to None.
+        assert_eq!(serialize(Some(Message::KeepAlive)), vec![0, 0, 0, 0]);
+        assert_eq!(round_trip(Message::KeepAlive), None);
+    }
+
+    #[test]
+    fn read_keep_alive_length_zero() {
+        assert_eq!(read(&[0, 0, 0, 0], &[]), None);
+    }
+
+    #[test]
+    fn read_truncated_payloads() {
+        let cases: &[(&[u8], &[u8])] = &[
+            // Have claims length 5 (id + 4) but only the id byte is present
+            (&[0, 0, 0, 5], &[4]),
+            // Have with a present but too-short payload
+            (&[0, 0, 0, 2], &[4, 0]),
+            // Piece payload shorter than 8 bytes
+            (&[0, 0, 0, 5], &[7, 0, 0, 0, 1]),
+            (&[0, 0, 0, 8], &[7, 0, 0, 0, 1, 0, 0, 0]),
+            // Request payload shorter than 12 bytes
+            (&[0, 0, 0, 9], &[6, 0, 0, 0, 1, 0, 0, 0, 0]),
+            (&[0, 0, 0, 12], &[6, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]),
+        ];
+
+        for (length_buf, message_buf) in cases {
+            assert_eq!(read(length_buf, message_buf), None);
+        }
+    }
+
+    #[test]
+    fn read_unknown_id() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (&[0, 0, 0, 1], &[99]),
+            (&[0, 0, 0, 3], &[9, 0, 1]),
+            (&[0, 0, 0, 1], &[255]),
+        ];
+
+        for (length_buf, message_buf) in cases {
+            assert_eq!(read(length_buf, message_buf), None);
+        }
+    }
+
+    #[test]
+    fn read_empty_buffer() {
+        assert_eq!(read(&[], &[]), None);
+        assert_eq!(read(&[0, 0, 0, 1], &[]), None);
+    }
+
+    #[test]
+    fn piece_framing_payload_sizes() {
+        use rand::{Rng, RngCore};
+
+        let mut rng = rand::thread_rng();
+        let mut sizes = vec![0usize, 1, 16, 16383, 16384, 40000];
+        for _ in 0..5 {
+            sizes.push(rng.gen_range(2..4096));
+        }
+
+        for size in sizes {
+            let mut data = vec![0u8; size];
+            rng.fill_bytes(&mut data);
+
+            let index = 3u32;
+            let start = 16u32;
+            let msg = Message::Piece(PieceChunk {
+                index,
+                start,
+                length: size as u32,
+                data: data.clone(),
+            });
+
+            let bytes = serialize(Some(msg));
+            let length = u32::from_be_bytes(bytes[0..4].try_into().unwrap());
+            assert_eq!(length, 1 + 8 + size as u32);
+
+            let parsed = read(&bytes[0..4], &bytes[4..]).expect("piece should parse");
+            assert_eq!(
+                parsed,
+                Message::Piece(PieceChunk {
+                    index,
+                    start,
+                    length: size as u32,
+                    data,
+                })
+            );
+        }
+    }
 }

--- a/crates/bit_rev/src/peer.rs
+++ b/crates/bit_rev/src/peer.rs
@@ -165,4 +165,85 @@ mod tests {
         );
         assert!(decoded.get_peers().unwrap().is_empty());
     }
+
+    fn compact_v4_response(buf: &[u8]) -> BencodeResponse {
+        BencodeResponse {
+            peers: Some(Value::Bytes(buf.to_vec())),
+            peers6: None,
+            interval: None,
+            min_interval: None,
+            failure_reason: None,
+            warning_message: None,
+            tracker_id: None,
+            complete: None,
+            incomplete: None,
+        }
+    }
+
+    fn compact_v6_response(buf: &[u8]) -> BencodeResponse {
+        BencodeResponse {
+            peers: None,
+            peers6: Some(ByteBuf::from(buf.to_vec())),
+            interval: None,
+            min_interval: None,
+            failure_reason: None,
+            warning_message: None,
+            tracker_id: None,
+            complete: None,
+            incomplete: None,
+        }
+    }
+
+    #[test]
+    fn compact_peers_decode_multiple_addresses() {
+        let buf = [
+            127, 0, 0, 1, 0x1A, 0xE1, 192, 168, 1, 2, 0x1A, 0xE9, 10, 0, 0, 5, 0x00, 0x50,
+        ];
+        let response = compact_v4_response(&buf);
+        assert_eq!(
+            response.get_peers().unwrap(),
+            vec![
+                "127.0.0.1:6881".parse().unwrap(),
+                "192.168.1.2:6889".parse().unwrap(),
+                "10.0.0.5:80".parse().unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn compact_peers_odd_length_is_error() {
+        for len in [5, 7] {
+            let buf = vec![0u8; len];
+            let err = compact_v4_response(&buf).get_peers().unwrap_err();
+            assert!(
+                err.to_string().contains("invalid compact peers length"),
+                "len={len}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn compact_peers_empty_is_empty_vec() {
+        let response = compact_v4_response(&[]);
+        assert!(response.get_peers().unwrap().is_empty());
+    }
+
+    #[test]
+    fn compact_peers6_one_address() {
+        let mut buf = [0u8; 18];
+        buf[15] = 1;
+        buf[16] = 0x1A;
+        buf[17] = 0xE1;
+        let response = compact_v6_response(&buf);
+        assert_eq!(
+            response.get_peers().unwrap(),
+            vec!["[::1]:6881".parse().unwrap()]
+        );
+    }
+
+    #[test]
+    fn compact_peers6_odd_length_is_error() {
+        let err = compact_v6_response(&[0u8; 17]).get_peers().unwrap_err();
+        assert!(err.to_string().contains("invalid compact peers6 length"));
+    }
 }

--- a/crates/bit_rev/src/peer_connection.rs
+++ b/crates/bit_rev/src/peer_connection.rs
@@ -656,3 +656,158 @@ impl PeerConnection {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    fn piece(index: u32, length: u32) -> PieceWorkState {
+        PieceWorkState {
+            piece_work: PieceWork {
+                index,
+                length,
+                hash: [0; 20],
+            },
+            chuncks: Mutex::new(vec![]),
+            downloaded: AtomicBool::new(false),
+            reserved: Mutex::new(None),
+        }
+    }
+
+    fn state(n: u32, piece_len: u32) -> TorrentDownloadedState {
+        TorrentDownloadedState {
+            semaphore: Semaphore::new(0),
+            pieces: (0..n).map(|i| piece(i, piece_len)).collect(),
+        }
+    }
+
+    fn peer(port: u16) -> PeerAddr {
+        (std::net::Ipv4Addr::LOCALHOST, port).into()
+    }
+
+    #[tokio::test]
+    async fn get_and_reserve_piece_assigns_distinct_peers_then_steals_without_overwrite() {
+        let s = state(3, 16);
+        let p1 = peer(6881);
+        let p2 = peer(6882);
+        let p3 = peer(6883);
+        let p4 = peer(6884);
+
+        let a = s.get_and_reserve_piece(p1).await.unwrap();
+        assert_eq!(a.piece_work.index, 0);
+        assert_eq!(*a.reserved.lock().unwrap(), Some(p1));
+
+        let b = s.get_and_reserve_piece(p2).await.unwrap();
+        assert_eq!(b.piece_work.index, 1);
+        assert_eq!(*b.reserved.lock().unwrap(), Some(p2));
+
+        let c = s.get_and_reserve_piece(p3).await.unwrap();
+        assert_eq!(c.piece_work.index, 2);
+        assert_eq!(*c.reserved.lock().unwrap(), Some(p3));
+
+        let stolen = s.get_and_reserve_piece(p4).await.unwrap();
+        assert_eq!(stolen.piece_work.index, 0);
+        assert_eq!(*stolen.reserved.lock().unwrap(), Some(p1));
+        assert_eq!(*s.pieces[0].reserved.lock().unwrap(), Some(p1));
+        assert_eq!(*s.pieces[1].reserved.lock().unwrap(), Some(p2));
+        assert_eq!(*s.pieces[2].reserved.lock().unwrap(), Some(p3));
+    }
+
+    #[tokio::test]
+    async fn remove_reserved_clears_only_that_peer() {
+        let s = state(3, 16);
+        let p1 = peer(6881);
+        let p2 = peer(6882);
+        let p3 = peer(6883);
+
+        s.get_and_reserve_piece(p1).await.unwrap();
+        s.get_and_reserve_piece(p2).await.unwrap();
+        s.get_and_reserve_piece(p3).await.unwrap();
+
+        s.remove_reserved(p2);
+
+        assert_eq!(*s.pieces[0].reserved.lock().unwrap(), Some(p1));
+        assert!(s.pieces[1].reserved.lock().unwrap().is_none());
+        assert_eq!(*s.pieces[2].reserved.lock().unwrap(), Some(p3));
+    }
+
+    #[test]
+    fn set_chuncks_then_downloaded_when_lengths_sum() {
+        let s = state(2, 16);
+
+        s.set_chuncks(0, 0, vec![0u8; 8]);
+        assert!(s.set_downloaded_if_all_chunks(0).is_none());
+        assert!(!s.pieces[0].downloaded.load(Ordering::Relaxed));
+        assert!(!s.is_complete());
+
+        s.set_chuncks(0, 8, vec![1u8; 8]);
+        let done = s.set_downloaded_if_all_chunks(0);
+        assert!(done.is_some());
+        assert_eq!(done.unwrap().piece_work.index, 0);
+        assert!(s.pieces[0].downloaded.load(Ordering::Relaxed));
+        assert!(!s.is_complete());
+
+        s.set_chuncks(1, 0, vec![2u8; 16]);
+        assert!(s.set_downloaded_if_all_chunks(1).is_some());
+        assert!(s.pieces[1].downloaded.load(Ordering::Relaxed));
+        assert!(s.is_complete());
+    }
+
+    #[test]
+    fn remove_downloaded_clears_chunks_and_flag() {
+        let s = state(1, 16);
+        s.set_chuncks(0, 0, vec![7u8; 16]);
+        assert!(s.set_downloaded_if_all_chunks(0).is_some());
+        assert!(s.pieces[0].downloaded.load(Ordering::Relaxed));
+        assert_eq!(s.pieces[0].chuncks.lock().unwrap().len(), 1);
+
+        s.remove_downloaded(0);
+        assert!(!s.pieces[0].downloaded.load(Ordering::Relaxed));
+        assert!(s.pieces[0].chuncks.lock().unwrap().is_empty());
+        assert!(!s.is_complete());
+    }
+
+    #[tokio::test]
+    async fn concurrent_reservation_completes_each_piece_once() {
+        const N: u16 = 16;
+        const M: u32 = 8;
+        const PIECE_LEN: u32 = 16;
+
+        let s = Arc::new(state(M, PIECE_LEN));
+        let mut set = tokio::task::JoinSet::new();
+
+        for i in 0..N {
+            let s = Arc::clone(&s);
+            let peer = peer(6881 + i);
+            set.spawn(async move {
+                let mut completed = 0u32;
+                while let Some(pw) = s.get_and_reserve_piece(peer).await {
+                    let reserved_by_me = pw.reserved.lock().unwrap().as_ref() == Some(&peer);
+                    if reserved_by_me {
+                        let index = pw.piece_work.index;
+                        s.set_chuncks(index, 0, vec![0u8; PIECE_LEN as usize]);
+                        s.set_downloaded_if_all_chunks(index);
+                        completed += 1;
+                    } else {
+                        tokio::task::yield_now().await;
+                    }
+                }
+                completed
+            });
+        }
+
+        let mut total_completed = 0u32;
+        while let Some(res) = set.join_next().await {
+            total_completed += res.unwrap();
+        }
+
+        assert_eq!(total_completed, M);
+        assert!(s.is_complete());
+        for pw in s.pieces.iter() {
+            assert!(pw.downloaded.load(Ordering::Relaxed));
+            let reserved = pw.reserved.lock().unwrap();
+            assert!(reserved.is_some());
+        }
+    }
+}

--- a/crates/bit_rev/src/protocol.rs
+++ b/crates/bit_rev/src/protocol.rs
@@ -6,7 +6,6 @@ use byteorder::{BigEndian, ByteOrder};
 use std::time::Duration;
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
 use tokio::time::error::Elapsed;
 
 const HANDSHAKE_TIMEOUT: u64 = 3;
@@ -105,8 +104,11 @@ impl Protocol {
             .map_err(ProtocolError::Io)
     }
 
-    pub async fn send_not_interested(&self, stream: &mut TcpStream) -> Result<(), ProtocolError> {
-        let msg = message::Message::Interested;
+    pub async fn send_not_interested(
+        &self,
+        mut stream: impl AsyncWriteExt + Unpin,
+    ) -> Result<(), ProtocolError> {
+        let msg = message::Message::NotInterested;
         let msg_bytes = message::serialize(Some(msg));
         stream
             .write_all(&msg_bytes)
@@ -126,7 +128,11 @@ impl Protocol {
             .map_err(ProtocolError::Io)
     }
 
-    pub async fn send_have(&self, stream: &mut TcpStream, index: u32) -> Result<(), ProtocolError> {
+    pub async fn send_have(
+        &self,
+        mut stream: impl AsyncWriteExt + Unpin,
+        index: u32,
+    ) -> Result<(), ProtocolError> {
         let msg = message::format_have(index);
         let msg_bytes = message::serialize(Some(msg));
         stream
@@ -137,7 +143,7 @@ impl Protocol {
 
     pub async fn complete_handshake(
         &self,
-        stream: &mut TcpStream,
+        stream: &mut (impl AsyncReadExt + AsyncWriteExt + Unpin),
     ) -> Result<Handshake, ProtocolError> {
         let timeout = tokio::time::timeout(Duration::from_secs(HANDSHAKE_TIMEOUT), async {
             let handshake = Handshake::new(self.info_hash, self.peer_id);
@@ -176,7 +182,10 @@ impl Protocol {
         }
     }
 
-    pub async fn recv_bitfield(&self, stream: &mut TcpStream) -> Result<Vec<u8>, ProtocolError> {
+    pub async fn recv_bitfield(
+        &self,
+        stream: &mut (impl AsyncReadExt + Unpin),
+    ) -> Result<Vec<u8>, ProtocolError> {
         let func = async {
             match self.read(stream).await? {
                 None => Err(ProtocolError::MessageIsNone),

--- a/crates/bit_rev/src/protocol.rs
+++ b/crates/bit_rev/src/protocol.rs
@@ -202,3 +202,106 @@ impl Protocol {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    const INFO_HASH: [u8; 20] = [
+        134, 212, 200, 0, 36, 164, 105, 190, 76, 80, 188, 90, 16, 44, 247, 23, 128, 49, 0, 116,
+    ];
+    const LOCAL_PEER_ID: [u8; 20] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    ];
+    const REMOTE_PEER_ID: [u8; 20] = [
+        20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+    ];
+
+    fn peer_addr() -> PeerAddr {
+        "127.0.0.1:6881".parse().unwrap()
+    }
+
+    async fn protocol() -> Protocol {
+        Protocol::connect(peer_addr(), INFO_HASH, LOCAL_PEER_ID)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn complete_handshake_success_round_trip() {
+        let proto = protocol().await;
+        let (mut client, mut server) = tokio::io::duplex(256);
+
+        let server_task = tokio::spawn(async move {
+            let mut client_hs = [0u8; 68];
+            server.read_exact(&mut client_hs).await.unwrap();
+            let reply = Handshake::new(INFO_HASH, REMOTE_PEER_ID).serialize();
+            server.write_all(&reply).await.unwrap();
+        });
+
+        let handshake = proto.complete_handshake(&mut client).await.unwrap();
+        assert_eq!(handshake.info_hash, INFO_HASH);
+        assert_eq!(handshake.peer_id, REMOTE_PEER_ID);
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn complete_handshake_info_hash_mismatch() {
+        let proto = protocol().await;
+        let (mut client, mut server) = tokio::io::duplex(256);
+        let other_hash = [0xABu8; 20];
+
+        let server_task = tokio::spawn(async move {
+            let mut client_hs = [0u8; 68];
+            server.read_exact(&mut client_hs).await.unwrap();
+            let reply = Handshake::new(other_hash, REMOTE_PEER_ID).serialize();
+            server.write_all(&reply).await.unwrap();
+        });
+
+        let err = proto.complete_handshake(&mut client).await.unwrap_err();
+        assert!(matches!(err, ProtocolError::InfoHashIsNotEqual));
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_not_interested_writes_not_interested_frame() {
+        let proto = protocol().await;
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+
+        proto.send_not_interested(&mut writer).await.unwrap();
+
+        let expected = message::serialize(Some(Message::NotInterested));
+        let interested = message::serialize(Some(Message::Interested));
+        let mut buf = vec![0u8; expected.len()];
+        reader.read_exact(&mut buf).await.unwrap();
+        assert_eq!(buf, expected);
+        assert_ne!(buf, interested);
+        assert_eq!(buf[4], message::MessageId::MsgNotInterested as u8);
+    }
+
+    #[tokio::test]
+    async fn send_interested_writes_interested_frame() {
+        let proto = protocol().await;
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+
+        proto.send_interested(&mut writer).await.unwrap();
+
+        let expected = message::serialize(Some(Message::Interested));
+        let mut buf = vec![0u8; expected.len()];
+        reader.read_exact(&mut buf).await.unwrap();
+        assert_eq!(buf, expected);
+        assert_eq!(buf[4], message::MessageId::MsgInterested as u8);
+    }
+
+    #[tokio::test]
+    async fn read_keep_alive_returns_none() {
+        let proto = protocol().await;
+        let (mut writer, reader) = tokio::io::duplex(64);
+
+        writer.write_all(&[0, 0, 0, 0]).await.unwrap();
+        let result = proto.read(reader).await.unwrap();
+        assert_eq!(result, None);
+    }
+}

--- a/crates/bit_rev/src/protocol_udp.rs
+++ b/crates/bit_rev/src/protocol_udp.rs
@@ -90,21 +90,21 @@ impl UdpTracker {
         let left = announce_options.left;
         let event = announce_options.event;
 
-        // Build announce request
-        let mut request = Vec::new();
-        request.write_u64::<BigEndian>(connection_id)?;
-        request.write_u32::<BigEndian>(ACTION_ANNOUNCE)?;
-        request.write_u32::<BigEndian>(transaction_id)?;
-        request.write_all(&torrent_meta.info_hash)?;
-        request.write_all(peer_id)?;
-        request.write_u64::<BigEndian>(downloaded)?;
-        request.write_u64::<BigEndian>(left)?;
-        request.write_u64::<BigEndian>(uploaded)?;
-        request.write_u32::<BigEndian>(event)?; // 0: none, 1: completed, 2: started, 3: stopped
-        request.write_u32::<BigEndian>(0)?; // IP address (0 = default)
-        request.write_u32::<BigEndian>(rand::thread_rng().gen())?; // key
-        request.write_i32::<BigEndian>(-1)?; // num_want (-1 = default)
-        request.write_u16::<BigEndian>(port)?;
+        let key = rand::thread_rng().gen();
+        let request = build_announce_request(AnnounceRequest {
+            connection_id,
+            transaction_id,
+            info_hash: torrent_meta.info_hash,
+            peer_id: *peer_id,
+            downloaded,
+            left,
+            uploaded,
+            event,
+            ip: 0,
+            key,
+            num_want: -1,
+            port,
+        })?;
 
         debug!("Sending UDP announce request to {}", addr);
         socket.send_to(&request, addr).await?;
@@ -122,11 +122,7 @@ impl UdpTracker {
 
         let transaction_id: u32 = rand::thread_rng().gen();
 
-        // Build connect request
-        let mut request = Vec::new();
-        request.write_u64::<BigEndian>(PROTOCOL_ID)?;
-        request.write_u32::<BigEndian>(ACTION_CONNECT)?;
-        request.write_u32::<BigEndian>(transaction_id)?;
+        let request = build_connect_request(transaction_id)?;
 
         debug!("Sending UDP connect request to {}", addr);
         socket.send_to(&request, addr).await?;
@@ -135,28 +131,7 @@ impl UdpTracker {
         let mut buf = [0u8; 16];
         let (len, _) = timeout(Duration::from_secs(15), socket.recv_from(&mut buf)).await??;
 
-        if len < 16 {
-            return Err(anyhow!("Connect response too short: {} bytes", len));
-        }
-
-        let mut cursor = Cursor::new(&buf[..len]);
-        let action = cursor.read_u32::<BigEndian>()?;
-        let response_transaction_id = cursor.read_u32::<BigEndian>()?;
-
-        if action == ACTION_ERROR {
-            let error_msg = String::from_utf8_lossy(&buf[8..len]);
-            return Err(anyhow!("Tracker error: {}", error_msg));
-        }
-
-        if action != ACTION_CONNECT {
-            return Err(anyhow!("Invalid action in connect response: {}", action));
-        }
-
-        if response_transaction_id != transaction_id {
-            return Err(anyhow!("Transaction ID mismatch in connect response"));
-        }
-
-        self.connection_id = Some(cursor.read_u64::<BigEndian>()?);
+        self.connection_id = Some(parse_connect_response(&buf[..len], transaction_id)?);
         self.last_connect = Some(Instant::now());
 
         debug!(
@@ -167,17 +142,7 @@ impl UdpTracker {
     }
 
     fn parse_udp_url(&self) -> Result<SocketAddr> {
-        if !self.url.starts_with("udp://") {
-            return Err(anyhow!("Invalid UDP tracker URL: {}", self.url));
-        }
-
-        let url_without_scheme = &self.url[6..]; // Remove "udp://"
-
-        // Split at the first '/' to separate hostname:port from path
-        let host_port = url_without_scheme
-            .split('/')
-            .next()
-            .ok_or_else(|| anyhow!("Invalid UDP tracker URL format: {}", self.url))?;
+        let host_port = parse_udp_host_port(&self.url)?;
 
         let addr = host_port
             .to_socket_addrs()?
@@ -245,6 +210,90 @@ impl UdpTracker {
             peers,
         })
     }
+}
+
+struct AnnounceRequest {
+    connection_id: u64,
+    transaction_id: u32,
+    info_hash: [u8; 20],
+    peer_id: [u8; 20],
+    downloaded: u64,
+    left: u64,
+    uploaded: u64,
+    event: u32,
+    ip: u32,
+    key: u32,
+    num_want: i32,
+    port: u16,
+}
+
+fn build_connect_request(transaction_id: u32) -> Result<Vec<u8>> {
+    let mut request = Vec::new();
+    request.write_u64::<BigEndian>(PROTOCOL_ID)?;
+    request.write_u32::<BigEndian>(ACTION_CONNECT)?;
+    request.write_u32::<BigEndian>(transaction_id)?;
+    Ok(request)
+}
+
+fn build_announce_request(req: AnnounceRequest) -> Result<Vec<u8>> {
+    let mut request = Vec::new();
+    request.write_u64::<BigEndian>(req.connection_id)?;
+    request.write_u32::<BigEndian>(ACTION_ANNOUNCE)?;
+    request.write_u32::<BigEndian>(req.transaction_id)?;
+    request.write_all(&req.info_hash)?;
+    request.write_all(&req.peer_id)?;
+    request.write_u64::<BigEndian>(req.downloaded)?;
+    request.write_u64::<BigEndian>(req.left)?;
+    request.write_u64::<BigEndian>(req.uploaded)?;
+    request.write_u32::<BigEndian>(req.event)?;
+    request.write_u32::<BigEndian>(req.ip)?;
+    request.write_u32::<BigEndian>(req.key)?;
+    request.write_i32::<BigEndian>(req.num_want)?;
+    request.write_u16::<BigEndian>(req.port)?;
+    Ok(request)
+}
+
+fn parse_udp_host_port(url: &str) -> Result<&str> {
+    if !url.starts_with("udp://") {
+        return Err(anyhow!("Invalid UDP tracker URL: {}", url));
+    }
+
+    let url_without_scheme = &url[6..];
+    let host_port = url_without_scheme
+        .split('/')
+        .next()
+        .ok_or_else(|| anyhow!("Invalid UDP tracker URL format: {}", url))?;
+
+    if host_port.is_empty() {
+        return Err(anyhow!("Invalid UDP tracker URL format: {}", url));
+    }
+
+    Ok(host_port)
+}
+
+fn parse_connect_response(data: &[u8], expected_transaction_id: u32) -> Result<u64> {
+    if data.len() < 16 {
+        return Err(anyhow!("Connect response too short: {} bytes", data.len()));
+    }
+
+    let mut cursor = Cursor::new(data);
+    let action = cursor.read_u32::<BigEndian>()?;
+    let response_transaction_id = cursor.read_u32::<BigEndian>()?;
+
+    if action == ACTION_ERROR {
+        let error_msg = String::from_utf8_lossy(&data[8..]);
+        return Err(anyhow!("Tracker error: {}", error_msg));
+    }
+
+    if action != ACTION_CONNECT {
+        return Err(anyhow!("Invalid action in connect response: {}", action));
+    }
+
+    if response_transaction_id != expected_transaction_id {
+        return Err(anyhow!("Transaction ID mismatch in connect response"));
+    }
+
+    Ok(cursor.read_u64::<BigEndian>()?)
 }
 
 impl UdpPeer {

--- a/crates/bit_rev/src/protocol_udp.rs
+++ b/crates/bit_rev/src/protocol_udp.rs
@@ -345,4 +345,157 @@ mod tests {
         let result = tracker.parse_udp_url();
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_build_connect_request() {
+        let transaction_id = 0x01020304;
+        let request = build_connect_request(transaction_id).unwrap();
+        let expected = [
+            0x00, 0x00, 0x04, 0x17, 0x27, 0x10, 0x19, 0x80, // protocol id 0x41727101980
+            0x00, 0x00, 0x00, 0x00, // action connect
+            0x01, 0x02, 0x03, 0x04, // transaction_id
+        ];
+        assert_eq!(request, expected);
+    }
+
+    #[test]
+    fn test_build_announce_request() {
+        let info_hash: [u8; 20] = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        ];
+        let peer_id: [u8; 20] = [
+            20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+        ];
+        let request = build_announce_request(AnnounceRequest {
+            connection_id: 0x1111_1111_1111_1111,
+            transaction_id: 0xaabbccdd,
+            info_hash,
+            peer_id,
+            downloaded: 1,
+            left: 2,
+            uploaded: 3,
+            event: 2,
+            ip: 0,
+            key: 0xdeadbeef,
+            num_want: -1,
+            port: 6881,
+        })
+        .unwrap();
+
+        let expected = [
+            0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, // connection_id
+            0x00, 0x00, 0x00, 0x01, // action announce
+            0xaa, 0xbb, 0xcc, 0xdd, // transaction_id
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+            20, // info_hash
+            20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, // peer_id
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // downloaded
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // left
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, // uploaded
+            0x00, 0x00, 0x00, 0x02, // event started
+            0x00, 0x00, 0x00, 0x00, // ip
+            0xde, 0xad, 0xbe, 0xef, // key
+            0xff, 0xff, 0xff, 0xff, // num_want -1
+            0x1a, 0xe1, // port 6881
+        ];
+        assert_eq!(request.len(), 98);
+        assert_eq!(request, expected);
+        assert_eq!(&request[96..], &[0x1a, 0xe1]);
+    }
+
+    #[test]
+    fn test_parse_connect_response() {
+        let transaction_id = 0x01020304;
+        let data = [
+            0x00, 0x00, 0x00, 0x00, // action connect
+            0x01, 0x02, 0x03, 0x04, // transaction_id
+            0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10, // connection_id
+        ];
+        let connection_id = parse_connect_response(&data, transaction_id).unwrap();
+        assert_eq!(connection_id, 0xfedcba9876543210);
+    }
+
+    #[test]
+    fn test_parse_announce_response() {
+        let tracker = UdpTracker::new("udp://127.0.0.1:1".into());
+        let transaction_id = 0xaabbccdd;
+        let data = [
+            0x00, 0x00, 0x00, 0x01, // action announce
+            0xaa, 0xbb, 0xcc, 0xdd, // transaction_id
+            0x00, 0x00, 0x07, 0x08, // interval 1800
+            0x00, 0x00, 0x00, 0x03, // leechers
+            0x00, 0x00, 0x00, 0x07, // seeders
+            127, 0, 0, 1, // 127.0.0.1
+            0x1a, 0xe1, // port 6881
+        ];
+        let response = tracker
+            .parse_announce_response(&data, transaction_id)
+            .unwrap();
+        assert_eq!(response.action, ACTION_ANNOUNCE);
+        assert_eq!(response.transaction_id, transaction_id);
+        assert_eq!(response.interval, 1800);
+        assert_eq!(response.leechers, 3);
+        assert_eq!(response.seeders, 7);
+        assert_eq!(response.peers.len(), 1);
+        assert_eq!(response.peers[0].ip, [127, 0, 0, 1]);
+        assert_eq!(response.peers[0].port, 6881);
+    }
+
+    #[test]
+    fn test_short_packets() {
+        let tracker = UdpTracker::new("udp://127.0.0.1:1".into());
+        let short_connect = [0u8; 15];
+        let short_announce = [0u8; 19];
+        assert!(parse_connect_response(&short_connect, 1).is_err());
+        assert!(tracker.parse_announce_response(&short_announce, 1).is_err());
+    }
+
+    #[test]
+    fn test_wrong_transaction_id() {
+        let tracker = UdpTracker::new("udp://127.0.0.1:1".into());
+        let connect_data = [
+            0x00, 0x00, 0x00, 0x00, // action connect
+            0x01, 0x02, 0x03, 0x04, // transaction_id
+            0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
+        ];
+        assert!(parse_connect_response(&connect_data, 0xdeadbeef).is_err());
+
+        let announce_data = [
+            0x00, 0x00, 0x00, 0x01, // action announce
+            0xaa, 0xbb, 0xcc, 0xdd, // transaction_id
+            0x00, 0x00, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        assert!(tracker
+            .parse_announce_response(&announce_data, 0x01020304)
+            .is_err());
+    }
+
+    #[test]
+    fn test_error_action() {
+        let tracker = UdpTracker::new("udp://127.0.0.1:1".into());
+        let transaction_id = 0x01020304;
+        let mut data = vec![
+            0x00, 0x00, 0x00, 0x03, // action error
+            0x01, 0x02, 0x03, 0x04, // transaction_id
+        ];
+        data.extend_from_slice(b"banned by tracker");
+
+        let connect_err = parse_connect_response(&data, transaction_id).unwrap_err();
+        assert!(connect_err.to_string().contains("banned by tracker"));
+
+        let announce_err = tracker
+            .parse_announce_response(&data, transaction_id)
+            .unwrap_err();
+        assert!(announce_err.to_string().contains("banned by tracker"));
+    }
+
+    #[test]
+    fn test_parse_udp_host_port() {
+        assert_eq!(
+            parse_udp_host_port("udp://tracker.example:1337/announce").unwrap(),
+            "tracker.example:1337"
+        );
+        assert!(parse_udp_host_port("http://tracker.example:80/announce").is_err());
+        assert!(parse_udp_host_port("udp://").is_err());
+    }
 }

--- a/crates/bit_rev/src/utils.rs
+++ b/crates/bit_rev/src/utils.rs
@@ -86,6 +86,38 @@ pub fn get_full_file_path(torrent: &Torrent, file_info: &TorrentFileInfo) -> std
 mod tests {
     use super::*;
     use crate::identity;
+    use crate::torrent::{Torrent, TorrentFileInfo};
+
+    fn torrent(files: &[i64], piece_length: i64) -> Torrent {
+        let mut offset = 0i64;
+        let files = files
+            .iter()
+            .enumerate()
+            .map(|(i, &len)| {
+                let f = TorrentFileInfo {
+                    path: vec![format!("f{i}")],
+                    length: len,
+                    offset,
+                };
+                offset += len;
+                f
+            })
+            .collect();
+        Torrent {
+            info_hash: [0; 20],
+            piece_hashes: vec![],
+            piece_length,
+            length: offset,
+            files,
+            name: "t".into(),
+        }
+    }
+
+    fn assert_mapping(m: &PieceFileMapping, file_index: usize, file_offset: usize, length: usize) {
+        assert_eq!(m.file_index, file_index);
+        assert_eq!(m.file_offset, file_offset);
+        assert_eq!(m.length, length);
+    }
 
     #[test]
     fn peer_id_matches_bep20_for_current_version() {
@@ -104,5 +136,46 @@ mod tests {
         let b = generate_peer_id();
         assert_eq!(&a[..8], &b[..8]);
         assert_ne!(&a[8..], &b[8..]);
+    }
+
+    #[test]
+    fn map_single_file_first_and_last_short_piece() {
+        let t = torrent(&[100], 40);
+        let piece0 = map_piece_to_files(&t, 0);
+        assert_eq!(piece0.len(), 1);
+        assert_mapping(&piece0[0], 0, 0, 40);
+
+        let piece2 = map_piece_to_files(&t, 2);
+        assert_eq!(piece2.len(), 1);
+        assert_mapping(&piece2[0], 0, 80, 20);
+    }
+
+    #[test]
+    fn map_piece_spanning_two_files() {
+        let t = torrent(&[30, 30], 40);
+        let piece0 = map_piece_to_files(&t, 0);
+        assert_eq!(piece0.len(), 2);
+        assert_mapping(&piece0[0], 0, 0, 30);
+        assert_mapping(&piece0[1], 1, 0, 10);
+    }
+
+    #[test]
+    fn map_piece_spanning_three_files() {
+        let t = torrent(&[10, 10, 10], 25);
+        let piece0 = map_piece_to_files(&t, 0);
+        assert_eq!(piece0.len(), 3);
+        assert_mapping(&piece0[0], 0, 0, 10);
+        assert_mapping(&piece0[1], 1, 0, 10);
+        assert_mapping(&piece0[2], 2, 0, 5);
+    }
+
+    #[test]
+    fn map_piece_includes_zero_length_file() {
+        let t = torrent(&[20, 0, 20], 30);
+        let piece0 = map_piece_to_files(&t, 0);
+        assert_eq!(piece0.len(), 3);
+        assert_mapping(&piece0[0], 0, 0, 20);
+        assert_mapping(&piece0[1], 1, 0, 0);
+        assert_mapping(&piece0[2], 2, 0, 10);
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #23: colocated unit tests for core `bit_rev` modules, plus small bugfixes the new tests exposed.

- Cover metainfo parsing (`file.rs`), message framing, handshake/protocol I/O, bitfield, piece-to-file mapping, compact peer lists, UDP tracker bytes, and piece reservation state.
- Tests are table-driven where it helps. No network (duplex streams only). No timing sleeps.
- Parse the debian sample torrent against a known-good info hash. Hand-built multi-file fixtures are generated in-test.
- Parser tests assert malformed input errors instead of panicking.

Bugfixes landed as separate commits:

- `send_not_interested` now sends `NotInterested`.
- Message frames use a 4-byte length prefix. Short/unknown frames return `None`.
- Handshake parse returns `BufferTooShort` instead of slicing blindly.
- Metainfo validates `pieces` length, `length`/`files`, and unsafe paths. Info hash is SHA-1 of the raw `info` dict bytes.

Minimal extracts so the suites can run in-process: `from_bytes`, generic handshake streams, UDP request/response builders.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p bit_rev` (77 lib tests, plus existing integration/tracker suites)

Closes #23