### PR TITLE
feat: complete UDP tracker protocol (BEP-0015)

### DIFF
--- a/crates/bit_rev/src/file.rs
+++ b/crates/bit_rev/src/file.rs
@@ -262,6 +262,14 @@ impl AnnounceEvent {
             Self::Completed => "completed",
         }
     }
+
+    pub fn as_udp(self) -> u32 {
+        match self {
+            Self::Completed => 1,
+            Self::Started => 2,
+            Self::Stopped => 3,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -362,6 +370,13 @@ mod tests {
             info_hash,
             piece_hashes: vec![info_hash],
         }
+    }
+
+    #[test]
+    fn announce_event_udp_codes() {
+        assert_eq!(AnnounceEvent::Completed.as_udp(), 1);
+        assert_eq!(AnnounceEvent::Started.as_udp(), 2);
+        assert_eq!(AnnounceEvent::Stopped.as_udp(), 3);
     }
 
     fn sample_params(event: Option<AnnounceEvent>) -> AnnounceParams {

--- a/crates/bit_rev/src/protocol_udp.rs
+++ b/crates/bit_rev/src/protocol_udp.rs
@@ -1,215 +1,92 @@
-use anyhow::{anyhow, Result};
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use rand::Rng;
-use std::io::{Cursor, Read, Write};
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
-use tokio::net::UdpSocket;
+
+use thiserror::Error;
+use tokio::net::{lookup_host, UdpSocket};
 use tokio::time::{timeout, Instant};
 use tracing::debug;
 
-use crate::file::TorrentMeta;
+use crate::file::{AnnounceEvent, AnnounceParams, TorrentMeta};
 
-const PROTOCOL_ID: u64 = 0x41727101980;
+const PROTOCOL_ID: u64 = 0x0417_2710_1980;
 const ACTION_CONNECT: u32 = 0;
 const ACTION_ANNOUNCE: u32 = 1;
-#[allow(dead_code)]
-const ACTION_SCRAPE: u32 = 2;
 const ACTION_ERROR: u32 = 3;
 
-#[derive(Debug, Clone)]
+const CONNECTION_TTL: Duration = Duration::from_secs(60);
+const TIMEOUT_BASE_SECS: u64 = 15;
+const DEFAULT_MAX_CONNECT_N: u32 = 3;
+const DEFAULT_MAX_ANNOUNCE_N: u32 = 3;
+const DEFAULT_MAX_TOTAL_WAIT: Duration = Duration::from_secs(120);
+const ANNOUNCE_REQUEST_LEN: usize = 98;
+const CONNECT_REQUEST_LEN: usize = 16;
+const CONNECT_RESPONSE_LEN: usize = 16;
+const ANNOUNCE_RESPONSE_HEADER_LEN: usize = 20;
+const ERROR_HEADER_LEN: usize = 8;
+const IPV4_PEER_LEN: usize = 6;
+const IPV6_PEER_LEN: usize = 18;
+
+#[derive(Debug, Error)]
+pub enum UdpTrackerError {
+    #[error("tracker error: {0}")]
+    Message(String),
+    #[error("UDP tracker timed out")]
+    Timeout,
+    #[error("invalid UDP tracker URL: {0}")]
+    InvalidUrl(String),
+    #[error("could not resolve UDP tracker address: {0}")]
+    Resolve(String),
+    #[error("UDP tracker I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AnnounceLimits {
+    pub max_connect_n: u32,
+    pub max_announce_n: u32,
+    pub max_total_wait: Duration,
+}
+
+impl AnnounceLimits {
+    pub const DEFAULT: Self = Self {
+        max_connect_n: DEFAULT_MAX_CONNECT_N,
+        max_announce_n: DEFAULT_MAX_ANNOUNCE_N,
+        max_total_wait: DEFAULT_MAX_TOTAL_WAIT,
+    };
+
+    pub const STOPPED: Self = Self {
+        max_connect_n: 0,
+        max_announce_n: 0,
+        max_total_wait: Duration::from_secs(5),
+    };
+}
+
 pub struct UdpTracker {
-    pub url: String,
-    pub connection_id: Option<u64>,
-    pub last_connect: Option<Instant>,
+    url: String,
+    socket: Option<UdpSocket>,
+    connection: Option<CachedConnection>,
+    resolved: Option<SocketAddr>,
 }
 
-#[derive(Debug, Clone)]
-pub struct UdpPeer {
-    pub ip: [u8; 4],
-    pub port: u16,
+struct CachedConnection {
+    id: u64,
+    obtained_at: Instant,
+    addr: SocketAddr,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UdpAnnounceResponse {
-    pub action: u32,
-    pub transaction_id: u32,
     pub interval: u32,
     pub leechers: u32,
     pub seeders: u32,
-    pub peers: Vec<UdpPeer>,
+    pub peers: Vec<SocketAddr>,
 }
 
-pub struct AnnounceOptions {
-    pub torrent_meta: TorrentMeta,
-    pub peer_id: [u8; 20],
-    pub port: u16,
-    pub uploaded: u64,
-    pub downloaded: u64,
-    pub left: u64,
-    pub event: u32,
-}
-
-impl UdpTracker {
-    pub fn new(url: String) -> Self {
-        Self {
-            url,
-            connection_id: None,
-            last_connect: None,
-        }
-    }
-
-    pub async fn announce(
-        &mut self,
-        announce_options: &AnnounceOptions,
-    ) -> Result<UdpAnnounceResponse> {
-        // Check if we need to connect/reconnect
-        if self.connection_id.is_none()
-            || self
-                .last_connect
-                .map_or_else(|| true, |t| t.elapsed() > Duration::from_secs(60))
-        {
-            self.connect().await?;
-        }
-
-        let connection_id = self
-            .connection_id
-            .ok_or_else(|| anyhow!("No connection ID"))?;
-
-        let socket = UdpSocket::bind("0.0.0.0:0").await?;
-        let addr = self.parse_udp_url()?;
-        // info!("Using UDP tracker at {}", addr);
-
-        let transaction_id: u32 = rand::thread_rng().gen();
-
-        let torrent_meta = &announce_options.torrent_meta;
-        let peer_id = &announce_options.peer_id;
-        let port = announce_options.port;
-        let uploaded = announce_options.uploaded;
-        let downloaded = announce_options.downloaded;
-        let left = announce_options.left;
-        let event = announce_options.event;
-
-        let key = rand::thread_rng().gen();
-        let request = build_announce_request(AnnounceRequest {
-            connection_id,
-            transaction_id,
-            info_hash: torrent_meta.info_hash,
-            peer_id: *peer_id,
-            downloaded,
-            left,
-            uploaded,
-            event,
-            ip: 0,
-            key,
-            num_want: -1,
-            port,
-        })?;
-
-        debug!("Sending UDP announce request to {}", addr);
-        socket.send_to(&request, addr).await?;
-
-        // Receive response with timeout
-        let mut buf = [0u8; 1024];
-        let (len, _) = timeout(Duration::from_secs(15), socket.recv_from(&mut buf)).await??;
-
-        self.parse_announce_response(&buf[..len], transaction_id)
-    }
-
-    async fn connect(&mut self) -> Result<()> {
-        let socket = UdpSocket::bind("0.0.0.0:0").await?;
-        let addr = self.parse_udp_url()?;
-
-        let transaction_id: u32 = rand::thread_rng().gen();
-
-        let request = build_connect_request(transaction_id)?;
-
-        debug!("Sending UDP connect request to {}", addr);
-        socket.send_to(&request, addr).await?;
-
-        // Receive response with timeout
-        let mut buf = [0u8; 16];
-        let (len, _) = timeout(Duration::from_secs(15), socket.recv_from(&mut buf)).await??;
-
-        self.connection_id = Some(parse_connect_response(&buf[..len], transaction_id)?);
-        self.last_connect = Some(Instant::now());
-
-        debug!(
-            "UDP tracker connected with connection_id: {:?}",
-            self.connection_id
-        );
-        Ok(())
-    }
-
-    fn parse_udp_url(&self) -> Result<SocketAddr> {
-        let host_port = parse_udp_host_port(&self.url)?;
-
-        let addr = host_port
-            .to_socket_addrs()?
-            .next()
-            .ok_or_else(|| anyhow!("Could not resolve UDP tracker address: {}", host_port))?;
-
-        Ok(addr)
-    }
-
-    fn parse_announce_response(
-        &self,
-        data: &[u8],
-        expected_transaction_id: u32,
-    ) -> Result<UdpAnnounceResponse> {
-        if data.len() < 20 {
-            return Err(anyhow!("Announce response too short: {} bytes", data.len()));
-        }
-
-        let mut cursor = Cursor::new(data);
-        let action = cursor.read_u32::<BigEndian>()?;
-        let transaction_id = cursor.read_u32::<BigEndian>()?;
-
-        if action == ACTION_ERROR {
-            let error_msg = String::from_utf8_lossy(&data[8..]);
-            return Err(anyhow!("Tracker error: {}", error_msg));
-        }
-
-        if action != ACTION_ANNOUNCE {
-            return Err(anyhow!("Invalid action in announce response: {}", action));
-        }
-
-        if transaction_id != expected_transaction_id {
-            return Err(anyhow!("Transaction ID mismatch in announce response"));
-        }
-
-        let interval = cursor.read_u32::<BigEndian>()?;
-        let leechers = cursor.read_u32::<BigEndian>()?;
-        let seeders = cursor.read_u32::<BigEndian>()?;
-
-        let mut peers = Vec::new();
-        let remaining_bytes = data.len() - 20;
-        let peer_count = remaining_bytes / 6; // Each peer is 6 bytes (4 IP + 2 port)
-
-        for _ in 0..peer_count {
-            let mut ip = [0u8; 4];
-            cursor.read_exact(&mut ip)?;
-            let port = cursor.read_u16::<BigEndian>()?;
-
-            peers.push(UdpPeer { ip, port });
-        }
-
-        debug!(
-            "UDP announce response: {} seeders, {} leechers, {} peers",
-            seeders,
-            leechers,
-            peers.len()
-        );
-
-        Ok(UdpAnnounceResponse {
-            action,
-            transaction_id,
-            interval,
-            leechers,
-            seeders,
-            peers,
-        })
-    }
+#[derive(Debug)]
+enum Packet<T> {
+    Valid(T),
+    Error(String),
+    Ignore,
 }
 
 struct AnnounceRequest {
@@ -227,78 +104,176 @@ struct AnnounceRequest {
     port: u16,
 }
 
-fn build_connect_request(transaction_id: u32) -> Result<Vec<u8>> {
-    let mut request = Vec::new();
-    request.write_u64::<BigEndian>(PROTOCOL_ID)?;
-    request.write_u32::<BigEndian>(ACTION_CONNECT)?;
-    request.write_u32::<BigEndian>(transaction_id)?;
-    Ok(request)
+pub fn is_udp_url(url: &str) -> bool {
+    url.get(..6)
+        .is_some_and(|s| s.eq_ignore_ascii_case("udp://"))
 }
 
-fn build_announce_request(req: AnnounceRequest) -> Result<Vec<u8>> {
-    let mut request = Vec::new();
-    request.write_u64::<BigEndian>(req.connection_id)?;
-    request.write_u32::<BigEndian>(ACTION_ANNOUNCE)?;
-    request.write_u32::<BigEndian>(req.transaction_id)?;
-    request.write_all(&req.info_hash)?;
-    request.write_all(&req.peer_id)?;
-    request.write_u64::<BigEndian>(req.downloaded)?;
-    request.write_u64::<BigEndian>(req.left)?;
-    request.write_u64::<BigEndian>(req.uploaded)?;
-    request.write_u32::<BigEndian>(req.event)?;
-    request.write_u32::<BigEndian>(req.ip)?;
-    request.write_u32::<BigEndian>(req.key)?;
-    request.write_i32::<BigEndian>(req.num_want)?;
-    request.write_u16::<BigEndian>(req.port)?;
-    Ok(request)
-}
-
-fn parse_udp_host_port(url: &str) -> Result<&str> {
-    if !url.starts_with("udp://") {
-        return Err(anyhow!("Invalid UDP tracker URL: {}", url));
+impl UdpTracker {
+    pub fn new(url: String) -> Self {
+        Self {
+            url,
+            socket: None,
+            connection: None,
+            resolved: None,
+        }
     }
 
-    let url_without_scheme = &url[6..];
-    let host_port = url_without_scheme
-        .split('/')
-        .next()
-        .ok_or_else(|| anyhow!("Invalid UDP tracker URL format: {}", url))?;
-
-    if host_port.is_empty() {
-        return Err(anyhow!("Invalid UDP tracker URL format: {}", url));
+    pub async fn announce(
+        &mut self,
+        info_hash: &[u8; 20],
+        peer_id: &[u8; 20],
+        params: &AnnounceParams,
+    ) -> Result<UdpAnnounceResponse, UdpTrackerError> {
+        self.announce_with_limits(info_hash, peer_id, params, AnnounceLimits::DEFAULT)
+            .await
     }
 
-    Ok(host_port)
-}
+    pub async fn announce_with_limits(
+        &mut self,
+        info_hash: &[u8; 20],
+        peer_id: &[u8; 20],
+        params: &AnnounceParams,
+        limits: AnnounceLimits,
+    ) -> Result<UdpAnnounceResponse, UdpTrackerError> {
+        let deadline = Instant::now() + limits.max_total_wait;
+        let addr = resolve_udp_url(&self.url, self.resolved).await?;
+        self.ensure_transport(addr).await?;
+        let ipv6 = addr.is_ipv6();
 
-fn parse_connect_response(data: &[u8], expected_transaction_id: u32) -> Result<u64> {
-    if data.len() < 16 {
-        return Err(anyhow!("Connect response too short: {} bytes", data.len()));
+        let mut n = 0u32;
+        loop {
+            if remaining_until(deadline).is_zero() {
+                return Err(UdpTrackerError::Timeout);
+            }
+
+            let connection_id = self
+                .obtain_connection(deadline, limits.max_connect_n)
+                .await?;
+            let wait = timeout_for(n).min(remaining_until(deadline));
+            if wait.is_zero() {
+                return Err(UdpTrackerError::Timeout);
+            }
+
+            let transaction_id = new_transaction_id();
+            let request = build_announce_request(&AnnounceRequest {
+                connection_id,
+                transaction_id,
+                info_hash: *info_hash,
+                peer_id: *peer_id,
+                downloaded: params.downloaded,
+                left: params.left,
+                uploaded: params.uploaded,
+                event: udp_event(params.event),
+                ip: 0,
+                key: params.key,
+                num_want: udp_num_want(params.numwant),
+                port: params.port,
+            });
+
+            debug!(tracker = %self.url, addr = %addr, "sending UDP announce");
+            self.socket().send(&request).await?;
+
+            match recv_packet(self.socket(), wait, |data| {
+                parse_announce_response(data, transaction_id, ipv6)
+            })
+            .await
+            {
+                Ok(response) => return Ok(response),
+                Err(UdpTrackerError::Timeout) => {
+                    if n >= limits.max_announce_n {
+                        return Err(UdpTrackerError::Timeout);
+                    }
+                    n += 1;
+                }
+                Err(err) => return Err(err),
+            }
+        }
     }
 
-    let mut cursor = Cursor::new(data);
-    let action = cursor.read_u32::<BigEndian>()?;
-    let response_transaction_id = cursor.read_u32::<BigEndian>()?;
+    async fn obtain_connection(
+        &mut self,
+        deadline: Instant,
+        max_n: u32,
+    ) -> Result<u64, UdpTrackerError> {
+        if let Some(id) = self.cached_connection_id() {
+            return Ok(id);
+        }
 
-    if action == ACTION_ERROR {
-        let error_msg = String::from_utf8_lossy(&data[8..]);
-        return Err(anyhow!("Tracker error: {}", error_msg));
+        let mut n = 0u32;
+        loop {
+            let wait = timeout_for(n).min(remaining_until(deadline));
+            if wait.is_zero() {
+                return Err(UdpTrackerError::Timeout);
+            }
+
+            let transaction_id = new_transaction_id();
+            let request = build_connect_request(transaction_id);
+            debug!(tracker = %self.url, "sending UDP connect");
+            self.socket().send(&request).await?;
+
+            match recv_packet(self.socket(), wait, |data| {
+                parse_connect_response(data, transaction_id)
+            })
+            .await
+            {
+                Ok(id) => {
+                    let addr = self.resolved.expect("resolved after ensure_transport");
+                    self.connection = Some(CachedConnection {
+                        id,
+                        obtained_at: Instant::now(),
+                        addr,
+                    });
+                    debug!(tracker = %self.url, connection_id = id, "UDP tracker connected");
+                    return Ok(id);
+                }
+                Err(UdpTrackerError::Timeout) => {
+                    if n >= max_n {
+                        return Err(UdpTrackerError::Timeout);
+                    }
+                    n += 1;
+                }
+                Err(err) => return Err(err),
+            }
+        }
     }
 
-    if action != ACTION_CONNECT {
-        return Err(anyhow!("Invalid action in connect response: {}", action));
+    fn cached_connection_id(&self) -> Option<u64> {
+        let cached = self.connection.as_ref()?;
+        let addr = self.resolved?;
+        if cached.addr == addr && cached.obtained_at.elapsed() < CONNECTION_TTL {
+            Some(cached.id)
+        } else {
+            None
+        }
     }
 
-    if response_transaction_id != expected_transaction_id {
-        return Err(anyhow!("Transaction ID mismatch in connect response"));
+    async fn ensure_transport(&mut self, addr: SocketAddr) -> Result<(), UdpTrackerError> {
+        let family_changed = self
+            .resolved
+            .is_some_and(|prev| prev.is_ipv6() != addr.is_ipv6());
+        if self.socket.is_none() || family_changed {
+            let bind_addr = unspecified_bind_addr(addr);
+            let socket = UdpSocket::bind(bind_addr).await?;
+            socket.connect(addr).await?;
+            self.socket = Some(socket);
+            self.connection = None;
+            self.resolved = Some(addr);
+            return Ok(());
+        }
+
+        if self.resolved != Some(addr) {
+            self.socket().connect(addr).await?;
+            self.connection = None;
+            self.resolved = Some(addr);
+        }
+        Ok(())
     }
 
-    Ok(cursor.read_u64::<BigEndian>()?)
-}
-
-impl UdpPeer {
-    pub fn to_socket_addr(&self) -> SocketAddr {
-        SocketAddr::from((self.ip, self.port))
+    fn socket(&self) -> &UdpSocket {
+        self.socket
+            .as_ref()
+            .expect("UDP socket exists after ensure_transport")
     }
 }
 
@@ -307,186 +282,587 @@ pub async fn request_udp_peers(
     torrent_meta: &TorrentMeta,
     peer_id: &[u8; 20],
     port: u16,
-) -> Result<UdpAnnounceResponse> {
+) -> Result<UdpAnnounceResponse, UdpTrackerError> {
     let mut tracker = UdpTracker::new(tracker_url.to_string());
-
-    let uploaded = 0;
-    let downloaded = 0;
-    let left = torrent_meta.torrent_file.info.length.unwrap_or(0) as u64;
-    let event = 2; // started event
-
-    let announce_options = AnnounceOptions {
-        torrent_meta: torrent_meta.clone(),
-        peer_id: *peer_id,
+    let params = AnnounceParams {
+        uploaded: 0,
+        downloaded: 0,
+        left: torrent_left_bytes(torrent_meta),
         port,
-        uploaded,
-        downloaded,
-        left,
-        event,
+        event: Some(AnnounceEvent::Started),
+        numwant: AnnounceParams::DEFAULT_NUMWANT,
+        key: rand::Rng::gen(&mut rand::thread_rng()),
+        tracker_id: None,
     };
+    tracker
+        .announce(&torrent_meta.info_hash, peer_id, &params)
+        .await
+}
 
-    tracker.announce(&announce_options).await
+fn torrent_left_bytes(torrent_meta: &TorrentMeta) -> u64 {
+    if let Some(length) = torrent_meta.torrent_file.info.length {
+        return length.max(0) as u64;
+    }
+    torrent_meta
+        .torrent_file
+        .info
+        .files
+        .as_ref()
+        .map(|files| files.iter().map(|file| file.length.max(0) as u64).sum())
+        .unwrap_or(0)
+}
+
+async fn resolve_udp_url(
+    url: &str,
+    preferred: Option<SocketAddr>,
+) -> Result<SocketAddr, UdpTrackerError> {
+    let host_port = parse_udp_host_port(url)?;
+    let addrs: Vec<SocketAddr> = lookup_host(host_port)
+        .await
+        .map_err(|e| UdpTrackerError::Resolve(format!("{host_port}: {e}")))?
+        .collect();
+    if let Some(prev) = preferred {
+        if addrs.contains(&prev) {
+            return Ok(prev);
+        }
+    }
+    addrs
+        .into_iter()
+        .min_by_key(|addr| addr.is_ipv6())
+        .ok_or_else(|| UdpTrackerError::Resolve(host_port.to_string()))
+}
+
+fn parse_udp_host_port(url: &str) -> Result<&str, UdpTrackerError> {
+    let rest = url
+        .get(6..)
+        .filter(|_| is_udp_url(url))
+        .ok_or_else(|| UdpTrackerError::InvalidUrl(url.to_string()))?;
+    let host_port = rest.split('/').next().unwrap_or_default();
+    if host_port.is_empty() {
+        return Err(UdpTrackerError::InvalidUrl(url.to_string()));
+    }
+    Ok(host_port)
+}
+
+fn unspecified_bind_addr(peer: SocketAddr) -> SocketAddr {
+    if peer.is_ipv6() {
+        SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0))
+    } else {
+        SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0))
+    }
+}
+
+fn new_transaction_id() -> u32 {
+    rand::Rng::gen(&mut rand::thread_rng())
+}
+
+fn udp_event(event: Option<AnnounceEvent>) -> u32 {
+    event.map(AnnounceEvent::as_udp).unwrap_or(0)
+}
+
+fn udp_num_want(numwant: u32) -> i32 {
+    i32::try_from(numwant).unwrap_or(i32::MAX)
+}
+
+fn timeout_for(n: u32) -> Duration {
+    let shift = n.min(8);
+    Duration::from_secs(TIMEOUT_BASE_SECS.saturating_mul(1u64 << shift))
+}
+
+fn remaining_until(deadline: Instant) -> Duration {
+    deadline
+        .checked_duration_since(Instant::now())
+        .unwrap_or_default()
+}
+
+async fn recv_packet<T>(
+    socket: &UdpSocket,
+    wait: Duration,
+    parse: impl Fn(&[u8]) -> Packet<T>,
+) -> Result<T, UdpTrackerError> {
+    let deadline = Instant::now() + wait;
+    let mut buf = vec![0u8; 65535];
+    loop {
+        let remaining = remaining_until(deadline);
+        if remaining.is_zero() {
+            return Err(UdpTrackerError::Timeout);
+        }
+        match timeout(remaining, socket.recv(&mut buf)).await {
+            Err(_) => return Err(UdpTrackerError::Timeout),
+            Ok(Err(err)) => return Err(err.into()),
+            Ok(Ok(len)) => match parse(&buf[..len]) {
+                Packet::Valid(value) => return Ok(value),
+                Packet::Error(message) => return Err(UdpTrackerError::Message(message)),
+                Packet::Ignore => {}
+            },
+        }
+    }
+}
+
+fn build_connect_request(transaction_id: u32) -> [u8; CONNECT_REQUEST_LEN] {
+    let mut request = [0u8; CONNECT_REQUEST_LEN];
+    request[0..8].copy_from_slice(&PROTOCOL_ID.to_be_bytes());
+    request[8..12].copy_from_slice(&ACTION_CONNECT.to_be_bytes());
+    request[12..16].copy_from_slice(&transaction_id.to_be_bytes());
+    request
+}
+
+fn build_announce_request(req: &AnnounceRequest) -> [u8; ANNOUNCE_REQUEST_LEN] {
+    let mut request = [0u8; ANNOUNCE_REQUEST_LEN];
+    request[0..8].copy_from_slice(&req.connection_id.to_be_bytes());
+    request[8..12].copy_from_slice(&ACTION_ANNOUNCE.to_be_bytes());
+    request[12..16].copy_from_slice(&req.transaction_id.to_be_bytes());
+    request[16..36].copy_from_slice(&req.info_hash);
+    request[36..56].copy_from_slice(&req.peer_id);
+    request[56..64].copy_from_slice(&req.downloaded.to_be_bytes());
+    request[64..72].copy_from_slice(&req.left.to_be_bytes());
+    request[72..80].copy_from_slice(&req.uploaded.to_be_bytes());
+    request[80..84].copy_from_slice(&req.event.to_be_bytes());
+    request[84..88].copy_from_slice(&req.ip.to_be_bytes());
+    request[88..92].copy_from_slice(&req.key.to_be_bytes());
+    request[92..96].copy_from_slice(&req.num_want.to_be_bytes());
+    request[96..98].copy_from_slice(&req.port.to_be_bytes());
+    request
+}
+
+fn parse_connect_response(data: &[u8], expected_transaction_id: u32) -> Packet<u64> {
+    match classify_header(
+        data,
+        expected_transaction_id,
+        ACTION_CONNECT,
+        CONNECT_RESPONSE_LEN,
+    ) {
+        Header::Ignore => Packet::Ignore,
+        Header::Error(message) => Packet::Error(message),
+        Header::Ok => match read_u64(data, 8) {
+            Some(connection_id) => Packet::Valid(connection_id),
+            None => Packet::Ignore,
+        },
+    }
+}
+
+fn parse_announce_response(
+    data: &[u8],
+    expected_transaction_id: u32,
+    ipv6: bool,
+) -> Packet<UdpAnnounceResponse> {
+    match classify_header(
+        data,
+        expected_transaction_id,
+        ACTION_ANNOUNCE,
+        ANNOUNCE_RESPONSE_HEADER_LEN,
+    ) {
+        Header::Ignore => Packet::Ignore,
+        Header::Error(message) => Packet::Error(message),
+        Header::Ok => parse_announce_body(data, ipv6),
+    }
+}
+
+fn parse_announce_body(data: &[u8], ipv6: bool) -> Packet<UdpAnnounceResponse> {
+    let Some(interval) = read_u32(data, 8) else {
+        return Packet::Ignore;
+    };
+    let Some(leechers) = read_u32(data, 12) else {
+        return Packet::Ignore;
+    };
+    let Some(seeders) = read_u32(data, 16) else {
+        return Packet::Ignore;
+    };
+    let Some(peers) = parse_peers(&data[ANNOUNCE_RESPONSE_HEADER_LEN..], ipv6) else {
+        return Packet::Ignore;
+    };
+    Packet::Valid(UdpAnnounceResponse {
+        interval,
+        leechers,
+        seeders,
+        peers,
+    })
+}
+
+fn parse_peers(rest: &[u8], ipv6: bool) -> Option<Vec<SocketAddr>> {
+    let entry_len = if ipv6 { IPV6_PEER_LEN } else { IPV4_PEER_LEN };
+    if !rest.len().is_multiple_of(entry_len) {
+        return None;
+    }
+    let mut peers = Vec::with_capacity(rest.len() / entry_len);
+    for chunk in rest.chunks_exact(entry_len) {
+        peers.push(if ipv6 {
+            parse_ipv6_peer(chunk)?
+        } else {
+            parse_ipv4_peer(chunk)?
+        });
+    }
+    Some(peers)
+}
+
+fn parse_ipv4_peer(chunk: &[u8]) -> Option<SocketAddr> {
+    if chunk.len() != IPV4_PEER_LEN {
+        return None;
+    }
+    let ip = Ipv4Addr::new(chunk[0], chunk[1], chunk[2], chunk[3]);
+    let port = u16::from_be_bytes([chunk[4], chunk[5]]);
+    Some(SocketAddr::from((ip, port)))
+}
+
+fn parse_ipv6_peer(chunk: &[u8]) -> Option<SocketAddr> {
+    if chunk.len() != IPV6_PEER_LEN {
+        return None;
+    }
+    let mut octets = [0u8; 16];
+    octets.copy_from_slice(&chunk[..16]);
+    let port = u16::from_be_bytes([chunk[16], chunk[17]]);
+    Some(SocketAddr::from((Ipv6Addr::from(octets), port)))
+}
+
+enum Header {
+    Ok,
+    Error(String),
+    Ignore,
+}
+
+fn classify_header(
+    data: &[u8],
+    expected_transaction_id: u32,
+    expected_action: u32,
+    min_ok_len: usize,
+) -> Header {
+    if data.len() < ERROR_HEADER_LEN {
+        return Header::Ignore;
+    }
+    let Some(action) = read_u32(data, 0) else {
+        return Header::Ignore;
+    };
+    let Some(transaction_id) = read_u32(data, 4) else {
+        return Header::Ignore;
+    };
+    if transaction_id != expected_transaction_id {
+        return Header::Ignore;
+    }
+    if action == ACTION_ERROR {
+        let message = String::from_utf8_lossy(&data[ERROR_HEADER_LEN..]).into_owned();
+        return Header::Error(message);
+    }
+    if action != expected_action || data.len() < min_ok_len {
+        return Header::Ignore;
+    }
+    Header::Ok
+}
+
+fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
+    data.get(offset..offset + 4)?
+        .try_into()
+        .ok()
+        .map(u32::from_be_bytes)
+}
+
+fn read_u64(data: &[u8], offset: usize) -> Option<u64> {
+    data.get(offset..offset + 8)?
+        .try_into()
+        .ok()
+        .map(u64::from_be_bytes)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{IpAddr, SocketAddrV6};
+    use tokio::sync::mpsc;
 
-    #[test]
-    fn test_parse_udp_url() {
-        let tracker = UdpTracker::new("udp://tracker.opentrackr.org:1337/announce".to_string());
-        let result = tracker.parse_udp_url();
-        assert!(result.is_ok());
+    const INFO_HASH: [u8; 20] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    ];
+    const PEER_ID: [u8; 20] = [
+        20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+    ];
+    const ANNOUNCE_KEY: u32 = 0xDEAD_BEEF;
+    const FIXED_CONNECTION_ID: u64 = 0x1111_1111_1111_1111;
+    const FIXED_TRANSACTION_ID: u32 = 0xAABB_CCDD;
+
+    fn sample_params(event: Option<AnnounceEvent>) -> AnnounceParams {
+        AnnounceParams {
+            uploaded: 3,
+            downloaded: 1,
+            left: 2,
+            port: 6881,
+            event,
+            numwant: AnnounceParams::DEFAULT_NUMWANT,
+            key: ANNOUNCE_KEY,
+            tracker_id: None,
+        }
     }
 
-    #[test]
-    fn test_invalid_udp_url() {
-        let tracker = UdpTracker::new("http://tracker.example.com:8080/announce".to_string());
-        let result = tracker.parse_udp_url();
-        assert!(result.is_err());
+    fn fixture_announce_request(num_want: i32) -> AnnounceRequest {
+        AnnounceRequest {
+            connection_id: FIXED_CONNECTION_ID,
+            transaction_id: FIXED_TRANSACTION_ID,
+            info_hash: INFO_HASH,
+            peer_id: PEER_ID,
+            downloaded: 1,
+            left: 2,
+            uploaded: 3,
+            event: 2,
+            ip: 0,
+            key: ANNOUNCE_KEY,
+            num_want,
+            port: 6881,
+        }
+    }
+
+    fn connect_response_bytes(transaction_id: u32, connection_id: u64) -> [u8; 16] {
+        let mut data = [0u8; 16];
+        data[0..4].copy_from_slice(&ACTION_CONNECT.to_be_bytes());
+        data[4..8].copy_from_slice(&transaction_id.to_be_bytes());
+        data[8..16].copy_from_slice(&connection_id.to_be_bytes());
+        data
+    }
+
+    fn announce_response_v4(
+        transaction_id: u32,
+        interval: u32,
+        leechers: u32,
+        seeders: u32,
+        peers: &[(Ipv4Addr, u16)],
+    ) -> Vec<u8> {
+        let mut data =
+            Vec::with_capacity(ANNOUNCE_RESPONSE_HEADER_LEN + peers.len() * IPV4_PEER_LEN);
+        data.extend_from_slice(&ACTION_ANNOUNCE.to_be_bytes());
+        data.extend_from_slice(&transaction_id.to_be_bytes());
+        data.extend_from_slice(&interval.to_be_bytes());
+        data.extend_from_slice(&leechers.to_be_bytes());
+        data.extend_from_slice(&seeders.to_be_bytes());
+        for (ip, port) in peers {
+            data.extend_from_slice(&ip.octets());
+            data.extend_from_slice(&port.to_be_bytes());
+        }
+        data
+    }
+
+    fn announce_response_v6(
+        transaction_id: u32,
+        interval: u32,
+        leechers: u32,
+        seeders: u32,
+        peers: &[(Ipv6Addr, u16)],
+    ) -> Vec<u8> {
+        let mut data =
+            Vec::with_capacity(ANNOUNCE_RESPONSE_HEADER_LEN + peers.len() * IPV6_PEER_LEN);
+        data.extend_from_slice(&ACTION_ANNOUNCE.to_be_bytes());
+        data.extend_from_slice(&transaction_id.to_be_bytes());
+        data.extend_from_slice(&interval.to_be_bytes());
+        data.extend_from_slice(&leechers.to_be_bytes());
+        data.extend_from_slice(&seeders.to_be_bytes());
+        for (ip, port) in peers {
+            data.extend_from_slice(&ip.octets());
+            data.extend_from_slice(&port.to_be_bytes());
+        }
+        data
+    }
+
+    fn error_response_bytes(transaction_id: u32, message: &str) -> Vec<u8> {
+        let mut data = Vec::with_capacity(ERROR_HEADER_LEN + message.len());
+        data.extend_from_slice(&ACTION_ERROR.to_be_bytes());
+        data.extend_from_slice(&transaction_id.to_be_bytes());
+        data.extend_from_slice(message.as_bytes());
+        data
+    }
+
+    fn read_u32_at(data: &[u8], offset: usize) -> u32 {
+        u32::from_be_bytes(data[offset..offset + 4].try_into().unwrap())
+    }
+
+    fn read_u64_at(data: &[u8], offset: usize) -> u64 {
+        u64::from_be_bytes(data[offset..offset + 8].try_into().unwrap())
+    }
+
+    fn assert_connect_request(data: &[u8]) -> u32 {
+        assert_eq!(data.len(), CONNECT_REQUEST_LEN);
+        assert_eq!(&data[0..8], &PROTOCOL_ID.to_be_bytes());
+        assert_eq!(read_u32_at(data, 8), ACTION_CONNECT);
+        read_u32_at(data, 12)
+    }
+
+    fn assert_announce_request(data: &[u8], connection_id: u64, params: &AnnounceParams) -> u32 {
+        assert_eq!(data.len(), ANNOUNCE_REQUEST_LEN);
+        assert_eq!(read_u64_at(data, 0), connection_id);
+        assert_eq!(read_u32_at(data, 8), ACTION_ANNOUNCE);
+        assert_eq!(&data[16..36], &INFO_HASH);
+        assert_eq!(&data[36..56], &PEER_ID);
+        assert_eq!(&data[56..64], &params.downloaded.to_be_bytes());
+        assert_eq!(&data[64..72], &params.left.to_be_bytes());
+        assert_eq!(&data[72..80], &params.uploaded.to_be_bytes());
+        assert_eq!(&data[80..84], &udp_event(params.event).to_be_bytes());
+        assert_eq!(&data[84..88], &0u32.to_be_bytes());
+        assert_eq!(&data[88..92], &params.key.to_be_bytes());
+        assert_eq!(&data[92..96], &udp_num_want(params.numwant).to_be_bytes());
+        assert_eq!(&data[96..98], &params.port.to_be_bytes());
+        read_u32_at(data, 12)
+    }
+
+    async fn bind_mock(addr: SocketAddr) -> UdpSocket {
+        UdpSocket::bind(addr).await.expect("bind mock tracker")
+    }
+
+    fn tracker_url(addr: SocketAddr) -> String {
+        match addr.ip() {
+            IpAddr::V4(ip) => format!("udp://{ip}:{}/announce", addr.port()),
+            IpAddr::V6(ip) => format!("udp://[{ip}]:{}/announce", addr.port()),
+        }
+    }
+
+    async fn recv_from_mock(socket: &UdpSocket) -> (Vec<u8>, SocketAddr) {
+        let mut buf = vec![0u8; 512];
+        let (len, from) = socket.recv_from(&mut buf).await.expect("mock recv");
+        (buf[..len].to_vec(), from)
     }
 
     #[test]
     fn test_build_connect_request() {
-        let transaction_id = 0x01020304;
-        let request = build_connect_request(transaction_id).unwrap();
+        let request = build_connect_request(0x0102_0304);
         let expected = [
-            0x00, 0x00, 0x04, 0x17, 0x27, 0x10, 0x19, 0x80, // protocol id 0x41727101980
-            0x00, 0x00, 0x00, 0x00, // action connect
-            0x01, 0x02, 0x03, 0x04, // transaction_id
+            0x00, 0x00, 0x04, 0x17, 0x27, 0x10, 0x19, 0x80, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02,
+            0x03, 0x04,
         ];
         assert_eq!(request, expected);
     }
 
     #[test]
     fn test_build_announce_request() {
-        let info_hash: [u8; 20] = [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-        ];
-        let peer_id: [u8; 20] = [
-            20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
-        ];
-        let request = build_announce_request(AnnounceRequest {
-            connection_id: 0x1111_1111_1111_1111,
-            transaction_id: 0xaabbccdd,
-            info_hash,
-            peer_id,
-            downloaded: 1,
-            left: 2,
-            uploaded: 3,
-            event: 2,
-            ip: 0,
-            key: 0xdeadbeef,
-            num_want: -1,
-            port: 6881,
-        })
-        .unwrap();
-
+        let request = build_announce_request(&fixture_announce_request(-1));
         let expected = [
-            0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, // connection_id
-            0x00, 0x00, 0x00, 0x01, // action announce
-            0xaa, 0xbb, 0xcc, 0xdd, // transaction_id
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-            20, // info_hash
-            20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, // peer_id
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // downloaded
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // left
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, // uploaded
-            0x00, 0x00, 0x00, 0x02, // event started
-            0x00, 0x00, 0x00, 0x00, // ip
-            0xde, 0xad, 0xbe, 0xef, // key
-            0xff, 0xff, 0xff, 0xff, // num_want -1
-            0x1a, 0xe1, // port 6881
+            0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x00, 0x00, 0x00, 0x01, 0xaa, 0xbb,
+            0xcc, 0xdd, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 20,
+            19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+            0x00, 0xde, 0xad, 0xbe, 0xef, 0xff, 0xff, 0xff, 0xff, 0x1a, 0xe1,
         ];
-        assert_eq!(request.len(), 98);
+        assert_eq!(request.len(), ANNOUNCE_REQUEST_LEN);
         assert_eq!(request, expected);
         assert_eq!(&request[96..], &[0x1a, 0xe1]);
     }
 
     #[test]
+    fn test_build_announce_request_http_lifecycle_numwant() {
+        let request = build_announce_request(&fixture_announce_request(50));
+        assert_eq!(&request[92..96], &50i32.to_be_bytes());
+        assert_eq!(request.len(), ANNOUNCE_REQUEST_LEN);
+    }
+
+    #[test]
     fn test_parse_connect_response() {
-        let transaction_id = 0x01020304;
-        let data = [
-            0x00, 0x00, 0x00, 0x00, // action connect
-            0x01, 0x02, 0x03, 0x04, // transaction_id
-            0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10, // connection_id
-        ];
-        let connection_id = parse_connect_response(&data, transaction_id).unwrap();
-        assert_eq!(connection_id, 0xfedcba9876543210);
+        let data = connect_response_bytes(0x0102_0304, 0xFEDC_BA98_7654_3210);
+        match parse_connect_response(&data, 0x0102_0304) {
+            Packet::Valid(connection_id) => assert_eq!(connection_id, 0xFEDC_BA98_7654_3210),
+            other => panic!("expected valid connect response, got {other:?}"),
+        }
     }
 
     #[test]
-    fn test_parse_announce_response() {
-        let tracker = UdpTracker::new("udp://127.0.0.1:1".into());
-        let transaction_id = 0xaabbccdd;
-        let data = [
-            0x00, 0x00, 0x00, 0x01, // action announce
-            0xaa, 0xbb, 0xcc, 0xdd, // transaction_id
-            0x00, 0x00, 0x07, 0x08, // interval 1800
-            0x00, 0x00, 0x00, 0x03, // leechers
-            0x00, 0x00, 0x00, 0x07, // seeders
-            127, 0, 0, 1, // 127.0.0.1
-            0x1a, 0xe1, // port 6881
-        ];
-        let response = tracker
-            .parse_announce_response(&data, transaction_id)
-            .unwrap();
-        assert_eq!(response.action, ACTION_ANNOUNCE);
-        assert_eq!(response.transaction_id, transaction_id);
-        assert_eq!(response.interval, 1800);
-        assert_eq!(response.leechers, 3);
-        assert_eq!(response.seeders, 7);
-        assert_eq!(response.peers.len(), 1);
-        assert_eq!(response.peers[0].ip, [127, 0, 0, 1]);
-        assert_eq!(response.peers[0].port, 6881);
+    fn test_parse_announce_response_ipv4() {
+        let data = announce_response_v4(
+            FIXED_TRANSACTION_ID,
+            1800,
+            3,
+            7,
+            &[(Ipv4Addr::new(127, 0, 0, 1), 6881)],
+        );
+        match parse_announce_response(&data, FIXED_TRANSACTION_ID, false) {
+            Packet::Valid(response) => {
+                assert_eq!(response.interval, 1800);
+                assert_eq!(response.leechers, 3);
+                assert_eq!(response.seeders, 7);
+                assert_eq!(
+                    response.peers,
+                    vec![SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 6881))]
+                );
+            }
+            other => panic!("expected valid announce response, got {other:?}"),
+        }
     }
 
     #[test]
-    fn test_short_packets() {
-        let tracker = UdpTracker::new("udp://127.0.0.1:1".into());
-        let short_connect = [0u8; 15];
-        let short_announce = [0u8; 19];
-        assert!(parse_connect_response(&short_connect, 1).is_err());
-        assert!(tracker.parse_announce_response(&short_announce, 1).is_err());
+    fn test_parse_announce_response_ipv6() {
+        let ip = Ipv6Addr::LOCALHOST;
+        let data = announce_response_v6(FIXED_TRANSACTION_ID, 900, 1, 2, &[(ip, 51413)]);
+        match parse_announce_response(&data, FIXED_TRANSACTION_ID, true) {
+            Packet::Valid(response) => {
+                assert_eq!(response.interval, 900);
+                assert_eq!(response.leechers, 1);
+                assert_eq!(response.seeders, 2);
+                assert_eq!(response.peers, vec![SocketAddr::from((ip, 51413))]);
+            }
+            other => panic!("expected valid IPv6 announce response, got {other:?}"),
+        }
     }
 
     #[test]
-    fn test_wrong_transaction_id() {
-        let tracker = UdpTracker::new("udp://127.0.0.1:1".into());
-        let connect_data = [
-            0x00, 0x00, 0x00, 0x00, // action connect
-            0x01, 0x02, 0x03, 0x04, // transaction_id
-            0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
-        ];
-        assert!(parse_connect_response(&connect_data, 0xdeadbeef).is_err());
+    fn test_short_packets_are_ignored() {
+        assert!(matches!(
+            parse_connect_response(&[0u8; 15], 1),
+            Packet::Ignore
+        ));
+        assert!(matches!(
+            parse_announce_response(&[0u8; 19], 1, false),
+            Packet::Ignore
+        ));
+        assert!(matches!(
+            parse_announce_response(&[0u8; 7], 1, false),
+            Packet::Ignore
+        ));
+    }
 
-        let announce_data = [
-            0x00, 0x00, 0x00, 0x01, // action announce
-            0xaa, 0xbb, 0xcc, 0xdd, // transaction_id
-            0x00, 0x00, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        ];
-        assert!(tracker
-            .parse_announce_response(&announce_data, 0x01020304)
-            .is_err());
+    #[test]
+    fn test_wrong_transaction_id_is_ignored() {
+        let connect = connect_response_bytes(0x0102_0304, 1);
+        assert!(matches!(
+            parse_connect_response(&connect, 0xDEAD_BEEF),
+            Packet::Ignore
+        ));
+
+        let announce = announce_response_v4(FIXED_TRANSACTION_ID, 1, 0, 0, &[]);
+        assert!(matches!(
+            parse_announce_response(&announce, 0x0102_0304, false),
+            Packet::Ignore
+        ));
+    }
+
+    #[test]
+    fn test_wrong_action_is_ignored() {
+        let connect = connect_response_bytes(1, 1);
+        assert!(matches!(
+            parse_announce_response(&connect, 1, false),
+            Packet::Ignore
+        ));
+    }
+
+    #[test]
+    fn test_misaligned_peers_are_ignored() {
+        let mut data = announce_response_v4(1, 1800, 0, 0, &[(Ipv4Addr::LOCALHOST, 1)]);
+        data.pop();
+        assert!(matches!(
+            parse_announce_response(&data, 1, false),
+            Packet::Ignore
+        ));
+
+        let mut v6 = announce_response_v6(1, 1800, 0, 0, &[(Ipv6Addr::LOCALHOST, 1)]);
+        v6.push(0);
+        assert!(matches!(
+            parse_announce_response(&v6, 1, true),
+            Packet::Ignore
+        ));
     }
 
     #[test]
     fn test_error_action() {
-        let tracker = UdpTracker::new("udp://127.0.0.1:1".into());
-        let transaction_id = 0x01020304;
-        let mut data = vec![
-            0x00, 0x00, 0x00, 0x03, // action error
-            0x01, 0x02, 0x03, 0x04, // transaction_id
-        ];
-        data.extend_from_slice(b"banned by tracker");
-
-        let connect_err = parse_connect_response(&data, transaction_id).unwrap_err();
-        assert!(connect_err.to_string().contains("banned by tracker"));
-
-        let announce_err = tracker
-            .parse_announce_response(&data, transaction_id)
-            .unwrap_err();
-        assert!(announce_err.to_string().contains("banned by tracker"));
+        let data = error_response_bytes(0x0102_0304, "banned by tracker");
+        match parse_connect_response(&data, 0x0102_0304) {
+            Packet::Error(message) => assert_eq!(message, "banned by tracker"),
+            other => panic!("expected connect error, got {other:?}"),
+        }
+        match parse_announce_response(&data, 0x0102_0304, false) {
+            Packet::Error(message) => assert_eq!(message, "banned by tracker"),
+            other => panic!("expected announce error, got {other:?}"),
+        }
     }
 
     #[test]
@@ -495,7 +871,422 @@ mod tests {
             parse_udp_host_port("udp://tracker.example:1337/announce").unwrap(),
             "tracker.example:1337"
         );
+        assert_eq!(
+            parse_udp_host_port("UDP://[::1]:1337/announce").unwrap(),
+            "[::1]:1337"
+        );
         assert!(parse_udp_host_port("http://tracker.example:80/announce").is_err());
         assert!(parse_udp_host_port("udp://").is_err());
+        assert!(is_udp_url("udp://127.0.0.1:1/announce"));
+        assert!(is_udp_url("UDP://127.0.0.1:1/announce"));
+        assert!(!is_udp_url("http://127.0.0.1:1/announce"));
+    }
+
+    #[test]
+    fn test_timeout_schedule() {
+        assert_eq!(timeout_for(0), Duration::from_secs(15));
+        assert_eq!(timeout_for(1), Duration::from_secs(30));
+        assert_eq!(timeout_for(2), Duration::from_secs(60));
+        assert_eq!(timeout_for(3), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn test_udp_event_and_num_want() {
+        assert_eq!(udp_event(None), 0);
+        assert_eq!(udp_event(Some(AnnounceEvent::Completed)), 1);
+        assert_eq!(udp_event(Some(AnnounceEvent::Started)), 2);
+        assert_eq!(udp_event(Some(AnnounceEvent::Stopped)), 3);
+        assert_eq!(udp_num_want(50), 50);
+        assert_eq!(udp_num_want(0), 0);
+    }
+
+    #[tokio::test]
+    async fn announce_round_trip_peers_and_interval() {
+        let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
+        let url = tracker_url(mock.local_addr().unwrap());
+        let params = sample_params(Some(AnnounceEvent::Started));
+        let client = tokio::spawn(async move {
+            let mut tracker = UdpTracker::new(url);
+            tracker.announce(&INFO_HASH, &PEER_ID, &params).await
+        });
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(
+            &connect_response_bytes(connect_tid, FIXED_CONNECTION_ID),
+            from,
+        )
+        .await
+        .unwrap();
+
+        let (announce, from) = recv_from_mock(&mock).await;
+        let announce_tid = assert_announce_request(
+            &announce,
+            FIXED_CONNECTION_ID,
+            &sample_params(Some(AnnounceEvent::Started)),
+        );
+        let response = announce_response_v4(
+            announce_tid,
+            1800,
+            3,
+            7,
+            &[(Ipv4Addr::new(127, 0, 0, 1), 6881)],
+        );
+        mock.send_to(&response, from).await.unwrap();
+
+        let got = client.await.unwrap().expect("announce succeeded");
+        assert_eq!(got.interval, 1800);
+        assert_eq!(got.leechers, 3);
+        assert_eq!(got.seeders, 7);
+        assert_eq!(
+            got.peers,
+            vec![SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 6881))]
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_mismatch_is_ignored_until_matching_packet() {
+        let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
+        let url = tracker_url(mock.local_addr().unwrap());
+        let params = sample_params(None);
+        let client_params = params.clone();
+        let client = tokio::spawn(async move {
+            let mut tracker = UdpTracker::new(url);
+            tracker.announce(&INFO_HASH, &PEER_ID, &client_params).await
+        });
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(
+            &connect_response_bytes(connect_tid.wrapping_add(1), FIXED_CONNECTION_ID),
+            from,
+        )
+        .await
+        .unwrap();
+        mock.send_to(
+            &connect_response_bytes(connect_tid, FIXED_CONNECTION_ID),
+            from,
+        )
+        .await
+        .unwrap();
+
+        let (announce, from) = recv_from_mock(&mock).await;
+        let announce_tid = assert_announce_request(&announce, FIXED_CONNECTION_ID, &params);
+        mock.send_to(
+            &announce_response_v4(announce_tid.wrapping_add(1), 60, 0, 0, &[]),
+            from,
+        )
+        .await
+        .unwrap();
+        mock.send_to(
+            &announce_response_v4(
+                announce_tid,
+                60,
+                0,
+                1,
+                &[(Ipv4Addr::new(10, 0, 0, 2), 51413)],
+            ),
+            from,
+        )
+        .await
+        .unwrap();
+
+        let got = client.await.unwrap().expect("announce succeeded");
+        assert_eq!(got.interval, 60);
+        assert_eq!(got.seeders, 1);
+        assert_eq!(
+            got.peers,
+            vec![SocketAddr::from((Ipv4Addr::new(10, 0, 0, 2), 51413))]
+        );
+    }
+
+    #[tokio::test]
+    async fn error_packet_is_typed_error() {
+        let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
+        let url = tracker_url(mock.local_addr().unwrap());
+        let params = sample_params(Some(AnnounceEvent::Started));
+        let client_params = params.clone();
+        let client = tokio::spawn(async move {
+            let mut tracker = UdpTracker::new(url);
+            tracker.announce(&INFO_HASH, &PEER_ID, &client_params).await
+        });
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(
+            &connect_response_bytes(connect_tid, FIXED_CONNECTION_ID),
+            from,
+        )
+        .await
+        .unwrap();
+
+        let (announce, from) = recv_from_mock(&mock).await;
+        let announce_tid = assert_announce_request(&announce, FIXED_CONNECTION_ID, &params);
+        mock.send_to(
+            &error_response_bytes(announce_tid, "banned by tracker"),
+            from,
+        )
+        .await
+        .unwrap();
+
+        match client.await.unwrap() {
+            Err(UdpTrackerError::Message(message)) => {
+                assert_eq!(message, "banned by tracker");
+            }
+            other => panic!("expected tracker message, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn expired_connection_id_reconnects() {
+        tokio::time::pause();
+        let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
+        let url = tracker_url(mock.local_addr().unwrap());
+        let params = sample_params(None);
+        let tracker = std::sync::Arc::new(tokio::sync::Mutex::new(UdpTracker::new(url)));
+
+        let first = {
+            let tracker = tracker.clone();
+            let params = params.clone();
+            tokio::spawn(async move {
+                tracker
+                    .lock()
+                    .await
+                    .announce(&INFO_HASH, &PEER_ID, &params)
+                    .await
+            })
+        };
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(&connect_response_bytes(connect_tid, 1), from)
+            .await
+            .unwrap();
+        let (announce, from) = recv_from_mock(&mock).await;
+        let announce_tid = assert_announce_request(&announce, 1, &params);
+        mock.send_to(&announce_response_v4(announce_tid, 1800, 0, 0, &[]), from)
+            .await
+            .unwrap();
+        first.await.unwrap().expect("first announce");
+
+        tokio::time::advance(Duration::from_secs(61)).await;
+
+        let second = {
+            let tracker = tracker.clone();
+            let params = params.clone();
+            tokio::spawn(async move {
+                tracker
+                    .lock()
+                    .await
+                    .announce(&INFO_HASH, &PEER_ID, &params)
+                    .await
+            })
+        };
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(&connect_response_bytes(connect_tid, 2), from)
+            .await
+            .unwrap();
+
+        let (stale, from) = recv_from_mock(&mock).await;
+        let stale_cid = read_u64_at(&stale, 0);
+        assert_eq!(
+            stale_cid, 2,
+            "client must announce with the fresh connection id"
+        );
+        let announce_tid = assert_announce_request(&stale, 2, &params);
+        mock.send_to(&announce_response_v4(announce_tid, 60, 0, 0, &[]), from)
+            .await
+            .unwrap();
+        second.await.unwrap().expect("second announce");
+    }
+
+    #[tokio::test]
+    async fn server_rejects_old_connection_id_then_client_reconnects() {
+        tokio::time::pause();
+        let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
+        let url = tracker_url(mock.local_addr().unwrap());
+        let params = sample_params(None);
+        let tracker = std::sync::Arc::new(tokio::sync::Mutex::new(UdpTracker::new(url)));
+
+        let first = {
+            let tracker = tracker.clone();
+            let params = params.clone();
+            tokio::spawn(async move {
+                tracker
+                    .lock()
+                    .await
+                    .announce(&INFO_HASH, &PEER_ID, &params)
+                    .await
+            })
+        };
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(&connect_response_bytes(connect_tid, 11), from)
+            .await
+            .unwrap();
+        let (announce, from) = recv_from_mock(&mock).await;
+        let announce_tid = assert_announce_request(&announce, 11, &params);
+        mock.send_to(&announce_response_v4(announce_tid, 1800, 0, 0, &[]), from)
+            .await
+            .unwrap();
+        first.await.unwrap().expect("first announce");
+
+        tokio::time::advance(Duration::from_secs(61)).await;
+
+        let second = {
+            let tracker = tracker.clone();
+            let params = params.clone();
+            tokio::spawn(async move {
+                tracker
+                    .lock()
+                    .await
+                    .announce(&INFO_HASH, &PEER_ID, &params)
+                    .await
+            })
+        };
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(&connect_response_bytes(connect_tid, 22), from)
+            .await
+            .unwrap();
+        let (announce, from) = recv_from_mock(&mock).await;
+        assert_ne!(
+            read_u64_at(&announce, 0),
+            11,
+            "server would reject the expired connection id"
+        );
+        let announce_tid = assert_announce_request(&announce, 22, &params);
+        mock.send_to(&announce_response_v4(announce_tid, 90, 1, 1, &[]), from)
+            .await
+            .unwrap();
+        let got = second.await.unwrap().expect("reconnected announce");
+        assert_eq!(got.interval, 90);
+    }
+
+    #[tokio::test]
+    async fn announce_over_ipv6_parses_18_byte_peers() {
+        let mock = match UdpSocket::bind(SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::LOCALHOST,
+            0,
+            0,
+            0,
+        )))
+        .await
+        {
+            Ok(socket) => socket,
+            Err(_) => return,
+        };
+        let url = tracker_url(mock.local_addr().unwrap());
+        let params = sample_params(Some(AnnounceEvent::Started));
+        let client_params = params.clone();
+        let client = tokio::spawn(async move {
+            let mut tracker = UdpTracker::new(url);
+            tracker.announce(&INFO_HASH, &PEER_ID, &client_params).await
+        });
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(
+            &connect_response_bytes(connect_tid, FIXED_CONNECTION_ID),
+            from,
+        )
+        .await
+        .unwrap();
+
+        let (announce, from) = recv_from_mock(&mock).await;
+        let announce_tid = assert_announce_request(&announce, FIXED_CONNECTION_ID, &params);
+        let peer = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        mock.send_to(
+            &announce_response_v6(announce_tid, 120, 4, 5, &[(peer, 6881)]),
+            from,
+        )
+        .await
+        .unwrap();
+
+        let got = client.await.unwrap().expect("IPv6 announce succeeded");
+        assert_eq!(got.interval, 120);
+        assert_eq!(got.leechers, 4);
+        assert_eq!(got.seeders, 5);
+        assert_eq!(got.peers, vec![SocketAddr::from((peer, 6881))]);
+    }
+
+    #[tokio::test]
+    async fn retransmit_on_dropped_announce() {
+        tokio::time::pause();
+        let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
+        let url = tracker_url(mock.local_addr().unwrap());
+        let params = sample_params(Some(AnnounceEvent::Started));
+        let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+        let client_params = params.clone();
+        let client = tokio::spawn(async move {
+            let mut tracker = UdpTracker::new(url);
+            let result = tracker.announce(&INFO_HASH, &PEER_ID, &client_params).await;
+            let _ = done_tx.send(());
+            result
+        });
+
+        let (connect, from) = recv_from_mock(&mock).await;
+        let connect_tid = assert_connect_request(&connect);
+        mock.send_to(
+            &connect_response_bytes(connect_tid, FIXED_CONNECTION_ID),
+            from,
+        )
+        .await
+        .unwrap();
+
+        let (first, _from) = recv_from_mock(&mock).await;
+        let first_tid = assert_announce_request(&first, FIXED_CONNECTION_ID, &params);
+
+        tokio::time::advance(Duration::from_secs(15)).await;
+
+        let (second, from) = recv_from_mock(&mock).await;
+        let second_tid = assert_announce_request(&second, FIXED_CONNECTION_ID, &params);
+        assert_ne!(
+            first_tid, second_tid,
+            "each request uses a fresh transaction id"
+        );
+        mock.send_to(
+            &announce_response_v4(
+                second_tid,
+                1800,
+                0,
+                0,
+                &[(Ipv4Addr::new(192, 168, 1, 10), 51413)],
+            ),
+            from,
+        )
+        .await
+        .unwrap();
+
+        let got = client.await.unwrap().expect("announce after retransmit");
+        assert!(done_rx.recv().await.is_some());
+        assert_eq!(got.interval, 1800);
+        assert_eq!(
+            got.peers,
+            vec![SocketAddr::from((Ipv4Addr::new(192, 168, 1, 10), 51413))]
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_packets_never_panic() {
+        let cases: &[&[u8]] = &[
+            &[],
+            &[0],
+            &[0; 7],
+            &[0; 8],
+            &[0; 15],
+            &[0; 19],
+            &[0; 21],
+            &[0xff; 3],
+        ];
+        for packet in cases {
+            let _ = parse_connect_response(packet, 1);
+            let _ = parse_announce_response(packet, 1, false);
+            let _ = parse_announce_response(packet, 1, true);
+        }
     }
 }

--- a/crates/bit_rev/src/tracker.rs
+++ b/crates/bit_rev/src/tracker.rs
@@ -12,6 +12,7 @@ use crate::{
     file::{self, AnnounceEvent, AnnounceParams, TorrentMeta},
     peer::BencodeResponse,
     peer_connection::TorrentDownloadedState,
+    protocol_udp::{self, AnnounceLimits, UdpTracker},
     session::DownloadState,
 };
 
@@ -37,6 +38,8 @@ pub enum TrackerError {
     Decode(String),
     #[error("tracker stopped announce timed out")]
     StoppedTimeout,
+    #[error(transparent)]
+    Udp(#[from] protocol_udp::UdpTrackerError),
 }
 
 pub fn http_client() -> reqwest::Client {
@@ -133,6 +136,17 @@ enum Wake {
 pub async fn run_http_announce_loop<F, Fut>(
     ctx: HttpAnnounceContext,
     shutdown: CancellationToken,
+    on_peers: F,
+) where
+    F: FnMut(Vec<std::net::SocketAddr>) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    run_announce_loop(ctx, shutdown, on_peers).await;
+}
+
+pub async fn run_announce_loop<F, Fut>(
+    ctx: HttpAnnounceContext,
+    shutdown: CancellationToken,
     mut on_peers: F,
 ) where
     F: FnMut(Vec<std::net::SocketAddr>) -> Fut,
@@ -143,6 +157,8 @@ pub async fn run_http_announce_loop<F, Fut>(
     let mut tracker_id: Option<Vec<u8>> = None;
     let mut backoff: Option<Duration> = None;
     let mut joined = false;
+    let mut udp = protocol_udp::is_udp_url(&ctx.tracker_url)
+        .then(|| UdpTracker::new(ctx.tracker_url.clone()));
 
     loop {
         if !wait_until_downloading(&ctx.download_state, &shutdown).await {
@@ -155,15 +171,13 @@ pub async fn run_http_announce_loop<F, Fut>(
             sent_completed,
         );
         let params = current_announce_params(&ctx, event, tracker_id.clone());
-        let url =
-            file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, &ctx.tracker_url, &params);
 
         joined = true;
-        let result = announce(&ctx.client, &url).await;
+        let result = dispatch_announce(&ctx, &params, udp.as_mut()).await;
         if shutdown.is_cancelled() {
-            if let Ok(resp) = result {
+            if let Ok(resp) = &result {
                 if let Some(id) = resp.tracker_id.as_ref() {
-                    tracker_id = Some(id.to_vec());
+                    tracker_id = Some(id.clone());
                 }
             }
             break;
@@ -178,21 +192,20 @@ pub async fn run_http_announce_loop<F, Fut>(
                 if event == Some(AnnounceEvent::Completed) {
                     sent_completed = true;
                 }
-                if let Some(id) = resp.tracker_id.as_ref() {
-                    tracker_id = Some(id.to_vec());
+                if let Some(id) = resp.tracker_id {
+                    tracker_id = Some(id);
                 }
-                match resp.get_peers() {
+                match resp.peers {
                     Ok(peers) => on_peers(peers).await,
                     Err(e) => {
                         debug!(
                             tracker = %ctx.tracker_url,
                             error = %e,
-                            "failed to parse peers from HTTP tracker"
+                            "failed to parse peers from tracker"
                         );
                     }
                 }
-                let interval = resp.interval.unwrap_or(DEFAULT_INTERVAL_SECS);
-                let delay = reannounce_delay(interval, resp.min_interval);
+                let delay = reannounce_delay(resp.interval, resp.min_interval);
                 match wait_reannounce(
                     delay,
                     &shutdown,
@@ -206,7 +219,7 @@ pub async fn run_http_announce_loop<F, Fut>(
                 }
             }
             Err(e) => {
-                debug!(tracker = %ctx.tracker_url, error = %e, "HTTP tracker announce failed");
+                debug!(tracker = %ctx.tracker_url, error = %e, "tracker announce failed");
                 let delay = next_backoff(backoff);
                 backoff = Some(delay);
                 match wait_reannounce(
@@ -225,8 +238,42 @@ pub async fn run_http_announce_loop<F, Fut>(
     }
 
     if joined {
-        send_stopped(&ctx, tracker_id).await;
+        send_stopped(&ctx, tracker_id, udp.as_mut()).await;
     }
+}
+
+struct DispatchedAnnounce {
+    peers: Result<Vec<std::net::SocketAddr>, String>,
+    interval: u64,
+    min_interval: Option<u64>,
+    tracker_id: Option<Vec<u8>>,
+}
+
+async fn dispatch_announce(
+    ctx: &HttpAnnounceContext,
+    params: &AnnounceParams,
+    udp: Option<&mut UdpTracker>,
+) -> Result<DispatchedAnnounce, TrackerError> {
+    if let Some(tracker) = udp {
+        let resp = tracker
+            .announce(&ctx.torrent_meta.info_hash, &ctx.peer_id, params)
+            .await?;
+        return Ok(DispatchedAnnounce {
+            peers: Ok(resp.peers),
+            interval: u64::from(resp.interval),
+            min_interval: None,
+            tracker_id: None,
+        });
+    }
+
+    let url = file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, &ctx.tracker_url, params);
+    let resp = announce(&ctx.client, &url).await?;
+    Ok(DispatchedAnnounce {
+        peers: resp.get_peers().map_err(|e| e.to_string()),
+        interval: resp.interval.unwrap_or(DEFAULT_INTERVAL_SECS),
+        min_interval: resp.min_interval,
+        tracker_id: resp.tracker_id.as_ref().map(|id| id.to_vec()),
+    })
 }
 
 fn next_announce_event(
@@ -261,7 +308,11 @@ fn current_announce_params(
     }
 }
 
-async fn send_stopped(ctx: &HttpAnnounceContext, tracker_id: Option<Vec<u8>>) {
+async fn send_stopped(
+    ctx: &HttpAnnounceContext,
+    tracker_id: Option<Vec<u8>>,
+    udp: Option<&mut UdpTracker>,
+) {
     let params = AnnounceParams {
         uploaded: 0,
         downloaded: ctx.torrent_downloaded_state.downloaded_bytes(),
@@ -272,12 +323,29 @@ async fn send_stopped(ctx: &HttpAnnounceContext, tracker_id: Option<Vec<u8>>) {
         key: ctx.announce_key,
         tracker_id,
     };
-    let url = file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, &ctx.tracker_url, &params);
-    if let Err(e) = announce_with_timeout(&ctx.client, &url, STOPPED_TIMEOUT).await {
+    let result = if let Some(tracker) = udp {
+        tracker
+            .announce_with_limits(
+                &ctx.torrent_meta.info_hash,
+                &ctx.peer_id,
+                &params,
+                AnnounceLimits::STOPPED,
+            )
+            .await
+            .map(|_| ())
+            .map_err(TrackerError::from)
+    } else {
+        let url =
+            file::build_tracker_url(&ctx.torrent_meta, &ctx.peer_id, &ctx.tracker_url, &params);
+        announce_with_timeout(&ctx.client, &url, STOPPED_TIMEOUT)
+            .await
+            .map(|_| ())
+    };
+    if let Err(e) = result {
         debug!(
             tracker = %ctx.tracker_url,
             error = %e,
-            "HTTP tracker stopped announce failed"
+            "tracker stopped announce failed"
         );
     }
 }

--- a/crates/bit_rev/src/tracker_peers.rs
+++ b/crates/bit_rev/src/tracker_peers.rs
@@ -1,8 +1,8 @@
 use rand::Rng;
 use std::sync::{atomic::AtomicBool, Arc, Mutex};
-use tokio::{select, sync::Semaphore, time::sleep};
+use tokio::{select, sync::Semaphore};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error};
+use tracing::debug;
 
 use crate::{
     file::TorrentMeta,
@@ -11,7 +11,6 @@ use crate::{
         FullPiece, PeerConnection, PeerHandler, PieceWorkState, TorrentDownloadedState,
     },
     peer_state::PeerStates,
-    protocol_udp::request_udp_peers,
     session::{DownloadState, PieceResult, PieceWork},
     tracker::{self, HttpAnnounceContext, TrackerError},
 };
@@ -84,22 +83,8 @@ impl TrackerPeers {
         let info_hash = self.torrent_meta.info_hash;
         let peer_id = self.peer_id;
 
-        let all_tracker_urls = all_trackers(&self.torrent_meta.clone());
-        let tcp_trackers: Vec<String> = all_tracker_urls
-            .iter()
-            .filter(|t| !t.starts_with("udp://"))
-            .cloned()
-            .collect();
-        let udp_trackers: Vec<String> = all_tracker_urls
-            .iter()
-            .filter(|t| t.starts_with("udp://"))
-            .cloned()
-            .collect();
-
-        debug!(
-            "Connecting to trackers: TCP: {:?}, UDP: {:?}",
-            tcp_trackers, udp_trackers
-        );
+        let all_tracker_urls = all_trackers(&self.torrent_meta);
+        debug!(trackers = ?all_tracker_urls, "connecting to trackers");
         let torrent_meta = self.torrent_meta.clone();
         let peer_states = self.peer_states.clone();
         let piece_tx = self.piece_tx.clone();
@@ -121,7 +106,7 @@ impl TrackerPeers {
                 .collect(),
         });
 
-        for tracker_url in tcp_trackers {
+        for tracker_url in all_tracker_urls {
             let ctx = HttpAnnounceContext {
                 client: http_client.clone(),
                 torrent_meta: torrent_meta.clone(),
@@ -139,7 +124,7 @@ impl TrackerPeers {
             let torrent_downloaded_state = torrent_downloaded_state.clone();
             let shutdown = cancel.clone();
             tokio::spawn(async move {
-                tracker::run_http_announce_loop(ctx, shutdown, |new_peers| {
+                tracker::run_announce_loop(ctx, shutdown, |new_peers| {
                     let peer_states = peer_states.clone();
                     let piece_tx = piece_tx.clone();
                     let have_broadcast = have_broadcast.clone();
@@ -162,74 +147,6 @@ impl TrackerPeers {
                     }
                 })
                 .await;
-            });
-        }
-
-        if !udp_trackers.is_empty() {
-            let udp_cancel = cancel;
-            tokio::spawn(async move {
-                loop {
-                    if udp_cancel.is_cancelled() {
-                        break;
-                    }
-                    while {
-                        let state = *download_state.lock().unwrap();
-                        state != DownloadState::Downloading
-                    } {
-                        if udp_cancel.is_cancelled() {
-                            return;
-                        }
-                        sleep(std::time::Duration::from_millis(100)).await;
-                    }
-
-                    for tracker in udp_trackers.clone() {
-                        let torrent_meta = torrent_meta.clone();
-                        let peer_states = peer_states.clone();
-                        let piece_tx = piece_tx.clone();
-                        let have_broadcast = have_broadcast.clone();
-                        let torrent_downloaded_state = torrent_downloaded_state.clone();
-                        let download_state = download_state.clone();
-                        tokio::spawn(async move {
-                            match request_udp_peers(&tracker, &torrent_meta, &peer_id, 6881).await {
-                                Ok(udp_response) => {
-                                    debug!(
-                                        "Received UDP response from tracker {}: {:?}",
-                                        tracker, udp_response
-                                    );
-                                    let new_peers: Vec<_> = udp_response
-                                        .peers
-                                        .into_iter()
-                                        .map(|p| p.to_socket_addr())
-                                        .collect();
-
-                                    process_peers(
-                                        new_peers,
-                                        PeerProcessorConfig {
-                                            info_hash,
-                                            peer_id,
-                                            peer_states: peer_states.clone(),
-                                            piece_tx: piece_tx.clone(),
-                                            have_broadcast: have_broadcast.clone(),
-                                            torrent_downloaded_state: torrent_downloaded_state
-                                                .clone(),
-                                            download_state: download_state.clone(),
-                                        },
-                                    )
-                                    .await;
-                                }
-                                Err(e) => error!(
-                                    "Failed to request peers from UDP tracker {}: {}",
-                                    tracker, e
-                                ),
-                            }
-                        });
-                    }
-
-                    tokio::select! {
-                        _ = udp_cancel.cancelled() => break,
-                        _ = sleep(std::time::Duration::from_secs(30)) => {}
-                    }
-                }
             });
         }
     }

--- a/crates/bit_rev/tests/tracker_udp.rs
+++ b/crates/bit_rev/tests/tracker_udp.rs
@@ -1,0 +1,375 @@
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+
+use bit_rev::{
+    file::{Info, TorrentFile, TorrentMeta},
+    peer_connection::{PieceWorkState, TorrentDownloadedState},
+    peer_state::PeerStates,
+    session::{DownloadState, PieceWork},
+    tracker::{self, run_announce_loop, HttpAnnounceContext},
+};
+use serde_bytes::ByteBuf;
+use tokio::{
+    net::UdpSocket,
+    sync::{mpsc, Semaphore},
+};
+use tokio_util::sync::CancellationToken;
+
+const INFO_HASH: [u8; 20] = [1u8; 20];
+const PEER_ID: [u8; 20] = *b"-BR0100-0123456789ab";
+const ANNOUNCE_KEY: u32 = 0xDF45_C574;
+const PROTOCOL_ID: u64 = 0x0417_2710_1980;
+const ACTION_CONNECT: u32 = 0;
+const ACTION_ANNOUNCE: u32 = 1;
+const ACTION_ERROR: u32 = 3;
+
+fn test_meta(announce: String) -> TorrentMeta {
+    TorrentMeta {
+        torrent_file: TorrentFile {
+            info: Info {
+                name: "test".into(),
+                pieces: ByteBuf::from(vec![0u8; 20]),
+                piece_length: 16384,
+                md5sum: None,
+                length: Some(16384),
+                files: None,
+                private: None,
+                path: None,
+                root_hash: None,
+            },
+            announce: Some(announce),
+            nodes: None,
+            encoding: None,
+            httpseeds: None,
+            announce_list: None,
+            creation_date: None,
+            comment: None,
+            created_by: None,
+        },
+        info_hash: INFO_HASH,
+        piece_hashes: vec![INFO_HASH],
+    }
+}
+
+fn incomplete_download() -> Arc<TorrentDownloadedState> {
+    Arc::new(TorrentDownloadedState {
+        semaphore: Semaphore::new(1),
+        pieces: vec![PieceWorkState {
+            piece_work: PieceWork {
+                index: 0,
+                length: 16384,
+                hash: INFO_HASH,
+            },
+            chuncks: Mutex::new(vec![]),
+            downloaded: AtomicBool::new(false),
+            reserved: Mutex::new(None),
+        }],
+    })
+}
+
+fn announce_ctx(url: String, download: Arc<TorrentDownloadedState>) -> HttpAnnounceContext {
+    HttpAnnounceContext {
+        client: tracker::http_client(),
+        torrent_meta: test_meta(url.clone()),
+        peer_id: PEER_ID,
+        tracker_url: url,
+        announce_key: ANNOUNCE_KEY,
+        port: 6881,
+        download_state: Arc::new(Mutex::new(DownloadState::Downloading)),
+        torrent_downloaded_state: download,
+    }
+}
+
+fn read_u32(data: &[u8], offset: usize) -> u32 {
+    u32::from_be_bytes(data[offset..offset + 4].try_into().unwrap())
+}
+
+fn read_u64(data: &[u8], offset: usize) -> u64 {
+    u64::from_be_bytes(data[offset..offset + 8].try_into().unwrap())
+}
+
+fn connect_response(transaction_id: u32, connection_id: u64) -> [u8; 16] {
+    let mut data = [0u8; 16];
+    data[0..4].copy_from_slice(&ACTION_CONNECT.to_be_bytes());
+    data[4..8].copy_from_slice(&transaction_id.to_be_bytes());
+    data[8..16].copy_from_slice(&connection_id.to_be_bytes());
+    data
+}
+
+fn announce_response(transaction_id: u32, interval: u32, peer: SocketAddr) -> Vec<u8> {
+    let SocketAddr::V4(peer) = peer else {
+        panic!("test helper expects IPv4 peer");
+    };
+    let mut data = Vec::with_capacity(26);
+    data.extend_from_slice(&ACTION_ANNOUNCE.to_be_bytes());
+    data.extend_from_slice(&transaction_id.to_be_bytes());
+    data.extend_from_slice(&interval.to_be_bytes());
+    data.extend_from_slice(&1u32.to_be_bytes());
+    data.extend_from_slice(&1u32.to_be_bytes());
+    data.extend_from_slice(&peer.ip().octets());
+    data.extend_from_slice(&peer.port().to_be_bytes());
+    data
+}
+
+fn error_response(transaction_id: u32, message: &str) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(&ACTION_ERROR.to_be_bytes());
+    data.extend_from_slice(&transaction_id.to_be_bytes());
+    data.extend_from_slice(message.as_bytes());
+    data
+}
+
+async fn recv(socket: &UdpSocket) -> (Vec<u8>, SocketAddr) {
+    let mut buf = vec![0u8; 512];
+    let (len, from) = socket.recv_from(&mut buf).await.expect("mock recv");
+    (buf[..len].to_vec(), from)
+}
+
+fn assert_connect(data: &[u8]) -> u32 {
+    assert_eq!(data.len(), 16);
+    assert_eq!(&data[0..8], &PROTOCOL_ID.to_be_bytes());
+    assert_eq!(read_u32(data, 8), ACTION_CONNECT);
+    read_u32(data, 12)
+}
+
+struct RecordedAnnounce {
+    event: u32,
+    downloaded: u64,
+    left: u64,
+    uploaded: u64,
+    key: u32,
+    num_want: i32,
+    transaction_id: u32,
+    connection_id: u64,
+}
+
+fn parse_announce(data: &[u8]) -> RecordedAnnounce {
+    assert_eq!(data.len(), 98);
+    assert_eq!(read_u32(data, 8), ACTION_ANNOUNCE);
+    assert_eq!(&data[16..36], &INFO_HASH);
+    assert_eq!(&data[36..56], &PEER_ID);
+    RecordedAnnounce {
+        connection_id: read_u64(data, 0),
+        transaction_id: read_u32(data, 12),
+        downloaded: u64::from_be_bytes(data[56..64].try_into().unwrap()),
+        left: u64::from_be_bytes(data[64..72].try_into().unwrap()),
+        uploaded: u64::from_be_bytes(data[72..80].try_into().unwrap()),
+        event: read_u32(data, 80),
+        key: read_u32(data, 88),
+        num_want: i32::from_be_bytes(data[92..96].try_into().unwrap()),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum AnnounceReply {
+    Peers { interval: u32 },
+    Error,
+}
+
+async fn spawn_udp_mock(
+    replies: Vec<AnnounceReply>,
+) -> (
+    String,
+    mpsc::UnboundedReceiver<RecordedAnnounce>,
+    tokio::task::JoinHandle<()>,
+) {
+    let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .await
+        .unwrap();
+    let addr = socket.local_addr().unwrap();
+    let url = format!("udp://{addr}/announce");
+    let (tx, rx) = mpsc::unbounded_channel();
+    let peer = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 51413));
+    let idx = Arc::new(AtomicUsize::new(0));
+
+    let handle = tokio::spawn(async move {
+        let mut connection_id = 1u64;
+        loop {
+            let (packet, from) = recv(&socket).await;
+            if packet.len() == 16 {
+                let tid = assert_connect(&packet);
+                connection_id += 1;
+                if socket
+                    .send_to(&connect_response(tid, connection_id), from)
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                continue;
+            }
+            if packet.len() != 98 {
+                continue;
+            }
+            let announce = parse_announce(&packet);
+            let i = idx.fetch_add(1, Ordering::SeqCst);
+            let reply = replies
+                .get(i)
+                .copied()
+                .unwrap_or(AnnounceReply::Peers { interval: 1800 });
+            let payload = match reply {
+                AnnounceReply::Peers { interval } => {
+                    announce_response(announce.transaction_id, interval, peer)
+                }
+                AnnounceReply::Error => error_response(announce.transaction_id, "try again later"),
+            };
+            if socket.send_to(&payload, from).await.is_err() {
+                break;
+            }
+            if tx.send(announce).is_err() {
+                break;
+            }
+        }
+    });
+
+    (url, rx, handle)
+}
+
+async fn settle() {
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+}
+
+#[tokio::test]
+async fn announce_loop_round_trips_started_and_interval() {
+    let (url, mut rx, handle) = spawn_udp_mock(vec![AnnounceReply::Peers { interval: 1800 }]).await;
+    let peer_states = Arc::new(PeerStates::default());
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx(url, incomplete_download());
+    let peers_for_loop = peer_states.clone();
+
+    let loop_task = tokio::spawn(async move {
+        run_announce_loop(ctx, loop_shutdown, |peers| {
+            let peer_states = peers_for_loop.clone();
+            async move {
+                for peer in peers {
+                    peer_states.add_if_not_seen(peer);
+                }
+            }
+        })
+        .await;
+    });
+
+    let announce = rx.recv().await.expect("started announce");
+    assert_eq!(announce.event, 2);
+    assert_eq!(announce.downloaded, 0);
+    assert_eq!(announce.left, 16384);
+    assert_eq!(announce.uploaded, 0);
+    assert_eq!(announce.key, ANNOUNCE_KEY);
+    assert_eq!(announce.num_want, 50);
+
+    settle().await;
+    assert_eq!(peer_states.states.len(), 1);
+
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_task).await;
+    handle.abort();
+}
+
+#[tokio::test]
+async fn announce_loop_respects_interval_and_sends_stopped() {
+    tokio::time::pause();
+    let (url, mut rx, handle) = spawn_udp_mock(vec![AnnounceReply::Peers { interval: 1800 }]).await;
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx(url, incomplete_download());
+
+    let loop_task = tokio::spawn(async move {
+        run_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+    });
+
+    let first = rx.recv().await.expect("started announce");
+    assert_eq!(first.event, 2);
+    settle().await;
+
+    tokio::time::advance(Duration::from_secs(1799)).await;
+    settle().await;
+    assert!(rx.try_recv().is_err(), "re-announce sent before interval");
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    let second = rx.recv().await.expect("interval re-announce");
+    assert_eq!(second.event, 0);
+    assert_eq!(second.key, ANNOUNCE_KEY);
+
+    shutdown.cancel();
+    settle().await;
+    let stopped = rx.recv().await.expect("stopped announce");
+    assert_eq!(stopped.event, 3);
+    assert_eq!(stopped.num_want, 0);
+    assert_eq!(stopped.key, ANNOUNCE_KEY);
+
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_task).await;
+    handle.abort();
+}
+
+#[tokio::test]
+async fn announce_loop_retries_error_packet_with_backoff() {
+    tokio::time::pause();
+    let (url, mut rx, handle) = spawn_udp_mock(vec![
+        AnnounceReply::Error,
+        AnnounceReply::Peers { interval: 1800 },
+    ])
+    .await;
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx(url, incomplete_download());
+
+    let loop_task = tokio::spawn(async move {
+        run_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+    });
+
+    let first = rx.recv().await.expect("failed started announce");
+    assert_eq!(first.event, 2);
+    settle().await;
+
+    tokio::time::advance(Duration::from_secs(14)).await;
+    settle().await;
+    assert!(rx.try_recv().is_err(), "retried before backoff elapsed");
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    let retry = rx.recv().await.expect("backoff retry");
+    assert_eq!(retry.event, 2);
+    assert_eq!(retry.key, ANNOUNCE_KEY);
+
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_task).await;
+    handle.abort();
+}
+
+#[tokio::test]
+async fn announce_loop_reuses_connection_id_until_expiry() {
+    let (url, mut rx, handle) = spawn_udp_mock(vec![
+        AnnounceReply::Peers { interval: 1800 },
+        AnnounceReply::Peers { interval: 1800 },
+    ])
+    .await;
+    let shutdown = CancellationToken::new();
+    let loop_shutdown = shutdown.clone();
+    let ctx = announce_ctx(url, incomplete_download());
+
+    let loop_task = tokio::spawn(async move {
+        run_announce_loop(ctx, loop_shutdown, |_| async {}).await;
+    });
+
+    let first = rx.recv().await.expect("started announce");
+    let first_cid = first.connection_id;
+
+    shutdown.cancel();
+    let stopped = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("stopped announce timed out")
+        .expect("stopped announce");
+    assert_eq!(stopped.event, 3);
+    assert_eq!(stopped.connection_id, first_cid);
+
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_task).await;
+    handle.abort();
+}


### PR DESCRIPTION
## Summary

Implements issue #13: complete BEP-0015 UDP tracker protocol, with the same announce lifecycle HTTP already uses.

- Cache `connection_id` per resolved tracker address on a reused UDP socket and treat it as expired after 60s. Fresh random `transaction_id` on every request.
- Retransmit with timeout `15 * 2^n` seconds (n up to 3), cap total wait at ~2 minutes, and re-connect first when a retry happens after the id could have expired.
- Parse `action=3` error packets as a typed `UdpTrackerError::Message`. Ignore (keep waiting) packets that are too short, have the wrong `transaction_id`, or the wrong action. Fuzz-safe slicing, no panics on malformed packets.
- Wire real `downloaded`, `left`, `uploaded`, `event` (0 none / 1 completed / 2 started / 3 stopped), session-stable `key`, and `numwant` from the HTTP announce params.
- Parse IPv4 6-byte and IPv6 18-byte peer entries based on the resolved tracker address family. Reject misaligned peer tails.
- Route `udp://` URLs through the shared periodic announce loop (`started` / interval / `completed` / `stopped`) and the same failure backoff as HTTP.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- In-process `UdpSocket` mock covers 98-byte announce layout, transaction mismatch (ignored), error packets, expired connection id (client re-connects), IPv6 18-byte peers, and retransmit after a dropped packet (`tokio::time::pause`).
- `tests/tracker_udp.rs` covers the announce-loop lifecycle: started counters, interval re-announce, error backoff, stopped on shutdown, and connection-id reuse.

Closes #13