### PR TITLE
feat: implement BEP-0012 multitracker announce tiers

### DIFF
--- a/crates/bit_rev/src/file.rs
+++ b/crates/bit_rev/src/file.rs
@@ -82,6 +82,12 @@ impl TorrentMeta {
         Ok(Self::from_validated(torrent_file, info_hash))
     }
 
+    /// BEP-0012 tiers: `announce-list` wins when it has at least one URL,
+    /// otherwise a single tier is synthesized from `announce`.
+    pub fn announce_tiers(&self) -> Vec<Vec<String>> {
+        self.torrent_file.announce_tiers()
+    }
+
     fn from_validated(torrent_file: TorrentFile, info_hash: [u8; 20]) -> Self {
         let piece_hashes = torrent_file.info.pieces.as_chunks::<20>().0.to_vec();
 
@@ -91,6 +97,37 @@ impl TorrentMeta {
             piece_hashes,
         }
     }
+}
+
+impl TorrentFile {
+    /// BEP-0012 tiers from metainfo. `announce-list` takes precedence when it
+    /// contains at least one non-empty URL. Empty inner lists are dropped.
+    pub fn announce_tiers(&self) -> Vec<Vec<String>> {
+        let from_list = self
+            .announce_list
+            .as_ref()
+            .map(|list| normalize_announce_list(list))
+            .unwrap_or_default();
+        if !from_list.is_empty() {
+            return from_list;
+        }
+        match self.announce.as_deref() {
+            Some(url) if !url.is_empty() => vec![vec![url.to_string()]],
+            _ => Vec::new(),
+        }
+    }
+}
+
+fn normalize_announce_list(list: &[Vec<String>]) -> Vec<Vec<String>> {
+    list.iter()
+        .map(|tier| {
+            tier.iter()
+                .filter(|url| !url.is_empty())
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .filter(|tier| !tier.is_empty())
+        .collect()
 }
 
 pub fn from_bytes(content: &[u8]) -> Result<TorrentMeta> {
@@ -262,6 +299,20 @@ impl AnnounceEvent {
             Self::Completed => "completed",
         }
     }
+
+    /// BEP-0015 event codes: 1 completed, 2 started, 3 stopped. Regular
+    /// re-announces omit the event and use 0.
+    pub fn as_udp(self) -> u32 {
+        match self {
+            Self::Completed => 1,
+            Self::Started => 2,
+            Self::Stopped => 3,
+        }
+    }
+}
+
+pub fn udp_announce_event(event: Option<AnnounceEvent>) -> u32 {
+    event.map(AnnounceEvent::as_udp).unwrap_or(0)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -439,6 +490,14 @@ mod tests {
     }
 
     #[test]
+    fn udp_announce_event_codes_match_bep_0015() {
+        assert_eq!(udp_announce_event(None), 0);
+        assert_eq!(udp_announce_event(Some(AnnounceEvent::Completed)), 1);
+        assert_eq!(udp_announce_event(Some(AnnounceEvent::Started)), 2);
+        assert_eq!(udp_announce_event(Some(AnnounceEvent::Stopped)), 3);
+    }
+
+    #[test]
     fn url_encode_bytes_encodes_binary_info_hash() {
         assert_eq!(url_encode_bytes(&INFO_HASH_FIXTURE), INFO_HASH_ENCODED);
     }
@@ -554,6 +613,70 @@ mod tests {
             meta.torrent_file.announce.as_deref(),
             Some("http://bttracker.debian.org:6969/announce")
         );
+        assert!(meta.torrent_file.announce_list.is_none());
+        assert_eq!(
+            meta.announce_tiers(),
+            vec![vec!["http://bttracker.debian.org:6969/announce".to_string()]]
+        );
+    }
+
+    #[test]
+    fn from_filename_parses_multi_tier_announce_list() {
+        const GIMP_SAMPLE: &str = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../samples/gimp-3.0.4-arm64.dmg.torrent"
+        );
+
+        let meta = from_filename(GIMP_SAMPLE).expect("parse gimp sample");
+        assert_eq!(
+            meta.torrent_file.announce.as_deref(),
+            Some("udp://tracker.opentrackr.org:1337/announce")
+        );
+        let list = meta
+            .torrent_file
+            .announce_list
+            .as_ref()
+            .expect("gimp torrent has announce-list");
+        assert_eq!(list.len(), 5);
+        assert_eq!(
+            list,
+            &vec![
+                vec!["udp://tracker.opentrackr.org:1337/announce".to_string()],
+                vec!["udp://tracker.coppersurfer.tk:6969/announce".to_string()],
+                vec!["udp://tracker.leechers-paradise.org:6969/announce".to_string()],
+                vec!["udp://tracker.openbittorrent.com:80/announce".to_string()],
+                vec!["https://ashrise.com:443/phoenix/announce".to_string()],
+            ]
+        );
+        assert_eq!(meta.announce_tiers(), *list);
+    }
+
+    #[test]
+    fn from_filename_parses_mixed_scheme_announce_list() {
+        const FOLDER_SAMPLE: &str = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../samples/test_folder-d984f67af9917b214cd8b6048ab5624c7df6a07a.torrent"
+        );
+
+        let meta = from_filename(FOLDER_SAMPLE).expect("parse test_folder sample");
+        assert_eq!(
+            meta.torrent_file.announce.as_deref(),
+            Some("https://academictorrents.com/announce.php")
+        );
+        let list = meta
+            .torrent_file
+            .announce_list
+            .as_ref()
+            .expect("test_folder torrent has announce-list");
+        assert_eq!(
+            list,
+            &vec![
+                vec!["https://academictorrents.com/announce.php".to_string()],
+                vec!["https://ipv6.academictorrents.com/announce.php".to_string()],
+                vec!["udp://tracker.opentrackr.org:1337/announce".to_string()],
+            ]
+        );
+        assert_eq!(meta.announce_tiers(), *list);
     }
 
     #[test]
@@ -677,6 +800,86 @@ mod tests {
             Some(vec![torrent_file_entry(&[], 4)]),
         );
         assert!(from_bytes(&empty_path).is_err());
+    }
+
+    #[test]
+    fn from_bytes_parses_single_tier_multi_url_announce_list() {
+        let mut torrent = torrent_file("test", 16384, vec![0u8; 20], Some(4), None);
+        torrent.announce = Some("http://ignored.example/announce".into());
+        torrent.announce_list = Some(vec![vec![
+            "http://a.example/announce".into(),
+            "http://b.example/announce".into(),
+            "udp://c.example:80/announce".into(),
+        ]]);
+        let encoded = ser::to_bytes(&torrent).expect("serialize torrent");
+        assert!(encoded.windows(13).any(|w| w == b"announce-list"));
+
+        let meta = from_bytes(&encoded).expect("parse single-tier announce-list");
+        assert_eq!(
+            meta.torrent_file.announce.as_deref(),
+            Some("http://ignored.example/announce")
+        );
+        assert_eq!(
+            meta.torrent_file.announce_list,
+            Some(vec![vec![
+                "http://a.example/announce".into(),
+                "http://b.example/announce".into(),
+                "udp://c.example:80/announce".into(),
+            ]])
+        );
+        assert_eq!(
+            meta.announce_tiers(),
+            vec![vec![
+                "http://a.example/announce".to_string(),
+                "http://b.example/announce".to_string(),
+                "udp://c.example:80/announce".to_string(),
+            ]]
+        );
+    }
+
+    #[test]
+    fn from_bytes_parses_multi_tier_announce_list() {
+        let mut torrent = torrent_file("test", 16384, vec![0u8; 20], Some(4), None);
+        torrent.announce = Some("http://legacy.example/announce".into());
+        torrent.announce_list = Some(vec![
+            vec!["http://tier0.example/announce".into()],
+            vec![
+                "http://tier1a.example/announce".into(),
+                "udp://tier1b.example:6969/announce".into(),
+            ],
+        ]);
+        let encoded = ser::to_bytes(&torrent).expect("serialize torrent");
+        let meta = from_bytes(&encoded).expect("parse multi-tier announce-list");
+
+        assert_eq!(
+            meta.announce_tiers(),
+            vec![
+                vec!["http://tier0.example/announce".to_string()],
+                vec![
+                    "http://tier1a.example/announce".to_string(),
+                    "udp://tier1b.example:6969/announce".to_string(),
+                ],
+            ]
+        );
+    }
+
+    #[test]
+    fn announce_tiers_synthesizes_announce_when_list_absent_or_empty() {
+        let mut torrent = torrent_file("test", 16384, vec![0u8; 20], Some(4), None);
+        assert_eq!(
+            torrent.announce_tiers(),
+            vec![vec!["http://tracker.example/announce".to_string()]]
+        );
+
+        torrent.announce_list = Some(vec![vec![String::new()], vec![]]);
+        assert_eq!(
+            torrent.announce_tiers(),
+            vec![vec!["http://tracker.example/announce".to_string()]]
+        );
+
+        torrent.announce = None;
+        torrent.announce_list = None;
+        assert!(torrent.announce_tiers().is_empty());
     }
 
     #[test]

--- a/crates/bit_rev/src/protocol_udp.rs
+++ b/crates/bit_rev/src/protocol_udp.rs
@@ -48,6 +48,7 @@ pub struct AnnounceOptions {
     pub downloaded: u64,
     pub left: u64,
     pub event: u32,
+    pub key: u32,
 }
 
 impl UdpTracker {
@@ -90,7 +91,6 @@ impl UdpTracker {
         let left = announce_options.left;
         let event = announce_options.event;
 
-        let key = rand::thread_rng().gen();
         let request = build_announce_request(AnnounceRequest {
             connection_id,
             transaction_id,
@@ -101,7 +101,7 @@ impl UdpTracker {
             uploaded,
             event,
             ip: 0,
-            key,
+            key: announce_options.key,
             num_want: -1,
             port,
         })?;
@@ -323,6 +323,7 @@ pub async fn request_udp_peers(
         downloaded,
         left,
         event,
+        key: rand::thread_rng().gen(),
     };
 
     tracker.announce(&announce_options).await

--- a/crates/bit_rev/src/tracker/mod.rs
+++ b/crates/bit_rev/src/tracker/mod.rs
@@ -1,4 +1,6 @@
 use std::{
+    collections::HashMap,
+    net::SocketAddr,
     sync::{Arc, Mutex, OnceLock},
     time::Duration,
 };
@@ -9,11 +11,15 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use crate::{
-    file::{self, AnnounceEvent, AnnounceParams, TorrentMeta},
+    file::{self, udp_announce_event, AnnounceEvent, AnnounceParams, TorrentMeta},
     peer::BencodeResponse,
     peer_connection::TorrentDownloadedState,
+    protocol_udp::{AnnounceOptions, UdpTracker},
     session::DownloadState,
 };
+
+pub mod tiers;
+pub use tiers::{tracker_scheme, TrackerScheme, TrackerTiers};
 
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -35,6 +41,8 @@ pub enum TrackerError {
     Request(#[from] reqwest::Error),
     #[error("invalid tracker response: {0}")]
     Decode(String),
+    #[error("UDP tracker announce failed: {0}")]
+    Udp(String),
     #[error("tracker stopped announce timed out")]
     StoppedTimeout,
 }
@@ -113,15 +121,24 @@ pub async fn announce_with_timeout(
         .map_err(|_| TrackerError::StoppedTimeout)?
 }
 
-pub struct HttpAnnounceContext {
+pub struct AnnounceContext {
     pub client: reqwest::Client,
     pub torrent_meta: TorrentMeta,
     pub peer_id: [u8; 20],
-    pub tracker_url: String,
+    pub tiers: TrackerTiers,
     pub announce_key: u32,
     pub port: u16,
     pub download_state: Arc<Mutex<DownloadState>>,
     pub torrent_downloaded_state: Arc<TorrentDownloadedState>,
+}
+
+pub type HttpAnnounceContext = AnnounceContext;
+
+struct AnnounceOutcome {
+    peers: Vec<SocketAddr>,
+    interval: u64,
+    min_interval: Option<u64>,
+    tracker_id: Option<Vec<u8>>,
 }
 
 enum Wake {
@@ -130,19 +147,26 @@ enum Wake {
     Shutdown,
 }
 
-pub async fn run_http_announce_loop<F, Fut>(
-    ctx: HttpAnnounceContext,
+pub async fn run_announce_loop<F, Fut>(
+    mut ctx: AnnounceContext,
     shutdown: CancellationToken,
     mut on_peers: F,
 ) where
-    F: FnMut(Vec<std::net::SocketAddr>) -> Fut,
+    F: FnMut(Vec<SocketAddr>) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
     let mut sent_started = false;
     let mut sent_completed = false;
-    let mut tracker_id: Option<Vec<u8>> = None;
+    let mut tracker_ids: HashMap<String, Vec<u8>> = HashMap::new();
+    let mut udp_sessions: HashMap<String, UdpTracker> = HashMap::new();
     let mut backoff: Option<Duration> = None;
     let mut joined = false;
+    let mut last_success_url: Option<String> = None;
+
+    if ctx.tiers.is_empty() {
+        shutdown.cancelled().await;
+        return;
+    }
 
     loop {
         if !wait_until_downloading(&ctx.download_state, &shutdown).await {
@@ -154,23 +178,51 @@ pub async fn run_http_announce_loop<F, Fut>(
             sent_started,
             sent_completed,
         );
-        let params = current_announce_params(&ctx, event, tracker_id.clone());
-        let url =
-            file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, &ctx.tracker_url, &params);
+        let urls: Vec<String> = ctx.tiers.urls().map(str::to_owned).collect();
+        let mut outcome: Option<AnnounceOutcome> = None;
 
-        joined = true;
-        let result = announce(&ctx.client, &url).await;
-        if shutdown.is_cancelled() {
-            if let Ok(resp) = result {
-                if let Some(id) = resp.tracker_id.as_ref() {
-                    tracker_id = Some(id.to_vec());
+        for url in urls {
+            let Some(scheme) = tracker_scheme(&url) else {
+                warn!(tracker = %url, "skipping tracker with unsupported scheme");
+                continue;
+            };
+
+            let params = current_announce_params(&ctx, event, tracker_ids.get(&url).cloned());
+            joined = true;
+            let result = announce_to_url(&ctx, &url, scheme, &params, &mut udp_sessions).await;
+            if shutdown.is_cancelled() {
+                if let Ok(resp) = result {
+                    ctx.tiers.promote(&url);
+                    last_success_url = Some(url.clone());
+                    if let Some(id) = resp.tracker_id {
+                        tracker_ids.insert(url, id);
+                    }
+                }
+                break;
+            }
+
+            match result {
+                Ok(resp) => {
+                    ctx.tiers.promote(&url);
+                    last_success_url = Some(url.clone());
+                    if let Some(id) = resp.tracker_id.as_ref() {
+                        tracker_ids.insert(url, id.clone());
+                    }
+                    outcome = Some(resp);
+                    break;
+                }
+                Err(e) => {
+                    debug!(tracker = %url, error = %e, "tracker announce failed");
                 }
             }
+        }
+
+        if shutdown.is_cancelled() {
             break;
         }
 
-        match result {
-            Ok(resp) => {
+        match outcome {
+            Some(resp) => {
                 backoff = None;
                 if event == Some(AnnounceEvent::Started) {
                     sent_started = true;
@@ -178,21 +230,8 @@ pub async fn run_http_announce_loop<F, Fut>(
                 if event == Some(AnnounceEvent::Completed) {
                     sent_completed = true;
                 }
-                if let Some(id) = resp.tracker_id.as_ref() {
-                    tracker_id = Some(id.to_vec());
-                }
-                match resp.get_peers() {
-                    Ok(peers) => on_peers(peers).await,
-                    Err(e) => {
-                        debug!(
-                            tracker = %ctx.tracker_url,
-                            error = %e,
-                            "failed to parse peers from HTTP tracker"
-                        );
-                    }
-                }
-                let interval = resp.interval.unwrap_or(DEFAULT_INTERVAL_SECS);
-                let delay = reannounce_delay(interval, resp.min_interval);
+                on_peers(resp.peers).await;
+                let delay = reannounce_delay(resp.interval, resp.min_interval);
                 match wait_reannounce(
                     delay,
                     &shutdown,
@@ -205,8 +244,7 @@ pub async fn run_http_announce_loop<F, Fut>(
                     Wake::Completed | Wake::IntervalElapsed => {}
                 }
             }
-            Err(e) => {
-                debug!(tracker = %ctx.tracker_url, error = %e, "HTTP tracker announce failed");
+            None => {
                 let delay = next_backoff(backoff);
                 backoff = Some(delay);
                 match wait_reannounce(
@@ -225,8 +263,93 @@ pub async fn run_http_announce_loop<F, Fut>(
     }
 
     if joined {
-        send_stopped(&ctx, tracker_id).await;
+        let stopped_url = last_success_url.or_else(|| ctx.tiers.urls().next().map(str::to_owned));
+        if let Some(url) = stopped_url {
+            let tracker_id = tracker_ids.get(&url).cloned();
+            send_stopped(&ctx, &url, tracker_id, &mut udp_sessions).await;
+        }
     }
+}
+
+pub async fn run_http_announce_loop<F, Fut>(
+    ctx: HttpAnnounceContext,
+    shutdown: CancellationToken,
+    on_peers: F,
+) where
+    F: FnMut(Vec<SocketAddr>) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    run_announce_loop(ctx, shutdown, on_peers).await;
+}
+
+async fn announce_to_url(
+    ctx: &AnnounceContext,
+    url: &str,
+    scheme: TrackerScheme,
+    params: &AnnounceParams,
+    udp_sessions: &mut HashMap<String, UdpTracker>,
+) -> Result<AnnounceOutcome, TrackerError> {
+    match scheme {
+        TrackerScheme::Http => announce_http(ctx, url, params).await,
+        TrackerScheme::Udp => announce_udp(ctx, url, params, udp_sessions).await,
+    }
+}
+
+async fn announce_http(
+    ctx: &AnnounceContext,
+    tracker_url: &str,
+    params: &AnnounceParams,
+) -> Result<AnnounceOutcome, TrackerError> {
+    let url = file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, tracker_url, params);
+    let resp = announce(&ctx.client, &url).await?;
+    let peers = match resp.get_peers() {
+        Ok(peers) => peers,
+        Err(e) => {
+            debug!(
+                tracker = %tracker_url,
+                error = %e,
+                "failed to parse peers from HTTP tracker"
+            );
+            Vec::new()
+        }
+    };
+    Ok(AnnounceOutcome {
+        peers,
+        interval: resp.interval.unwrap_or(DEFAULT_INTERVAL_SECS),
+        min_interval: resp.min_interval,
+        tracker_id: resp.tracker_id.as_ref().map(|id| id.to_vec()),
+    })
+}
+
+async fn announce_udp(
+    ctx: &AnnounceContext,
+    tracker_url: &str,
+    params: &AnnounceParams,
+    udp_sessions: &mut HashMap<String, UdpTracker>,
+) -> Result<AnnounceOutcome, TrackerError> {
+    let tracker = udp_sessions
+        .entry(tracker_url.to_string())
+        .or_insert_with(|| UdpTracker::new(tracker_url.to_string()));
+    let options = AnnounceOptions {
+        torrent_meta: ctx.torrent_meta.clone(),
+        peer_id: ctx.peer_id,
+        port: params.port,
+        uploaded: params.uploaded,
+        downloaded: params.downloaded,
+        left: params.left,
+        event: udp_announce_event(params.event),
+        key: params.key,
+    };
+    let resp = tracker
+        .announce(&options)
+        .await
+        .map_err(|e| TrackerError::Udp(e.to_string()))?;
+    Ok(AnnounceOutcome {
+        peers: resp.peers.into_iter().map(|p| p.to_socket_addr()).collect(),
+        interval: u64::from(resp.interval),
+        min_interval: None,
+        tracker_id: None,
+    })
 }
 
 fn next_announce_event(
@@ -244,7 +367,7 @@ fn next_announce_event(
 }
 
 fn current_announce_params(
-    ctx: &HttpAnnounceContext,
+    ctx: &AnnounceContext,
     event: Option<AnnounceEvent>,
     tracker_id: Option<Vec<u8>>,
 ) -> AnnounceParams {
@@ -261,7 +384,15 @@ fn current_announce_params(
     }
 }
 
-async fn send_stopped(ctx: &HttpAnnounceContext, tracker_id: Option<Vec<u8>>) {
+async fn send_stopped(
+    ctx: &AnnounceContext,
+    tracker_url: &str,
+    tracker_id: Option<Vec<u8>>,
+    udp_sessions: &mut HashMap<String, UdpTracker>,
+) {
+    let Some(scheme) = tracker_scheme(tracker_url) else {
+        return;
+    };
     let params = AnnounceParams {
         uploaded: 0,
         downloaded: ctx.torrent_downloaded_state.downloaded_bytes(),
@@ -272,13 +403,26 @@ async fn send_stopped(ctx: &HttpAnnounceContext, tracker_id: Option<Vec<u8>>) {
         key: ctx.announce_key,
         tracker_id,
     };
-    let url = file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, &ctx.tracker_url, &params);
-    if let Err(e) = announce_with_timeout(&ctx.client, &url, STOPPED_TIMEOUT).await {
-        debug!(
-            tracker = %ctx.tracker_url,
-            error = %e,
-            "HTTP tracker stopped announce failed"
-        );
+    let result = tokio::time::timeout(
+        STOPPED_TIMEOUT,
+        announce_to_url(ctx, tracker_url, scheme, &params, udp_sessions),
+    )
+    .await;
+    match result {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            debug!(
+                tracker = %tracker_url,
+                error = %e,
+                "tracker stopped announce failed"
+            );
+        }
+        Err(_) => {
+            debug!(
+                tracker = %tracker_url,
+                "tracker stopped announce timed out"
+            );
+        }
     }
 }
 

--- a/crates/bit_rev/src/tracker/tiers.rs
+++ b/crates/bit_rev/src/tracker/tiers.rs
@@ -1,0 +1,232 @@
+use rand::seq::SliceRandom;
+
+use crate::file::TorrentFile;
+
+/// Transport selected from a tracker URL scheme.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackerScheme {
+    Http,
+    Udp,
+}
+
+/// BEP-0012 tier list. URLs inside each tier are shuffled once at load.
+/// Successful URLs are moved to the front of their tier and tried first
+/// on the next announce cycle. Tiers themselves stay in file order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackerTiers {
+    tiers: Vec<Vec<String>>,
+}
+
+impl TrackerTiers {
+    pub fn from_torrent_file(file: &TorrentFile) -> Self {
+        Self::from_resolved(file.announce_tiers(), true)
+    }
+
+    pub fn from_metainfo(announce: Option<&str>, announce_list: Option<&[Vec<String>]>) -> Self {
+        Self::from_resolved(resolve_tiers(announce, announce_list), true)
+    }
+
+    pub fn from_tiers_unshuffled(tiers: Vec<Vec<String>>) -> Self {
+        Self::from_resolved(tiers, false)
+    }
+
+    fn from_resolved(tiers: Vec<Vec<String>>, shuffle: bool) -> Self {
+        let mut tiers = normalize_tiers(tiers);
+        if shuffle {
+            shuffle_tiers(&mut tiers);
+        }
+        Self { tiers }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tiers.iter().all(|tier| tier.is_empty())
+    }
+
+    pub fn tiers(&self) -> &[Vec<String>] {
+        &self.tiers
+    }
+
+    /// URLs in announce-try order: tiers first to last, then left to right.
+    pub fn urls(&self) -> impl Iterator<Item = &str> {
+        self.tiers.iter().flatten().map(String::as_str)
+    }
+
+    /// Move `url` to the front of the tier that contains it.
+    pub fn promote(&mut self, url: &str) {
+        for tier in &mut self.tiers {
+            if let Some(idx) = tier.iter().position(|candidate| candidate == url) {
+                if idx > 0 {
+                    let chosen = tier.remove(idx);
+                    tier.insert(0, chosen);
+                }
+                return;
+            }
+        }
+    }
+}
+
+pub fn tracker_scheme(url: &str) -> Option<TrackerScheme> {
+    let scheme = url.split("://").next().unwrap_or(url);
+    match scheme.to_ascii_lowercase().as_str() {
+        "http" | "https" => Some(TrackerScheme::Http),
+        "udp" => Some(TrackerScheme::Udp),
+        _ => None,
+    }
+}
+
+fn resolve_tiers(
+    announce: Option<&str>,
+    announce_list: Option<&[Vec<String>]>,
+) -> Vec<Vec<String>> {
+    let from_list = announce_list
+        .map(|list| normalize_tiers(list.to_vec()))
+        .unwrap_or_default();
+    if !from_list.is_empty() {
+        return from_list;
+    }
+    match announce {
+        Some(url) if !url.is_empty() => vec![vec![url.to_string()]],
+        _ => Vec::new(),
+    }
+}
+
+fn shuffle_tiers(tiers: &mut [Vec<String>]) {
+    let mut rng = rand::thread_rng();
+    for tier in tiers {
+        tier.shuffle(&mut rng);
+    }
+}
+
+fn normalize_tiers(tiers: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    tiers
+        .into_iter()
+        .map(|tier| {
+            tier.into_iter()
+                .filter(|url| !url.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .filter(|tier| !tier.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unshuffled(tiers: &[&[&str]]) -> TrackerTiers {
+        TrackerTiers::from_tiers_unshuffled(
+            tiers
+                .iter()
+                .map(|tier| tier.iter().map(|url| (*url).to_string()).collect())
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn from_metainfo_synthesizes_single_tier_when_list_absent() {
+        let tiers = TrackerTiers::from_metainfo(Some("http://tracker.example/announce"), None);
+        assert_eq!(
+            tiers.tiers(),
+            &[vec!["http://tracker.example/announce".to_string()]]
+        );
+    }
+
+    #[test]
+    fn from_metainfo_prefers_announce_list() {
+        let list = vec![
+            vec!["http://a.example/announce".to_string()],
+            vec!["http://b.example/announce".to_string()],
+        ];
+        let tiers = TrackerTiers::from_metainfo(
+            Some("http://legacy.example/announce"),
+            Some(list.as_slice()),
+        );
+        assert_eq!(tiers.tiers(), list.as_slice());
+        assert!(!tiers
+            .urls()
+            .any(|url| url == "http://legacy.example/announce"));
+    }
+
+    #[test]
+    fn promote_moves_url_to_front_of_its_tier() {
+        let mut tiers = unshuffled(&[&["a", "b", "c"], &["d"]]);
+        tiers.promote("c");
+        assert_eq!(
+            tiers.tiers(),
+            &[
+                vec!["c".to_string(), "a".to_string(), "b".to_string()],
+                vec!["d".to_string()]
+            ]
+        );
+        assert_eq!(tiers.urls().collect::<Vec<_>>(), vec!["c", "a", "b", "d"]);
+    }
+
+    #[test]
+    fn promote_unknown_url_is_a_no_op() {
+        let mut tiers = unshuffled(&[&["a", "b"]]);
+        tiers.promote("missing");
+        assert_eq!(tiers.tiers(), &[vec!["a".to_string(), "b".to_string()]]);
+    }
+
+    #[test]
+    fn walk_order_is_tiers_then_urls() {
+        let tiers = unshuffled(&[&["t0"], &["t1a", "t1b"], &["t2"]]);
+        assert_eq!(
+            tiers.urls().collect::<Vec<_>>(),
+            vec!["t0", "t1a", "t1b", "t2"]
+        );
+    }
+
+    #[test]
+    fn from_metainfo_shuffles_urls_within_each_tier() {
+        let original: Vec<String> = (0..8)
+            .map(|i| format!("http://t{i}.example/announce"))
+            .collect();
+        let list = vec![
+            original.clone(),
+            vec!["http://only.example/announce".into()],
+        ];
+        let tiers = TrackerTiers::from_metainfo(None, Some(list.as_slice()));
+
+        let mut first = tiers.tiers()[0].clone();
+        first.sort();
+        let mut expected = original;
+        expected.sort();
+        assert_eq!(first, expected);
+        assert_eq!(
+            tiers.tiers()[1],
+            vec!["http://only.example/announce".to_string()]
+        );
+    }
+
+    #[test]
+    fn tracker_scheme_classifies_known_and_skips_unknown() {
+        assert_eq!(
+            tracker_scheme("http://tracker.example/announce"),
+            Some(TrackerScheme::Http)
+        );
+        assert_eq!(
+            tracker_scheme("HTTPS://tracker.example/announce"),
+            Some(TrackerScheme::Http)
+        );
+        assert_eq!(
+            tracker_scheme("udp://tracker.example:80/announce"),
+            Some(TrackerScheme::Udp)
+        );
+        assert_eq!(tracker_scheme("wss://tracker.example/announce"), None);
+        assert_eq!(tracker_scheme("not-a-url"), None);
+    }
+
+    #[test]
+    fn from_tiers_unshuffled_drops_empty_entries() {
+        let tiers = TrackerTiers::from_tiers_unshuffled(vec![
+            vec![String::new()],
+            vec!["http://ok.example/announce".into(), String::new()],
+            vec![],
+        ]);
+        assert_eq!(
+            tiers.tiers(),
+            &[vec!["http://ok.example/announce".to_string()]]
+        );
+    }
+}

--- a/crates/bit_rev/src/tracker_peers.rs
+++ b/crates/bit_rev/src/tracker_peers.rs
@@ -1,8 +1,8 @@
 use rand::Rng;
 use std::sync::{atomic::AtomicBool, Arc, Mutex};
-use tokio::{select, sync::Semaphore, time::sleep};
+use tokio::{select, sync::Semaphore};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error};
+use tracing::debug;
 
 use crate::{
     file::TorrentMeta,
@@ -11,9 +11,8 @@ use crate::{
         FullPiece, PeerConnection, PeerHandler, PieceWorkState, TorrentDownloadedState,
     },
     peer_state::PeerStates,
-    protocol_udp::request_udp_peers,
     session::{DownloadState, PieceResult, PieceWork},
-    tracker::{self, HttpAnnounceContext, TrackerError},
+    tracker::{self, AnnounceContext, TrackerError, TrackerTiers},
 };
 
 #[derive(Debug, Clone)]
@@ -84,22 +83,9 @@ impl TrackerPeers {
         let info_hash = self.torrent_meta.info_hash;
         let peer_id = self.peer_id;
 
-        let all_tracker_urls = all_trackers(&self.torrent_meta.clone());
-        let tcp_trackers: Vec<String> = all_tracker_urls
-            .iter()
-            .filter(|t| !t.starts_with("udp://"))
-            .cloned()
-            .collect();
-        let udp_trackers: Vec<String> = all_tracker_urls
-            .iter()
-            .filter(|t| t.starts_with("udp://"))
-            .cloned()
-            .collect();
+        let tiers = TrackerTiers::from_torrent_file(&self.torrent_meta.torrent_file);
+        debug!(trackers = ?tiers.urls().collect::<Vec<_>>(), "connecting to trackers");
 
-        debug!(
-            "Connecting to trackers: TCP: {:?}, UDP: {:?}",
-            tcp_trackers, udp_trackers
-        );
         let torrent_meta = self.torrent_meta.clone();
         let peer_states = self.peer_states.clone();
         let piece_tx = self.piece_tx.clone();
@@ -121,117 +107,46 @@ impl TrackerPeers {
                 .collect(),
         });
 
-        for tracker_url in tcp_trackers {
-            let ctx = HttpAnnounceContext {
-                client: http_client.clone(),
-                torrent_meta: torrent_meta.clone(),
-                peer_id,
-                tracker_url,
-                announce_key,
-                port: 6881,
-                download_state: download_state.clone(),
-                torrent_downloaded_state: torrent_downloaded_state.clone(),
-            };
-            let peer_states = peer_states.clone();
-            let piece_tx = piece_tx.clone();
-            let have_broadcast = have_broadcast.clone();
-            let download_state = download_state.clone();
-            let torrent_downloaded_state = torrent_downloaded_state.clone();
-            let shutdown = cancel.clone();
-            tokio::spawn(async move {
-                tracker::run_http_announce_loop(ctx, shutdown, |new_peers| {
-                    let peer_states = peer_states.clone();
-                    let piece_tx = piece_tx.clone();
-                    let have_broadcast = have_broadcast.clone();
-                    let torrent_downloaded_state = torrent_downloaded_state.clone();
-                    let download_state = download_state.clone();
-                    async move {
-                        process_peers(
-                            new_peers,
-                            PeerProcessorConfig {
-                                info_hash,
-                                peer_id,
-                                peer_states,
-                                piece_tx,
-                                have_broadcast,
-                                torrent_downloaded_state,
-                                download_state,
-                            },
-                        )
-                        .await;
-                    }
-                })
-                .await;
-            });
+        if tiers.is_empty() {
+            debug!("no trackers in metainfo");
+            return;
         }
 
-        if !udp_trackers.is_empty() {
-            let udp_cancel = cancel;
-            tokio::spawn(async move {
-                loop {
-                    if udp_cancel.is_cancelled() {
-                        break;
-                    }
-                    while {
-                        let state = *download_state.lock().unwrap();
-                        state != DownloadState::Downloading
-                    } {
-                        if udp_cancel.is_cancelled() {
-                            return;
-                        }
-                        sleep(std::time::Duration::from_millis(100)).await;
-                    }
-
-                    for tracker in udp_trackers.clone() {
-                        let torrent_meta = torrent_meta.clone();
-                        let peer_states = peer_states.clone();
-                        let piece_tx = piece_tx.clone();
-                        let have_broadcast = have_broadcast.clone();
-                        let torrent_downloaded_state = torrent_downloaded_state.clone();
-                        let download_state = download_state.clone();
-                        tokio::spawn(async move {
-                            match request_udp_peers(&tracker, &torrent_meta, &peer_id, 6881).await {
-                                Ok(udp_response) => {
-                                    debug!(
-                                        "Received UDP response from tracker {}: {:?}",
-                                        tracker, udp_response
-                                    );
-                                    let new_peers: Vec<_> = udp_response
-                                        .peers
-                                        .into_iter()
-                                        .map(|p| p.to_socket_addr())
-                                        .collect();
-
-                                    process_peers(
-                                        new_peers,
-                                        PeerProcessorConfig {
-                                            info_hash,
-                                            peer_id,
-                                            peer_states: peer_states.clone(),
-                                            piece_tx: piece_tx.clone(),
-                                            have_broadcast: have_broadcast.clone(),
-                                            torrent_downloaded_state: torrent_downloaded_state
-                                                .clone(),
-                                            download_state: download_state.clone(),
-                                        },
-                                    )
-                                    .await;
-                                }
-                                Err(e) => error!(
-                                    "Failed to request peers from UDP tracker {}: {}",
-                                    tracker, e
-                                ),
-                            }
-                        });
-                    }
-
-                    tokio::select! {
-                        _ = udp_cancel.cancelled() => break,
-                        _ = sleep(std::time::Duration::from_secs(30)) => {}
-                    }
+        let ctx = AnnounceContext {
+            client: http_client,
+            torrent_meta,
+            peer_id,
+            tiers,
+            announce_key,
+            port: 6881,
+            download_state: download_state.clone(),
+            torrent_downloaded_state: torrent_downloaded_state.clone(),
+        };
+        tokio::spawn(async move {
+            tracker::run_announce_loop(ctx, cancel, |new_peers| {
+                let peer_states = peer_states.clone();
+                let piece_tx = piece_tx.clone();
+                let have_broadcast = have_broadcast.clone();
+                let torrent_downloaded_state = torrent_downloaded_state.clone();
+                let download_state = download_state.clone();
+                async move {
+                    process_peers(
+                        new_peers,
+                        PeerProcessorConfig {
+                            info_hash,
+                            peer_id,
+                            peer_states,
+                            piece_tx,
+                            have_broadcast,
+                            torrent_downloaded_state,
+                            download_state,
+                        },
+                    )
+                    .await;
                 }
-            });
-        }
+            })
+            .await;
+        });
     }
 }
 
@@ -309,24 +224,6 @@ async fn process_peers(new_peers: Vec<std::net::SocketAddr>, config: PeerProcess
                 }
             }
         });
-    }
-}
-
-fn all_trackers(torrent_meta: &TorrentMeta) -> Vec<String> {
-    match (
-        &torrent_meta.torrent_file.announce,
-        &torrent_meta.torrent_file.announce_list,
-    ) {
-        (Some(announce), None) => vec![announce.clone()],
-        (Some(announce), Some(announce_list)) => {
-            let mut h = Vec::<String>::from_iter(announce_list.iter().flatten().cloned());
-            if !h.contains(announce) {
-                h.push(announce.clone());
-            }
-            h.into_iter().collect()
-        }
-        (None, Some(announce_list)) => announce_list.clone().into_iter().flatten().collect(),
-        (None, None) => vec![],
     }
 }
 

--- a/crates/bit_rev/tests/tracker_http.rs
+++ b/crates/bit_rev/tests/tracker_http.rs
@@ -15,8 +15,8 @@ use bit_rev::{
     peer_state::PeerStates,
     session::{DownloadState, PieceWork},
     tracker::{
-        self, announce, build_http_client, http_client, run_http_announce_loop,
-        HttpAnnounceContext, TrackerError,
+        self, announce, build_http_client, http_client, run_announce_loop, AnnounceContext,
+        TrackerError, TrackerTiers,
     },
 };
 use serde::Serialize;
@@ -240,12 +240,22 @@ fn incomplete_download() -> Arc<TorrentDownloadedState> {
     })
 }
 
-fn announce_ctx(url: String, download: Arc<TorrentDownloadedState>) -> HttpAnnounceContext {
-    HttpAnnounceContext {
+fn announce_ctx(url: String, download: Arc<TorrentDownloadedState>) -> AnnounceContext {
+    announce_ctx_with_tiers(vec![vec![url.clone()]], url, download)
+}
+
+fn announce_ctx_with_tiers(
+    tiers: Vec<Vec<String>>,
+    announce: String,
+    download: Arc<TorrentDownloadedState>,
+) -> AnnounceContext {
+    let mut meta = test_meta(announce);
+    meta.torrent_file.announce_list = Some(tiers.clone());
+    AnnounceContext {
         client: test_http_client(),
-        torrent_meta: test_meta(url.clone()),
+        torrent_meta: meta,
         peer_id: *b"-BR0100-0123456789ab",
-        tracker_url: url,
+        tiers: TrackerTiers::from_tiers_unshuffled(tiers),
         announce_key: 0xDF45_C574,
         port: 6881,
         download_state: Arc::new(Mutex::new(DownloadState::Downloading)),
@@ -342,7 +352,7 @@ async fn announce_loop_respects_interval_and_echoes_tracker_id() {
     let peers_for_loop = peer_states.clone();
 
     let loop_task = tokio::spawn(async move {
-        run_http_announce_loop(ctx, loop_shutdown, |peers| {
+        run_announce_loop(ctx, loop_shutdown, |peers| {
             let peer_states = peers_for_loop.clone();
             async move {
                 for peer in peers {
@@ -400,7 +410,7 @@ async fn announce_loop_retries_failure_reason_with_backoff() {
     let loop_shutdown = shutdown.clone();
     let ctx = announce_ctx(url, incomplete_download());
     let loop_task = tokio::spawn(async move {
-        run_http_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+        run_announce_loop(ctx, loop_shutdown, |_| async {}).await;
     });
 
     let first = rx.recv().await.expect("failed started announce");
@@ -433,7 +443,7 @@ async fn announce_loop_sends_stopped_on_shutdown() {
     let loop_shutdown = shutdown.clone();
     let ctx = announce_ctx(url, incomplete_download());
     let loop_task = tokio::spawn(async move {
-        run_http_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+        run_announce_loop(ctx, loop_shutdown, |_| async {}).await;
     });
 
     let first = tokio::time::timeout(Duration::from_secs(2), rx.recv())
@@ -453,4 +463,221 @@ async fn announce_loop_sends_stopped_on_shutdown() {
 
     let _ = tokio::time::timeout(Duration::from_secs(2), loop_task).await;
     handle.abort();
+}
+
+fn ok_announce_peer(ip: [u8; 4], port: u16, interval: i64) -> Vec<u8> {
+    ser::to_bytes(&TestAnnounce {
+        interval,
+        min_interval: None,
+        tracker_id: None,
+        warning_message: None,
+        peers: ByteBuf::from(compact_peer(ip, port)),
+    })
+    .unwrap()
+}
+
+#[tokio::test]
+async fn announce_loop_falls_back_to_second_tier() {
+    let (dead_url, mut dead_rx, dead_handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 500,
+        body: b"dead".to_vec(),
+    }])
+    .await;
+    let (live_url, mut live_rx, live_handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 200,
+        body: ok_announce_peer([10, 0, 0, 2], 6882, 1800),
+    }])
+    .await;
+
+    let peer_states = Arc::new(PeerStates::default());
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx_with_tiers(
+        vec![vec![dead_url], vec![live_url]],
+        "http://legacy.example/announce".into(),
+        incomplete_download(),
+    );
+    let peers_for_loop = peer_states.clone();
+    let loop_task = tokio::spawn(async move {
+        run_announce_loop(ctx, loop_shutdown, |peers| {
+            let peer_states = peers_for_loop.clone();
+            async move {
+                for peer in peers {
+                    peer_states.add_if_not_seen(peer);
+                }
+            }
+        })
+        .await;
+    });
+
+    let dead_req = tokio::time::timeout(Duration::from_secs(2), dead_rx.recv())
+        .await
+        .expect("dead tracker timed out")
+        .expect("dead tracker request");
+    assert_eq!(dead_req.query_param("event"), Some("started"));
+
+    let live_req = tokio::time::timeout(Duration::from_secs(2), live_rx.recv())
+        .await
+        .expect("live tracker timed out")
+        .expect("live tracker request");
+    assert_eq!(live_req.query_param("event"), Some("started"));
+    settle_io().await;
+
+    assert_eq!(peer_states.states.len(), 1);
+    assert!(peer_states
+        .states
+        .contains_key(&"10.0.0.2:6882".parse().unwrap()));
+
+    shutdown.cancel();
+    settle_io().await;
+    let _ = loop_task.await;
+    dead_handle.abort();
+    live_handle.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn announce_loop_promotes_successful_url_in_tier() {
+    let (fail_url, mut fail_rx, fail_handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 200,
+        body: failure_announce("unavailable"),
+    }])
+    .await;
+    let (ok_url, mut ok_rx, ok_handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 200,
+        body: ok_announce_peer([10, 0, 0, 3], 6883, 1800),
+    }])
+    .await;
+
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx_with_tiers(
+        vec![vec![fail_url, ok_url]],
+        "http://legacy.example/announce".into(),
+        incomplete_download(),
+    );
+    let loop_task = tokio::spawn(async move {
+        run_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+    });
+
+    let first_fail = fail_rx.recv().await.expect("first failing announce");
+    assert_eq!(first_fail.query_param("event"), Some("started"));
+    let first_ok = ok_rx.recv().await.expect("first successful announce");
+    assert_eq!(first_ok.query_param("event"), Some("started"));
+    settle_io().await;
+    assert!(fail_rx.try_recv().is_err());
+    assert!(ok_rx.try_recv().is_err());
+
+    tokio::time::advance(Duration::from_secs(1801)).await;
+    let second_ok = ok_rx.recv().await.expect("promoted re-announce");
+    assert_eq!(second_ok.query_param("event"), None);
+    settle_io().await;
+    assert!(
+        fail_rx.try_recv().is_err(),
+        "failed URL must not be tried after promotion"
+    );
+
+    shutdown.cancel();
+    settle_io().await;
+    let _ = loop_task.await;
+    fail_handle.abort();
+    ok_handle.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn announce_loop_retries_from_top_after_all_fail_backoff() {
+    let (first_url, mut first_rx, first_handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 500,
+        body: b"down".to_vec(),
+    }])
+    .await;
+    let (second_url, mut second_rx, second_handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 500,
+        body: b"down".to_vec(),
+    }])
+    .await;
+
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx_with_tiers(
+        vec![vec![first_url], vec![second_url]],
+        "http://legacy.example/announce".into(),
+        incomplete_download(),
+    );
+    let loop_task = tokio::spawn(async move {
+        run_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+    });
+
+    first_rx.recv().await.expect("first tier attempt");
+    second_rx.recv().await.expect("second tier attempt");
+    settle_io().await;
+
+    tokio::time::advance(Duration::from_secs(14)).await;
+    settle_io().await;
+    assert!(
+        first_rx.try_recv().is_err(),
+        "retried before backoff elapsed"
+    );
+    assert!(
+        second_rx.try_recv().is_err(),
+        "retried before backoff elapsed"
+    );
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    first_rx.recv().await.expect("retry starts at first tier");
+    second_rx
+        .recv()
+        .await
+        .expect("retry continues to second tier");
+
+    shutdown.cancel();
+    settle_io().await;
+    let _ = loop_task.await;
+    first_handle.abort();
+    second_handle.abort();
+}
+
+#[tokio::test]
+async fn announce_loop_skips_unknown_scheme() {
+    let (live_url, mut live_rx, live_handle) = spawn_scripted_tracker(vec![MockResponse {
+        status: 200,
+        body: ok_announce_peer([10, 0, 0, 4], 6884, 1800),
+    }])
+    .await;
+
+    let peer_states = Arc::new(PeerStates::default());
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx_with_tiers(
+        vec![
+            vec!["wss://tracker.example/announce".into()],
+            vec![live_url],
+        ],
+        "http://legacy.example/announce".into(),
+        incomplete_download(),
+    );
+    let peers_for_loop = peer_states.clone();
+    let loop_task = tokio::spawn(async move {
+        run_announce_loop(ctx, loop_shutdown, |peers| {
+            let peer_states = peers_for_loop.clone();
+            async move {
+                for peer in peers {
+                    peer_states.add_if_not_seen(peer);
+                }
+            }
+        })
+        .await;
+    });
+
+    let live_req = tokio::time::timeout(Duration::from_secs(2), live_rx.recv())
+        .await
+        .expect("live tracker timed out")
+        .expect("live tracker request");
+    assert_eq!(live_req.query_param("event"), Some("started"));
+    settle_io().await;
+    assert_eq!(peer_states.states.len(), 1);
+
+    shutdown.cancel();
+    settle_io().await;
+    let _ = loop_task.await;
+    live_handle.abort();
 }


### PR DESCRIPTION
## Summary

Implements issue #19: Multitracker Metadata Extension (BEP-0012).

Stacked on #34 so this review is only the tracker-tier work.

- Resolve `announce-list` into tiers (`announce-list` wins when it has URLs, otherwise synthesize one tier from `announce`). Parse tests cover debian (no list), gimp (multi-tier), the test-folder mixed-scheme sample, plus synthetic single-tier multi-URL and multi-tier fixtures.
- Add `TrackerTiers`: shuffle URLs inside each tier once at load, walk tiers then URLs in order, promote a successful URL to the front of its tier, and after an all-fail cycle back off and retry from the top.
- Drive HTTP and UDP from one periodic announce loop. `http(s)://` uses the existing HTTP path, `udp://` uses the UDP path with the session `key` and the same event/counters, unknown schemes are skipped with a warning. Peers still go through `PeerStates` dedup.
- `TrackerPeers::connect` no longer fans out one HTTP loop per URL plus a parallel UDP loop.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- Mock HTTP trackers cover: first tier dead / second tier returns peers, promotion-on-success so the next announce hits the promoted URL first, all-fail then 15s backoff then retry from the top, and `wss://` skipped with HTTP fallback.

Closes #19