### PR TITLE
feat: add BEP-0027 private torrent support

### DIFF
--- a/crates/bit_rev/src/discovery.rs
+++ b/crates/bit_rev/src/discovery.rs
@@ -1,0 +1,178 @@
+//! Peer discovery source gating (BEP-0027).
+//!
+//! All peer sources register here. Private torrents accept only trackers
+//! listed in the metainfo. DHT, PEX, and LSD must go through this registry
+//! so they stay off for private torrents from day one.
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+/// How a torrent learns about peers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiscoverySource {
+    /// HTTP or UDP tracker URLs from `announce` / `announce-list`.
+    Tracker,
+    /// Mainline DHT (BEP-0005).
+    Dht,
+    /// Peer exchange (BEP-0011).
+    Pex,
+    /// Local service / peer discovery (BEP-0014).
+    Lsd,
+}
+
+impl DiscoverySource {
+    pub const ALL: [Self; 4] = [Self::Tracker, Self::Dht, Self::Pex, Self::Lsd];
+
+    /// Non-tracker sources that BEP-0027 forbids on private torrents.
+    pub const PRIVATE_DISABLED: [Self; 3] = [Self::Dht, Self::Pex, Self::Lsd];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tracker => "tracker",
+            Self::Dht => "DHT",
+            Self::Pex => "PEX",
+            Self::Lsd => "LSD",
+        }
+    }
+
+    pub fn is_tracker(self) -> bool {
+        matches!(self, Self::Tracker)
+    }
+
+    /// Whether this source may be used for a torrent with the given privacy.
+    pub fn allowed_for(self, is_private: bool) -> bool {
+        !is_private || self.is_tracker()
+    }
+}
+
+impl fmt::Display for DiscoverySource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A peer source was refused for a private torrent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceDenied {
+    pub source: DiscoverySource,
+}
+
+impl fmt::Display for SourceDenied {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} is disabled for private torrents (BEP-0027)",
+            self.source
+        )
+    }
+}
+
+impl std::error::Error for SourceDenied {}
+
+/// Single choke point for registering peer discovery sources on a torrent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceRegistry {
+    private: bool,
+    registered: BTreeSet<DiscoverySource>,
+}
+
+impl SourceRegistry {
+    pub fn new(is_private: bool) -> Self {
+        Self {
+            private: is_private,
+            registered: BTreeSet::new(),
+        }
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.private
+    }
+
+    pub fn allows(&self, source: DiscoverySource) -> bool {
+        source.allowed_for(self.private)
+    }
+
+    pub fn allows_dht(&self) -> bool {
+        self.allows(DiscoverySource::Dht)
+    }
+
+    pub fn allows_pex(&self) -> bool {
+        self.allows(DiscoverySource::Pex)
+    }
+
+    pub fn allows_lsd(&self) -> bool {
+        self.allows(DiscoverySource::Lsd)
+    }
+
+    /// Sources BEP-0027 disables when this torrent is private.
+    pub fn disabled_sources(&self) -> &'static [DiscoverySource] {
+        if self.private {
+            &DiscoverySource::PRIVATE_DISABLED
+        } else {
+            &[]
+        }
+    }
+
+    /// Register a source. Private torrents accept only metainfo trackers.
+    pub fn register(&mut self, source: DiscoverySource) -> Result<(), SourceDenied> {
+        if !self.allows(source) {
+            return Err(SourceDenied { source });
+        }
+        self.registered.insert(source);
+        Ok(())
+    }
+
+    pub fn is_registered(&self, source: DiscoverySource) -> bool {
+        self.registered.contains(&source)
+    }
+
+    pub fn registered(&self) -> impl Iterator<Item = DiscoverySource> + '_ {
+        self.registered.iter().copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_registry_accepts_every_source() {
+        let mut registry = SourceRegistry::new(false);
+        assert!(!registry.is_private());
+        assert!(registry.disabled_sources().is_empty());
+        for source in DiscoverySource::ALL {
+            assert!(registry.allows(source), "{source} should be allowed");
+            assert!(registry.register(source).is_ok());
+            assert!(registry.is_registered(source));
+        }
+        assert!(registry.allows_dht());
+        assert!(registry.allows_pex());
+        assert!(registry.allows_lsd());
+    }
+
+    #[test]
+    fn private_registry_refuses_non_tracker_sources() {
+        let mut registry = SourceRegistry::new(true);
+        assert!(registry.is_private());
+        assert_eq!(
+            registry.disabled_sources(),
+            &DiscoverySource::PRIVATE_DISABLED
+        );
+
+        assert!(registry.register(DiscoverySource::Tracker).is_ok());
+        assert!(registry.is_registered(DiscoverySource::Tracker));
+
+        for source in DiscoverySource::PRIVATE_DISABLED {
+            let err = registry
+                .register(source)
+                .expect_err("non-tracker source must be refused");
+            assert_eq!(err, SourceDenied { source });
+            assert!(!registry.is_registered(source));
+            assert!(!registry.allows(source));
+        }
+
+        assert!(!registry.allows_dht());
+        assert!(!registry.allows_pex());
+        assert!(!registry.allows_lsd());
+    }
+}

--- a/crates/bit_rev/src/file.rs
+++ b/crates/bit_rev/src/file.rs
@@ -41,6 +41,13 @@ pub struct Info {
     pub root_hash: Option<String>,
 }
 
+impl Info {
+    /// BEP-0027: `private=1` is private; missing or `0` is public.
+    pub fn is_private(&self) -> bool {
+        matches!(self.private, Some(flag) if flag != 0)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TorrentFile {
     pub info: Info,
@@ -569,6 +576,7 @@ mod tests {
             meta.torrent_file.announce.as_deref(),
             Some("http://bttracker.debian.org:6969/announce")
         );
+        assert!(!info.is_private());
     }
 
     #[test]
@@ -705,6 +713,66 @@ mod tests {
         assert_eq!(
             meta.torrent_file.announce.as_deref(),
             Some("http://tracker.example/announce")
+        );
+    }
+
+    fn fixture_path(name: &str) -> String {
+        format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    #[test]
+    fn from_filename_parses_private_fixture() {
+        const PRIVATE_INFO_HASH_HEX: &str = "f40c245c537eb8d8f3519fe1993632a806b6b571";
+
+        let meta = from_filename(&fixture_path("private.torrent")).expect("parse private fixture");
+        assert_eq!(meta.torrent_file.info.name, "private.bin");
+        assert_eq!(meta.torrent_file.info.private, Some(1));
+        assert!(meta.torrent_file.info.is_private());
+        assert_eq!(meta.info_hash, decode_info_hash(PRIVATE_INFO_HASH_HEX));
+
+        let torrent = crate::torrent::Torrent::new(&meta).expect("torrent");
+        assert!(torrent.is_private());
+        assert!(!torrent.allows_dht());
+        assert!(!torrent.allows_pex());
+        assert!(!torrent.allows_lsd());
+    }
+
+    #[test]
+    fn from_filename_private_zero_is_public() {
+        let meta =
+            from_filename(&fixture_path("private-zero.torrent")).expect("parse private=0 fixture");
+        assert_eq!(meta.torrent_file.info.private, Some(0));
+        assert!(!meta.torrent_file.info.is_private());
+        let torrent = crate::torrent::Torrent::new(&meta).expect("torrent");
+        assert!(!torrent.is_private());
+        assert!(torrent.allows_dht());
+    }
+
+    #[test]
+    fn from_filename_info_hash_includes_unknown_info_keys() {
+        // extra-field and unknown-key live inside info and are not on Info.
+        // Hashing a re-encoded struct would drop them and change the info hash.
+        const EXTRA_INFO_HASH_HEX: &str = "6a90441e947dcc1910191a8a5f710399dbe90d6f";
+
+        let path = fixture_path("extra-info-keys.torrent");
+        let bytes = std::fs::read(&path).expect("read extra-info-keys fixture");
+        let meta = from_bytes(&bytes).expect("parse extra-info-keys fixture");
+
+        assert_eq!(meta.torrent_file.info.name, "tiny.bin");
+        assert!(meta.torrent_file.info.private.is_none());
+        assert!(!meta.torrent_file.info.is_private());
+        assert_eq!(meta.info_hash, decode_info_hash(EXTRA_INFO_HASH_HEX));
+
+        let raw_info = raw_info_dict(&bytes).expect("raw info");
+        let mut hasher = sha1_smol::Sha1::new();
+        hasher.update(raw_info);
+        assert_eq!(meta.info_hash, hasher.digest().bytes());
+
+        let reencoded = ser::to_bytes(&meta.torrent_file.info).expect("re-encode info");
+        assert_ne!(
+            reencoded.as_slice(),
+            raw_info,
+            "re-encoding must drop unknown info keys, proving from_bytes hashes the original bytes"
         );
     }
 }

--- a/crates/bit_rev/src/identity.rs
+++ b/crates/bit_rev/src/identity.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 /// Product name used in HTTP User-Agent and the BEP-0010 handshake `v` field.
 pub const CLIENT_NAME: &str = "bitrev";
 
@@ -50,6 +52,55 @@ fn parse_component(part: Option<&str>) -> u32 {
     part.unwrap_or("0").parse().unwrap_or(0)
 }
 
+/// Random announce `key` (BEP-0003). Stable for one tracker URL, rotated on switch.
+pub fn random_announce_key() -> u32 {
+    rand::thread_rng().gen()
+}
+
+/// Per-tracker announce identity. A new `key` is minted when the URL changes (BEP-0027).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackerIdentity {
+    url: String,
+    key: u32,
+}
+
+impl TrackerIdentity {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            key: random_announce_key(),
+        }
+    }
+
+    pub fn with_key(url: impl Into<String>, key: u32) -> Self {
+        Self {
+            url: url.into(),
+            key,
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub fn key(&self) -> u32 {
+        self.key
+    }
+
+    /// Switch to a different tracker URL and mint a fresh `key`.
+    ///
+    /// Issue #19 (tier fallback) should call this instead of reusing the old key.
+    pub fn switch_url(&mut self, url: impl Into<String>) -> bool {
+        let url = url.into();
+        if url == self.url {
+            return false;
+        }
+        self.url = url;
+        self.key = random_announce_key();
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,5 +120,16 @@ mod tests {
         assert_eq!(azureus_version("0.1.0"), *b"0100");
         assert_eq!(azureus_version("1.2.3"), *b"1230");
         assert_eq!(azureus_version("0.1.0-alpha"), *b"0100");
+    }
+
+    #[test]
+    fn switch_url_mints_a_fresh_key() {
+        let mut identity = TrackerIdentity::with_key("http://a.example/announce", 1);
+        assert!(!identity.switch_url("http://a.example/announce"));
+        assert_eq!(identity.key(), 1);
+
+        assert!(identity.switch_url("http://b.example/announce"));
+        assert_eq!(identity.url(), "http://b.example/announce");
+        assert_ne!(identity.key(), 1);
     }
 }

--- a/crates/bit_rev/src/lib.rs
+++ b/crates/bit_rev/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bitfield;
+pub mod discovery;
 pub mod file;
 pub mod handshake;
 pub mod identity;

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -7,6 +7,7 @@ use crate::tracker_peers::TrackerPeers;
 use crate::utils;
 use dashmap::DashMap;
 use flume::Receiver;
+use tracing::info;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DownloadState {
@@ -147,6 +148,18 @@ impl Session {
         add_torrent: AddTorrentOptions,
     ) -> anyhow::Result<AddTorrentResult> {
         let torrent = Torrent::new(&add_torrent.torrent_meta.clone())?;
+        if torrent.is_private() {
+            let disabled: Vec<&str> = torrent
+                .disabled_discovery_sources()
+                .iter()
+                .map(|source| source.as_str())
+                .collect();
+            info!(
+                name = %torrent.name,
+                disabled = %disabled.join(", "),
+                "private torrent: non-tracker peer sources are disabled"
+            );
+        }
         let torrent_meta = add_torrent.torrent_meta.clone();
         let (pr_tx, pr_rx) = flume::bounded::<PieceResult>(torrent.piece_hashes.len());
         let have_broadcast = Arc::new(tokio::sync::broadcast::channel(128).0);

--- a/crates/bit_rev/src/torrent.rs
+++ b/crates/bit_rev/src/torrent.rs
@@ -1,3 +1,4 @@
+use crate::discovery::{DiscoverySource, SourceRegistry};
 use crate::file::TorrentMeta;
 
 use anyhow::Result;
@@ -10,6 +11,7 @@ pub struct Torrent {
     pub length: i64,
     pub files: Vec<TorrentFileInfo>,
     pub name: String,
+    pub(crate) private: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -60,6 +62,117 @@ impl Torrent {
             length: total_length,
             files,
             name: info.name.clone(),
+            private: info.is_private(),
         })
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.private
+    }
+
+    pub fn allows_source(&self, source: DiscoverySource) -> bool {
+        source.allowed_for(self.private)
+    }
+
+    pub fn allows_dht(&self) -> bool {
+        self.allows_source(DiscoverySource::Dht)
+    }
+
+    pub fn allows_pex(&self) -> bool {
+        self.allows_source(DiscoverySource::Pex)
+    }
+
+    pub fn allows_lsd(&self) -> bool {
+        self.allows_source(DiscoverySource::Lsd)
+    }
+
+    pub fn source_registry(&self) -> SourceRegistry {
+        SourceRegistry::new(self.private)
+    }
+
+    /// Sources that stay off for this torrent (empty when public).
+    pub fn disabled_discovery_sources(&self) -> &'static [DiscoverySource] {
+        self.source_registry().disabled_sources()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file::{File, Info, TorrentFile};
+    use serde_bytes::ByteBuf;
+
+    fn meta_with_private(private: Option<u8>) -> TorrentMeta {
+        TorrentMeta {
+            torrent_file: TorrentFile {
+                info: Info {
+                    name: "test".into(),
+                    pieces: ByteBuf::from(vec![0u8; 20]),
+                    piece_length: 16384,
+                    md5sum: None,
+                    length: Some(16384),
+                    files: None,
+                    private,
+                    path: None,
+                    root_hash: None,
+                },
+                announce: Some("http://tracker.example/announce".into()),
+                nodes: None,
+                encoding: None,
+                httpseeds: None,
+                announce_list: None,
+                creation_date: None,
+                comment: None,
+                created_by: None,
+            },
+            info_hash: [0u8; 20],
+            piece_hashes: vec![[0u8; 20]],
+        }
+    }
+
+    #[test]
+    fn absent_and_zero_private_are_public() {
+        for flag in [None, Some(0)] {
+            let torrent = Torrent::new(&meta_with_private(flag)).expect("torrent");
+            assert!(!torrent.is_private());
+            assert!(torrent.allows_dht());
+            assert!(torrent.allows_pex());
+            assert!(torrent.allows_lsd());
+            assert!(torrent.disabled_discovery_sources().is_empty());
+        }
+    }
+
+    #[test]
+    fn private_flag_disables_non_tracker_sources() {
+        let torrent = Torrent::new(&meta_with_private(Some(1))).expect("torrent");
+        assert!(torrent.is_private());
+        assert!(!torrent.allows_dht());
+        assert!(!torrent.allows_pex());
+        assert!(!torrent.allows_lsd());
+        assert!(torrent.allows_source(DiscoverySource::Tracker));
+        assert_eq!(
+            torrent.disabled_discovery_sources(),
+            &DiscoverySource::PRIVATE_DISABLED
+        );
+
+        let mut registry = torrent.source_registry();
+        assert!(registry.register(DiscoverySource::Tracker).is_ok());
+        assert!(registry.register(DiscoverySource::Dht).is_err());
+        assert!(registry.register(DiscoverySource::Pex).is_err());
+        assert!(registry.register(DiscoverySource::Lsd).is_err());
+    }
+
+    #[test]
+    fn multi_file_layout_preserves_private_flag() {
+        let mut meta = meta_with_private(Some(1));
+        meta.torrent_file.info.length = None;
+        meta.torrent_file.info.files = Some(vec![File {
+            path: vec!["a.bin".into()],
+            length: 4,
+            md5sum: None,
+        }]);
+        let torrent = Torrent::new(&meta).expect("torrent");
+        assert!(torrent.is_private());
+        assert_eq!(torrent.files.len(), 1);
     }
 }

--- a/crates/bit_rev/src/tracker.rs
+++ b/crates/bit_rev/src/tracker.rs
@@ -10,6 +10,7 @@ use tracing::{debug, warn};
 
 use crate::{
     file::{self, AnnounceEvent, AnnounceParams, TorrentMeta},
+    identity::TrackerIdentity,
     peer::BencodeResponse,
     peer_connection::TorrentDownloadedState,
     protocol_udp::{self, AnnounceLimits, UdpTracker},
@@ -125,6 +126,19 @@ pub struct HttpAnnounceContext {
     pub port: u16,
     pub download_state: Arc<Mutex<DownloadState>>,
     pub torrent_downloaded_state: Arc<TorrentDownloadedState>,
+}
+
+impl HttpAnnounceContext {
+    /// Move to a different tracker URL and mint a fresh announce `key` (BEP-0027).
+    pub fn switch_tracker(&mut self, url: impl Into<String>) -> bool {
+        let mut identity = TrackerIdentity::with_key(self.tracker_url.clone(), self.announce_key);
+        let switched = identity.switch_url(url);
+        if switched {
+            self.tracker_url = identity.url().to_string();
+            self.announce_key = identity.key();
+        }
+        switched
+    }
 }
 
 enum Wake {
@@ -437,5 +451,32 @@ mod tests {
         let second = http_client();
         drop((first, second));
         let _ = build_http_client();
+    }
+
+    #[test]
+    fn switch_tracker_rotates_announce_key() {
+        let mut ctx = HttpAnnounceContext {
+            client: build_http_client(),
+            torrent_meta: crate::file::from_bytes(
+                b"d8:announce31:http://tracker.example/announce4:infod6:lengthi4e4:name8:tiny.bin12:piece lengthi16384e6:pieces20:01234567890123456789ee",
+            )
+            .expect("meta"),
+            peer_id: *b"-BR0100-0123456789ab",
+            tracker_url: "http://a.example/announce".into(),
+            announce_key: 42,
+            port: 6881,
+            download_state: Arc::new(Mutex::new(DownloadState::Downloading)),
+            torrent_downloaded_state: Arc::new(TorrentDownloadedState {
+                semaphore: tokio::sync::Semaphore::new(1),
+                pieces: vec![],
+            }),
+        };
+
+        assert!(!ctx.switch_tracker("http://a.example/announce"));
+        assert_eq!(ctx.announce_key, 42);
+
+        assert!(ctx.switch_tracker("http://b.example/announce"));
+        assert_eq!(ctx.tracker_url, "http://b.example/announce");
+        assert_ne!(ctx.announce_key, 42);
     }
 }

--- a/crates/bit_rev/src/tracker_peers.rs
+++ b/crates/bit_rev/src/tracker_peers.rs
@@ -1,11 +1,12 @@
-use rand::Rng;
 use std::sync::{atomic::AtomicBool, Arc, Mutex};
 use tokio::{select, sync::Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use crate::{
+    discovery::{DiscoverySource, SourceDenied, SourceRegistry},
     file::TorrentMeta,
+    identity::TrackerIdentity,
     peer::BencodeResponse,
     peer_connection::{
         FullPiece, PeerConnection, PeerHandler, PieceWorkState, TorrentDownloadedState,
@@ -25,7 +26,7 @@ pub struct TrackerPeers {
     pub pr_rx: flume::Receiver<PieceResult>,
     pub have_broadcast: Arc<tokio::sync::broadcast::Sender<u32>>,
     pub download_state: Arc<Mutex<DownloadState>>,
-    announce_key: u32,
+    sources: Arc<Mutex<SourceRegistry>>,
     cancel: CancellationToken,
 }
 
@@ -40,6 +41,7 @@ impl TrackerPeers {
         download_state: Arc<Mutex<DownloadState>>,
     ) -> TrackerPeers {
         let (sender, receiver) = flume::unbounded();
+        let sources = SourceRegistry::new(torrent_meta.torrent_file.info.is_private());
         TrackerPeers {
             torrent_meta,
             peer_id,
@@ -49,9 +51,17 @@ impl TrackerPeers {
             peer_states,
             have_broadcast,
             download_state,
-            announce_key: rand::thread_rng().gen(),
+            sources: Arc::new(Mutex::new(sources)),
             cancel: CancellationToken::new(),
         }
+    }
+
+    pub fn register_source(&self, source: DiscoverySource) -> Result<(), SourceDenied> {
+        self.sources.lock().unwrap().register(source)
+    }
+
+    pub fn allows_source(&self, source: DiscoverySource) -> bool {
+        self.sources.lock().unwrap().allows(source)
     }
 
     pub fn shutdown(&self) {
@@ -90,7 +100,6 @@ impl TrackerPeers {
         let piece_tx = self.piece_tx.clone();
         let have_broadcast = self.have_broadcast.clone();
         let download_state = self.download_state.clone();
-        let announce_key = self.announce_key;
         let cancel = self.cancel.clone();
         let http_client = tracker::http_client();
         let torrent_downloaded_state = Arc::new(TorrentDownloadedState {
@@ -106,13 +115,20 @@ impl TrackerPeers {
                 .collect(),
         });
 
+        if let Err(denied) = self.register_source(DiscoverySource::Tracker) {
+            debug!(error = %denied, "refused tracker source");
+            return;
+        }
+
         for tracker_url in all_tracker_urls {
+            // One key per tracker URL. Issue #19 should call switch_url on fallback.
+            let identity = TrackerIdentity::new(tracker_url);
             let ctx = HttpAnnounceContext {
                 client: http_client.clone(),
                 torrent_meta: torrent_meta.clone(),
                 peer_id,
-                tracker_url,
-                announce_key,
+                tracker_url: identity.url().to_string(),
+                announce_key: identity.key(),
                 port: 6881,
                 download_state: download_state.clone(),
                 torrent_downloaded_state: torrent_downloaded_state.clone(),
@@ -249,4 +265,48 @@ fn all_trackers(torrent_meta: &TorrentMeta) -> Vec<String> {
 
 pub async fn request_peers(uri: &str) -> Result<BencodeResponse, TrackerError> {
     tracker::announce(&tracker::http_client(), uri).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file::from_filename;
+
+    fn fixture_meta(name: &str) -> TorrentMeta {
+        from_filename(&format!(
+            "{}/tests/fixtures/{name}",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .expect("parse fixture")
+    }
+
+    fn tracker_peers(meta: TorrentMeta) -> TrackerPeers {
+        let (_, pr_rx) = flume::unbounded();
+        TrackerPeers::new(
+            meta,
+            15,
+            *b"-BR0100-0123456789ab",
+            Arc::new(PeerStates::default()),
+            Arc::new(tokio::sync::broadcast::channel(8).0),
+            pr_rx,
+            Arc::new(Mutex::new(DownloadState::Init)),
+        )
+    }
+
+    #[test]
+    fn private_torrent_refuses_non_tracker_source() {
+        let peers = tracker_peers(fixture_meta("private.torrent"));
+        assert!(peers.register_source(DiscoverySource::Tracker).is_ok());
+        assert!(peers.register_source(DiscoverySource::Dht).is_err());
+        assert!(peers.register_source(DiscoverySource::Pex).is_err());
+        assert!(peers.register_source(DiscoverySource::Lsd).is_err());
+        assert!(!peers.allows_source(DiscoverySource::Dht));
+    }
+
+    #[test]
+    fn public_torrent_accepts_dht() {
+        let peers = tracker_peers(fixture_meta("private-zero.torrent"));
+        assert!(peers.register_source(DiscoverySource::Dht).is_ok());
+        assert!(peers.allows_source(DiscoverySource::Dht));
+    }
 }

--- a/crates/bit_rev/src/utils.rs
+++ b/crates/bit_rev/src/utils.rs
@@ -110,6 +110,7 @@ mod tests {
             length: offset,
             files,
             name: "t".into(),
+            private: false,
         }
     }
 

--- a/crates/bit_rev/tests/fixtures/extra-info-keys.torrent
+++ b/crates/bit_rev/tests/fixtures/extra-info-keys.torrent
@@ -1,0 +1,1 @@
+d8:announce31:http://tracker.example/announce4:infod11:extra-field5:hello6:lengthi4e4:name8:tiny.bin12:piece lengthi16384e6:pieces20:0123456789012345678911:unknown-key3:xyzee

--- a/crates/bit_rev/tests/fixtures/private-zero.torrent
+++ b/crates/bit_rev/tests/fixtures/private-zero.torrent
@@ -1,0 +1,1 @@
+d8:announce31:http://tracker.example/announce4:infod6:lengthi4e4:name10:public.bin12:piece lengthi16384e6:pieces20:012345678901234567897:privatei0eee

--- a/crates/bit_rev/tests/fixtures/private.torrent
+++ b/crates/bit_rev/tests/fixtures/private.torrent
@@ -1,0 +1,1 @@
+d8:announce31:http://tracker.example/announce4:infod6:lengthi4e4:name11:private.bin12:piece lengthi16384e6:pieces20:012345678901234567897:privatei1eee


### PR DESCRIPTION
## Summary

Implements issue #17: private torrent support per BEP-0027.

- Parse `info.private` (missing/`0` public, non-zero private) and expose `Torrent::is_private()`, `allows_dht()`, `allows_pex()`, and `allows_lsd()`.
- Hash the original bencoded `info` bytes so extra/unknown keys stay in the info hash. Adding the field to the struct does not change computed hashes.
- Add a single `SourceRegistry` choke point. Private torrents may register only metainfo trackers. DHT (issue #5) can ask `torrent.allows_dht()`.
- Mint a distinct announce `key` per tracker URL. `TrackerIdentity::switch_url` / `HttpAnnounceContext::switch_tracker` rotate the key on URL change for issue #19.
- Log at info when a torrent is private and which sources are disabled (`DHT`, `PEX`, `LSD`).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] New unit tests: private fixture parses with `is_private() == true`; `private=0` stays public; extra info keys keep the raw-bytes info hash; registry refuses DHT/PEX/LSD for private torrents; switching tracker URL rotates `key`.
- Pre-existing `protocol_udp` / `tracker_udp` `tokio::time::pause()` tests can flake on connect vs announce packet size. They fail the same way on clean `main` and are unrelated to this change.

Closes #17