### PR TITLE
feat: add seeding and upload path

### DIFF
--- a/crates/bit_rev/src/bitfield.rs
+++ b/crates/bit_rev/src/bitfield.rs
@@ -8,6 +8,17 @@ impl Bitfield {
         Bitfield { bytes }
     }
 
+    pub fn with_piece_count(count: usize) -> Bitfield {
+        let nbytes = count.div_ceil(8);
+        Bitfield {
+            bytes: vec![0u8; nbytes],
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
     pub fn has_piece(&self, index: usize) -> bool {
         let byte_index = index / 8;
         let offset = index % 8;
@@ -113,5 +124,15 @@ mod tests {
         bitfield.set_piece(0);
         assert!(!bitfield.is_empty());
         assert!(Bitfield::new(vec![]).is_empty());
+    }
+
+    #[test]
+    fn with_piece_count_sizes_and_set() {
+        let mut bitfield = Bitfield::with_piece_count(10);
+        assert_eq!(bitfield.as_bytes().len(), 2);
+        assert!(bitfield.is_empty());
+        bitfield.set_piece(9);
+        assert!(bitfield.has_piece(9));
+        assert!(!bitfield.has_piece(0));
     }
 }

--- a/crates/bit_rev/src/choke.rs
+++ b/crates/bit_rev/src/choke.rs
@@ -1,0 +1,346 @@
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use rand::Rng;
+
+pub const REGULAR_UNCHOKE_SLOTS: usize = 3;
+pub const CHOKE_INTERVAL: Duration = Duration::from_secs(10);
+pub const OPTIMISTIC_INTERVAL: Duration = Duration::from_secs(30);
+pub const NEW_PEER_BIAS_WINDOW: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChokeAction {
+    Choke,
+    Unchoke,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChokePeer {
+    pub addr: SocketAddr,
+    pub peer_interested: bool,
+    pub currently_unchoked: bool,
+    /// Bytes downloaded FROM this peer since the last choke interval (leeching metric).
+    pub download_bytes: u64,
+    pub last_unchoked: Option<Instant>,
+    pub connected_at: Instant,
+    pub is_optimistic: bool,
+}
+
+/// Compute the set of peers that should be unchoked.
+///
+/// - Only interested peers are eligible.
+/// - While `seeding` is false (leeching): pick up to REGULAR_UNCHOKE_SLOTS interested peers
+///   with the highest `download_bytes` (reciprocation). Ties broken by addr for determinism.
+/// - While `seeding` is true: pick up to REGULAR_UNCHOKE_SLOTS interested peers with the
+///   oldest `last_unchoked` (None = never = oldest). Ties broken by addr.
+/// - If `pick_optimistic` is true, add one extra optimistic unchoke chosen uniformly
+///   among remaining choked interested peers, except newly-connected peers
+///   (`now.saturating_duration_since(connected_at) < NEW_PEER_BIAS_WINDOW`) are 3x more
+///   likely (add 3 tickets vs 1). If `pick_optimistic` is false, keep the previous
+///   optimistic peer (the one with `is_optimistic == true`) if they are still interested
+///   and not already in the regular set.
+/// - Uninterested peers are never unchoked.
+pub fn select_unchoked<R: Rng + ?Sized>(
+    peers: &[ChokePeer],
+    seeding: bool,
+    pick_optimistic: bool,
+    now: Instant,
+    rng: &mut R,
+) -> HashSet<SocketAddr> {
+    let mut interested: Vec<&ChokePeer> = peers.iter().filter(|p| p.peer_interested).collect();
+
+    if seeding {
+        interested.sort_by(|a, b| match (a.last_unchoked, b.last_unchoked) {
+            (None, None) => a.addr.cmp(&b.addr),
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (Some(ta), Some(tb)) => ta.cmp(&tb).then(a.addr.cmp(&b.addr)),
+        });
+    } else {
+        interested.sort_by(|a, b| {
+            b.download_bytes
+                .cmp(&a.download_bytes)
+                .then(a.addr.cmp(&b.addr))
+        });
+    }
+
+    let mut unchoked: HashSet<SocketAddr> = interested
+        .iter()
+        .take(REGULAR_UNCHOKE_SLOTS)
+        .map(|p| p.addr)
+        .collect();
+
+    if pick_optimistic {
+        let remaining: Vec<&ChokePeer> = interested
+            .iter()
+            .copied()
+            .filter(|p| !unchoked.contains(&p.addr))
+            .collect();
+        if let Some(addr) = pick_optimistic_peer(&remaining, now, rng) {
+            unchoked.insert(addr);
+        }
+    } else {
+        for peer in &interested {
+            if peer.is_optimistic && !unchoked.contains(&peer.addr) {
+                unchoked.insert(peer.addr);
+            }
+        }
+    }
+
+    unchoked
+}
+
+/// Diff previous unchoked set vs next. Emit Choke for peers that left, Unchoke for peers
+/// that joined. Peers in both sets produce no action. Order: chokes first (sorted by addr),
+/// then unchokes (sorted by addr). This is what "emit choke/unchoke only on transitions"
+/// means, and tests assert exactly one message per change.
+pub fn choke_transitions(
+    previous: &HashSet<SocketAddr>,
+    next: &HashSet<SocketAddr>,
+) -> Vec<(SocketAddr, ChokeAction)> {
+    let mut chokes: Vec<SocketAddr> = previous.difference(next).copied().collect();
+    chokes.sort();
+    let mut unchokes: Vec<SocketAddr> = next.difference(previous).copied().collect();
+    unchokes.sort();
+
+    let mut actions = Vec::with_capacity(chokes.len() + unchokes.len());
+    actions.extend(chokes.into_iter().map(|addr| (addr, ChokeAction::Choke)));
+    actions.extend(
+        unchokes
+            .into_iter()
+            .map(|addr| (addr, ChokeAction::Unchoke)),
+    );
+    actions
+}
+
+fn pick_optimistic_peer<R: Rng + ?Sized>(
+    candidates: &[&ChokePeer],
+    now: Instant,
+    rng: &mut R,
+) -> Option<SocketAddr> {
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let mut tickets = Vec::new();
+    for (i, peer) in candidates.iter().enumerate() {
+        let weight = if now.saturating_duration_since(peer.connected_at) < NEW_PEER_BIAS_WINDOW {
+            3
+        } else {
+            1
+        };
+        tickets.extend(std::iter::repeat_n(i, weight));
+    }
+
+    let chosen = tickets[rng.gen_range(0..tickets.len())];
+    Some(candidates[chosen].addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    fn addr(port: u16) -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], port))
+    }
+
+    fn test_peer(port: u16, download_bytes: u64) -> ChokePeer {
+        ChokePeer {
+            addr: addr(port),
+            peer_interested: true,
+            currently_unchoked: false,
+            download_bytes,
+            last_unchoked: None,
+            connected_at: Instant::now() - Duration::from_secs(120),
+            is_optimistic: false,
+        }
+    }
+
+    fn rng() -> StdRng {
+        StdRng::seed_from_u64(0xC10C4)
+    }
+
+    #[test]
+    fn leeching_unchokes_top_downloaders() {
+        let now = Instant::now();
+        let peers = [
+            test_peer(6881, 10),
+            test_peer(6882, 50),
+            test_peer(6883, 30),
+            test_peer(6884, 5),
+            test_peer(6885, 40),
+        ];
+
+        let unchoked = select_unchoked(&peers, false, false, now, &mut rng());
+
+        assert_eq!(
+            unchoked,
+            HashSet::from([addr(6882), addr(6885), addr(6883)])
+        );
+    }
+
+    #[test]
+    fn seeding_round_robin_oldest_unchoke() {
+        let now = Instant::now();
+        let peers = [
+            ChokePeer {
+                last_unchoked: Some(now - Duration::from_secs(30)),
+                ..test_peer(6881, 0)
+            },
+            ChokePeer {
+                last_unchoked: Some(now - Duration::from_secs(10)),
+                ..test_peer(6882, 0)
+            },
+            ChokePeer {
+                last_unchoked: None,
+                ..test_peer(6883, 0)
+            },
+            ChokePeer {
+                last_unchoked: Some(now - Duration::from_secs(5)),
+                ..test_peer(6884, 0)
+            },
+        ];
+
+        let unchoked = select_unchoked(&peers, true, false, now, &mut rng());
+
+        assert_eq!(
+            unchoked,
+            HashSet::from([addr(6883), addr(6881), addr(6882)])
+        );
+    }
+
+    #[test]
+    fn uninterested_never_unchoked() {
+        let now = Instant::now();
+        let peers = [
+            ChokePeer {
+                peer_interested: false,
+                download_bytes: 1000,
+                ..test_peer(6881, 1000)
+            },
+            test_peer(6882, 10),
+            test_peer(6883, 20),
+            test_peer(6884, 30),
+            test_peer(6885, 5),
+        ];
+
+        let unchoked = select_unchoked(&peers, false, false, now, &mut rng());
+
+        assert_eq!(
+            unchoked,
+            HashSet::from([addr(6884), addr(6883), addr(6882)])
+        );
+        assert!(!unchoked.contains(&addr(6881)));
+    }
+
+    #[test]
+    fn optimistic_added_when_requested() {
+        let now = Instant::now();
+        let peers = [
+            test_peer(6881, 10),
+            test_peer(6882, 50),
+            test_peer(6883, 30),
+            test_peer(6884, 5),
+            test_peer(6885, 40),
+        ];
+        let regular = HashSet::from([addr(6882), addr(6885), addr(6883)]);
+
+        let unchoked = select_unchoked(&peers, false, true, now, &mut rng());
+
+        assert_eq!(unchoked.len(), 4);
+        assert!(regular.is_subset(&unchoked));
+        let extra: Vec<_> = unchoked.difference(&regular).copied().collect();
+        assert_eq!(extra.len(), 1);
+        assert!(extra[0] == addr(6881) || extra[0] == addr(6884));
+    }
+
+    #[test]
+    fn optimistic_kept_when_not_rotating() {
+        let now = Instant::now();
+        let peers = [
+            test_peer(6881, 10),
+            test_peer(6882, 50),
+            test_peer(6883, 30),
+            ChokePeer {
+                is_optimistic: true,
+                currently_unchoked: true,
+                ..test_peer(6884, 5)
+            },
+            test_peer(6885, 40),
+        ];
+
+        let unchoked = select_unchoked(&peers, false, false, now, &mut rng());
+
+        assert_eq!(
+            unchoked,
+            HashSet::from([addr(6882), addr(6885), addr(6883), addr(6884)])
+        );
+    }
+
+    #[test]
+    fn choke_transitions_emit_one_message_per_change() {
+        let a = addr(6881);
+        let b = addr(6882);
+        let c = addr(6883);
+
+        let previous = HashSet::from([a, b]);
+        let next = HashSet::from([b, c]);
+        assert_eq!(
+            choke_transitions(&previous, &next),
+            vec![(a, ChokeAction::Choke), (c, ChokeAction::Unchoke)]
+        );
+
+        assert!(choke_transitions(&previous, &previous).is_empty());
+
+        assert_eq!(
+            choke_transitions(&HashSet::new(), &HashSet::from([a])),
+            vec![(a, ChokeAction::Unchoke)]
+        );
+    }
+
+    #[test]
+    fn no_interested_peers_empty_set() {
+        let now = Instant::now();
+        let peers = [
+            ChokePeer {
+                peer_interested: false,
+                download_bytes: 100,
+                ..test_peer(6881, 100)
+            },
+            ChokePeer {
+                peer_interested: false,
+                download_bytes: 200,
+                is_optimistic: true,
+                ..test_peer(6882, 200)
+            },
+        ];
+
+        let unchoked = select_unchoked(&peers, false, true, now, &mut rng());
+        assert!(unchoked.is_empty());
+
+        let unchoked = select_unchoked(&[], false, true, now, &mut rng());
+        assert!(unchoked.is_empty());
+    }
+
+    #[test]
+    fn fewer_than_slots_unchokes_all_interested() {
+        let now = Instant::now();
+        let peers = [
+            test_peer(6881, 10),
+            test_peer(6882, 20),
+            ChokePeer {
+                peer_interested: false,
+                ..test_peer(6883, 999)
+            },
+        ];
+
+        let unchoked = select_unchoked(&peers, false, false, now, &mut rng());
+        assert_eq!(unchoked, HashSet::from([addr(6881), addr(6882)]));
+
+        let unchoked = select_unchoked(&peers, false, true, now, &mut rng());
+        assert_eq!(unchoked, HashSet::from([addr(6881), addr(6882)]));
+    }
+}

--- a/crates/bit_rev/src/lib.rs
+++ b/crates/bit_rev/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bitfield;
+pub mod choke;
 pub mod discovery;
 pub mod file;
 pub mod handshake;
@@ -10,7 +11,11 @@ pub mod peer_state;
 pub mod protocol;
 pub mod protocol_udp;
 pub mod session;
+pub mod storage;
 pub mod torrent;
 pub mod tracker;
 pub mod tracker_peers;
 pub mod utils;
+
+#[cfg(test)]
+mod seeding_tests;

--- a/crates/bit_rev/src/message.rs
+++ b/crates/bit_rev/src/message.rs
@@ -107,13 +107,80 @@ pub enum MessageError {
     InvalidPayload(String),
 }
 
-pub fn format_request(index: u32, start: u32, length: u32) -> Message {
-    let mut payload = Vec::with_capacity(12);
-    payload.extend_from_slice(&index.to_be_bytes());
-    payload.extend_from_slice(&start.to_be_bytes());
-    payload.extend_from_slice(&length.to_be_bytes());
+pub const MAX_INCOMING_REQUEST_LENGTH: u32 = 128 * 1024;
+pub const MAX_UPLOAD_QUEUE: usize = 8;
 
-    Message::Request(payload)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockRequest {
+    pub index: u32,
+    pub begin: u32,
+    pub length: u32,
+}
+
+impl BlockRequest {
+    pub fn from_payload(payload: &[u8]) -> Option<Self> {
+        if payload.len() < 12 {
+            return None;
+        }
+        Some(Self {
+            index: u32::from_be_bytes(payload[0..4].try_into().ok()?),
+            begin: u32::from_be_bytes(payload[4..8].try_into().ok()?),
+            length: u32::from_be_bytes(payload[8..12].try_into().ok()?),
+        })
+    }
+
+    pub fn to_payload(self) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(12);
+        payload.extend_from_slice(&self.index.to_be_bytes());
+        payload.extend_from_slice(&self.begin.to_be_bytes());
+        payload.extend_from_slice(&self.length.to_be_bytes());
+        payload
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestError {
+    MissingPiece,
+    InvalidLength,
+    OutOfBounds,
+}
+
+pub fn validate_request(
+    req: &BlockRequest,
+    piece_length: u32,
+    have_piece: bool,
+) -> Result<(), RequestError> {
+    if !have_piece {
+        return Err(RequestError::MissingPiece);
+    }
+    if req.length == 0 || req.length > MAX_INCOMING_REQUEST_LENGTH {
+        return Err(RequestError::InvalidLength);
+    }
+    let end = req.begin.checked_add(req.length);
+    match end {
+        Some(end) if end <= piece_length => Ok(()),
+        _ => Err(RequestError::OutOfBounds),
+    }
+}
+
+pub fn format_request(index: u32, start: u32, length: u32) -> Message {
+    Message::Request(
+        BlockRequest {
+            index,
+            begin: start,
+            length,
+        }
+        .to_payload(),
+    )
+}
+
+pub fn format_piece(index: u32, begin: u32, data: Vec<u8>) -> Message {
+    Message::Piece(PieceChunk {
+        index,
+        start: begin,
+        length: data.len() as u32,
+        data,
+    })
 }
 
 pub fn format_have(index: u32) -> Message {
@@ -299,6 +366,86 @@ mod tests {
         let msg = format_request(index, start, length);
 
         assert!(matches!(msg, Message::Request(payload) if payload == expected));
+    }
+
+    #[test]
+    fn block_request_round_trip() {
+        let req = BlockRequest {
+            index: 4,
+            begin: 567,
+            length: 4321,
+        };
+        assert_eq!(BlockRequest::from_payload(&req.to_payload()), Some(req));
+        assert_eq!(BlockRequest::from_payload(&[0u8; 11]), None);
+    }
+
+    #[test]
+    fn validate_request_accepts_in_range() {
+        let req = BlockRequest {
+            index: 0,
+            begin: 0,
+            length: 16 * 1024,
+        };
+        assert_eq!(validate_request(&req, 32 * 1024, true), Ok(()));
+        let last = BlockRequest {
+            index: 0,
+            begin: 16 * 1024,
+            length: 16 * 1024,
+        };
+        assert_eq!(validate_request(&last, 32 * 1024, true), Ok(()));
+    }
+
+    #[test]
+    fn validate_request_rejects_oversized_and_out_of_bounds() {
+        let oversized = BlockRequest {
+            index: 0,
+            begin: 0,
+            length: MAX_INCOMING_REQUEST_LENGTH + 1,
+        };
+        assert_eq!(
+            validate_request(&oversized, 1024 * 1024, true),
+            Err(RequestError::InvalidLength)
+        );
+
+        let zero = BlockRequest {
+            index: 0,
+            begin: 0,
+            length: 0,
+        };
+        assert_eq!(
+            validate_request(&zero, 16 * 1024, true),
+            Err(RequestError::InvalidLength)
+        );
+
+        let past_end = BlockRequest {
+            index: 0,
+            begin: 16 * 1024,
+            length: 1,
+        };
+        assert_eq!(
+            validate_request(&past_end, 16 * 1024, true),
+            Err(RequestError::OutOfBounds)
+        );
+
+        let overflow = BlockRequest {
+            index: 0,
+            begin: u32::MAX,
+            length: 1,
+        };
+        assert_eq!(
+            validate_request(&overflow, u32::MAX, true),
+            Err(RequestError::OutOfBounds)
+        );
+
+        let missing = BlockRequest {
+            index: 3,
+            begin: 0,
+            length: 16,
+        };
+        assert_eq!(
+            validate_request(&missing, 16 * 1024, false),
+            Err(RequestError::MissingPiece)
+        );
     }
 
     #[test]

--- a/crates/bit_rev/src/peer_connection.rs
+++ b/crates/bit_rev/src/peer_connection.rs
@@ -1,6 +1,8 @@
 use std::{
+    collections::VecDeque,
+    future,
     sync::{
-        atomic::{AtomicBool, AtomicU32},
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
         Arc, Mutex,
     },
     time::Duration,
@@ -16,11 +18,13 @@ use tracing::{debug, error, trace};
 
 use crate::{
     bitfield::Bitfield,
-    message::{self, Message, WriterRequest},
+    message::{self, validate_request, BlockRequest, Message, WriterRequest, MAX_UPLOAD_QUEUE},
     peer::PeerAddr,
-    peer_state::{PeerState, PeerStates},
+    peer_state::PeerStates,
     protocol::{Protocol, ProtocolError},
     session::{DownloadState, PieceWork},
+    storage::Storage,
+    torrent::Torrent,
     utils,
 };
 
@@ -50,6 +54,47 @@ impl TorrentDownloadedState {
             .filter(|pw| !pw.downloaded.load(std::sync::atomic::Ordering::Relaxed))
             .map(|pw| u64::from(pw.piece_work.length))
             .sum()
+    }
+
+    pub fn has_piece(&self, index: u32) -> bool {
+        self.pieces
+            .get(index as usize)
+            .map(|pw| pw.downloaded.load(std::sync::atomic::Ordering::Relaxed))
+            .unwrap_or(false)
+    }
+
+    pub fn piece_length(&self, index: u32) -> Option<u32> {
+        self.pieces
+            .get(index as usize)
+            .map(|pw| pw.piece_work.length)
+    }
+
+    pub fn piece_count(&self) -> usize {
+        self.pieces.len()
+    }
+
+    pub fn mark_all_downloaded(&self) {
+        for pw in &self.pieces {
+            pw.downloaded
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    pub fn mark_downloaded(&self, index: u32) {
+        if let Some(pw) = self.pieces.get(index as usize) {
+            pw.downloaded
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    pub fn our_bitfield(&self) -> Bitfield {
+        let mut bitfield = Bitfield::with_piece_count(self.pieces.len());
+        for (i, pw) in self.pieces.iter().enumerate() {
+            if pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
+                bitfield.set_piece(i);
+            }
+        }
+        bitfield
     }
 
     pub fn missing_pieces(&self) -> Vec<u32> {
@@ -231,6 +276,19 @@ impl PieceWorkState {
     }
 }
 
+pub struct PeerHandlerConfig {
+    pub peer: PeerAddr,
+    pub piece_tx: flume::Sender<FullPiece>,
+    pub peer_writer_tx: flume::Sender<WriterRequest>,
+    pub peers_state: Arc<PeerStates>,
+    pub torrent_downloaded_state: Arc<TorrentDownloadedState>,
+    pub download_state: Arc<Mutex<DownloadState>>,
+    pub storage: Arc<Storage>,
+    pub uploaded: Arc<AtomicU64>,
+    pub torrent: Arc<Torrent>,
+    pub choke_notify: Arc<Notify>,
+}
+
 pub struct PeerHandler {
     unchoke_notify: Notify,
     on_bitfield_notify: Notify,
@@ -243,44 +301,32 @@ pub struct PeerHandler {
     peer: PeerAddr,
     torrent_downloaded_state: Arc<TorrentDownloadedState>,
     download_state: Arc<Mutex<DownloadState>>,
+    storage: Arc<Storage>,
+    uploaded: Arc<AtomicU64>,
+    _torrent: Arc<Torrent>,
+    choke_notify: Arc<Notify>,
+    upload_queue: Mutex<VecDeque<BlockRequest>>,
 }
 
 impl PeerHandler {
-    pub fn new(
-        peer: PeerAddr,
-        unchoked_notify: Notify,
-        piece_tx: flume::Sender<FullPiece>,
-        peer_writer_tx: flume::Sender<WriterRequest>,
-        peers_state: Arc<PeerStates>,
-        //pieces: Vec<PieceWork>,
-        torrent_downloaded_state: Arc<TorrentDownloadedState>,
-        download_state: Arc<Mutex<DownloadState>>,
-    ) -> Self {
+    pub fn from_config(config: PeerHandlerConfig) -> Self {
         Self {
-            unchoke_notify: unchoked_notify,
+            unchoke_notify: Notify::new(),
             on_bitfield_notify: Notify::new(),
             downloaded: AtomicU32::new(0),
             chocked: AtomicBool::new(true),
-            peers_state,
+            peers_state: config.peers_state,
             requests_sem: Semaphore::new(0),
-            piece_tx,
-            peer_writer_tx,
-            peer,
-            torrent_downloaded_state,
-            download_state,
-            //torrent_downloaded_state: Arc::new(TorrentDownloadedState {
-            //
-            //    semaphore: Semaphore::new(1),
-            //    pieces: pieces
-            //        .into_iter()
-            //        .map(|pw| PieceWorkState {
-            //            piece_work: pw,
-            //            chuncks: Mutex::new(vec![]),
-            //            downloaded: AtomicBool::new(false),
-            //            reserverd: AtomicBool::new(false),
-            //        })
-            //        .collect(),
-            //}),
+            piece_tx: config.piece_tx,
+            peer_writer_tx: config.peer_writer_tx,
+            peer: config.peer,
+            torrent_downloaded_state: config.torrent_downloaded_state,
+            download_state: config.download_state,
+            storage: config.storage,
+            uploaded: config.uploaded,
+            _torrent: config.torrent,
+            choke_notify: config.choke_notify,
+            upload_queue: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -305,15 +351,113 @@ impl PeerHandler {
         self.get_download_state() == DownloadState::Downloading
     }
 
+    fn peer_has_needed_piece(&self) -> bool {
+        let Some(state) = self.peers_state.states.get(&self.peer) else {
+            return false;
+        };
+        self.torrent_downloaded_state
+            .pieces
+            .iter()
+            .enumerate()
+            .any(|(i, pw)| !pw.downloaded.load(Ordering::Relaxed) && state.bitfield.has_piece(i))
+    }
+
+    fn am_choking(&self) -> bool {
+        self.peers_state
+            .states
+            .get(&self.peer)
+            .map(|s| s.stats.am_choking.load(Ordering::Relaxed))
+            .unwrap_or(true)
+    }
+
+    fn on_incoming_request(&self, payload: Vec<u8>) -> Result<(), anyhow::Error> {
+        let req = BlockRequest::from_payload(&payload)
+            .ok_or_else(|| anyhow::anyhow!("truncated request from peer"))?;
+        let piece_length = self
+            .torrent_downloaded_state
+            .piece_length(req.index)
+            .ok_or_else(|| anyhow::anyhow!("request for unknown piece {}", req.index))?;
+        let have_piece = self.torrent_downloaded_state.has_piece(req.index);
+        validate_request(&req, piece_length, have_piece)
+            .map_err(|e| anyhow::anyhow!("invalid request {:?}: {:?}", req, e))?;
+
+        if self.am_choking() {
+            debug!("ignoring request while choking {:?}", req);
+            return Ok(());
+        }
+
+        let mut queue = self.upload_queue.lock().unwrap();
+        if queue.len() >= MAX_UPLOAD_QUEUE {
+            debug!("upload queue full, dropping request {:?}", req);
+            return Ok(());
+        }
+        queue.push_back(req);
+        drop(queue);
+        if let Some(state) = self.peers_state.states.get(&self.peer) {
+            state.stats.upload_notify.notify_waiters();
+        }
+        Ok(())
+    }
+
+    pub async fn task_peer_uploader(&self) -> Result<(), anyhow::Error> {
+        loop {
+            let stats = self
+                .peers_state
+                .states
+                .get(&self.peer)
+                .map(|s| s.stats.clone());
+            if let Some(stats) = stats {
+                stats.upload_notify.notified().await;
+            } else {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
+
+            loop {
+                if self.am_choking() {
+                    self.upload_queue.lock().unwrap().clear();
+                    break;
+                }
+                let req = self.upload_queue.lock().unwrap().pop_front();
+                let Some(req) = req else {
+                    break;
+                };
+                let data = self
+                    .storage
+                    .read_block(req.index, req.begin, req.length)
+                    .await?;
+                let length = data.len() as u64;
+                if self
+                    .peer_writer_tx
+                    .send(WriterRequest::Message(message::format_piece(
+                        req.index, req.begin, data,
+                    )))
+                    .is_err()
+                {
+                    return Ok(());
+                }
+                self.uploaded.fetch_add(length, Ordering::Relaxed);
+                if let Some(state) = self.peers_state.states.get(&self.peer) {
+                    state
+                        .stats
+                        .bytes_uploaded
+                        .fetch_add(length, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
     // The job of this is to request chunks and also to keep peer alive.
     // The moment this ends, the peer is disconnected.
     pub async fn task_peer_chunk_requester(&self) -> Result<(), anyhow::Error> {
-        let notfied = self.on_bitfield_notify.notified();
-        let user_state = self.peers_state.states.get(&self.peer);
-        if let Some(state) = user_state {
-            if state.bitfield.is_empty() {
-                notfied.await;
-            }
+        let needs_bitfield = self
+            .peers_state
+            .states
+            .get(&self.peer)
+            .map(|state| state.bitfield.is_empty())
+            .unwrap_or(true);
+        if needs_bitfield {
+            self.on_bitfield_notify.notified().await;
         }
 
         let mut update_interest = {
@@ -327,6 +471,9 @@ impl PeerHandler {
                         trace!("sending not interested");
                         WriterRequest::Message(Message::NotInterested)
                     })?;
+                    if let Some(mut state) = h.peers_state.states.get_mut(&h.peer) {
+                        state.set_am_interested(new_value);
+                    }
                     current = new_value;
                 }
                 Ok(())
@@ -334,9 +481,18 @@ impl PeerHandler {
         };
 
         loop {
-            // Wait while not downloading
             while !self.is_downloading() {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+
+            if self.torrent_downloaded_state.is_complete() || !self.peer_has_needed_piece() {
+                update_interest(self, false)?;
+                if self.torrent_downloaded_state.is_complete() {
+                    trace!("torrent complete, staying connected to seed");
+                    future::pending::<()>().await;
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                continue;
             }
 
             update_interest(self, true)?;
@@ -349,8 +505,9 @@ impl PeerHandler {
             trace!("unchoke received");
 
             if self.torrent_downloaded_state.is_complete() {
-                trace!("TORRENT IS COMPLETE");
-                return Ok(());
+                update_interest(self, false)?;
+                trace!("torrent complete, staying connected to seed");
+                future::pending::<()>().await;
             }
 
             let piece = self
@@ -359,8 +516,12 @@ impl PeerHandler {
                 .await;
 
             if piece.is_none() {
-                trace!("no more pieces to download");
-                return Ok(());
+                update_interest(self, false)?;
+                if self.torrent_downloaded_state.is_complete() {
+                    future::pending::<()>().await;
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                continue;
             }
 
             let piece = piece.unwrap().piece_work;
@@ -407,21 +568,33 @@ impl PeerHandler {
         match message {
             Message::Choke => {
                 debug!("peer choked us");
-                self.chocked
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                self.chocked.store(true, Ordering::Relaxed);
+                if let Some(mut state) = self.peers_state.states.get_mut(&self.peer) {
+                    state.set_peer_choking(true);
+                }
             }
             Message::Unchoke => {
                 debug!("peer unchoked us");
-                self.chocked
-                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                self.chocked.store(false, Ordering::Relaxed);
+                if let Some(mut state) = self.peers_state.states.get_mut(&self.peer) {
+                    state.set_peer_choking(false);
+                }
                 self.unchoke_notify.notify_waiters();
                 self.requests_sem.add_permits(128);
             }
             Message::Interested => {
                 debug!("peer is interested");
+                if let Some(mut state) = self.peers_state.states.get_mut(&self.peer) {
+                    state.set_peer_interested(true);
+                }
+                self.choke_notify.notify_waiters();
             }
             Message::NotInterested => {
                 debug!("peer is not interested");
+                if let Some(mut state) = self.peers_state.states.get_mut(&self.peer) {
+                    state.set_peer_interested(false);
+                }
+                self.choke_notify.notify_waiters();
             }
             Message::Have(h) => {
                 let p_state = self.peers_state.states.get_mut(&self.peer);
@@ -433,28 +606,24 @@ impl PeerHandler {
             }
             Message::Bitfield(vec) => {
                 debug!("peer sent bitfield");
-                let p_state = self.peers_state.states.get_mut(&self.peer);
-
-                if let Some(mut ps) = p_state {
+                if let Some(mut ps) = self.peers_state.states.get_mut(&self.peer) {
                     ps.bitfield = Bitfield::new(vec);
-                } else {
-                    self.peers_state.states.insert(
-                        self.peer,
-                        PeerState {
-                            bitfield: Bitfield::new(vec),
-                            peer_interested: false,
-                        },
-                    );
                 }
 
                 self.on_bitfield_notify.notify_waiters();
             }
-            Message::Request(_) => {
-                debug!("peer requested piece, not implemented");
+            Message::Request(payload) => {
+                self.on_incoming_request(payload)?;
             }
             Message::Piece(piece_chunk) => {
                 self.downloaded
-                    .fetch_add(piece_chunk.length, std::sync::atomic::Ordering::Relaxed);
+                    .fetch_add(piece_chunk.length, Ordering::Relaxed);
+                if let Some(state) = self.peers_state.states.get(&self.peer) {
+                    state
+                        .stats
+                        .bytes_downloaded
+                        .fetch_add(piece_chunk.length as u64, Ordering::Relaxed);
+                }
                 self.requests_sem.add_permits(1);
                 self.torrent_downloaded_state.set_chuncks(
                     piece_chunk.index,
@@ -493,9 +662,14 @@ impl PeerHandler {
                     piece_chunk.length
                 );
             }
-            Message::Cancel(_) => {
-                debug!("peer canceled request");
-                //trace!("peer canceled request");
+            Message::Cancel(payload) => {
+                if let Some(req) = BlockRequest::from_payload(&payload) {
+                    self.upload_queue
+                        .lock()
+                        .unwrap()
+                        .retain(|queued| *queued != req);
+                    debug!("peer canceled request {:?}", req);
+                }
             }
             message => {
                 debug!("received unsupported message {:?}, ignoring", message);
@@ -533,7 +707,7 @@ impl PeerConnection {
     pub async fn manage_peer_incoming(
         &self,
         peer_writer_rx: flume::Receiver<WriterRequest>,
-        mut have_broadcast: tokio::sync::broadcast::Receiver<u32>,
+        have_broadcast: tokio::sync::broadcast::Receiver<u32>,
     ) -> anyhow::Result<()> {
         let connect = async {
             TcpStream::connect(self.peer)
@@ -548,10 +722,42 @@ impl PeerConnection {
 
         let protocol = Arc::new(Protocol::connect(self.peer, self.info_hash, self.peer_id).await?);
         let _handshake = protocol.complete_handshake(&mut stream).await?;
-        protocol.send_unchoke(&mut stream).await?;
-        protocol.send_interested(&mut stream).await?;
+        self.send_initial_bitfield(&protocol, &mut stream).await?;
+        self.manage_established(stream, protocol, peer_writer_rx, have_broadcast)
+            .await
+    }
 
-        // manage peer
+    pub async fn manage_incoming_stream(
+        &self,
+        mut stream: TcpStream,
+        peer_writer_rx: flume::Receiver<WriterRequest>,
+        have_broadcast: tokio::sync::broadcast::Receiver<u32>,
+    ) -> anyhow::Result<()> {
+        let protocol = Arc::new(Protocol::connect(self.peer, self.info_hash, self.peer_id).await?);
+        self.send_initial_bitfield(&protocol, &mut stream).await?;
+        self.manage_established(stream, protocol, peer_writer_rx, have_broadcast)
+            .await
+    }
+
+    async fn send_initial_bitfield(
+        &self,
+        protocol: &Protocol,
+        stream: &mut TcpStream,
+    ) -> anyhow::Result<()> {
+        let bitfield = self.handler.torrent_downloaded_state.our_bitfield();
+        if !bitfield.is_empty() {
+            protocol.send_bitfield(stream, bitfield.as_bytes()).await?;
+        }
+        Ok(())
+    }
+
+    async fn manage_established(
+        &self,
+        mut stream: TcpStream,
+        protocol: Arc<Protocol>,
+        peer_writer_rx: flume::Receiver<WriterRequest>,
+        mut have_broadcast: tokio::sync::broadcast::Receiver<u32>,
+    ) -> anyhow::Result<()> {
         let (mut read, mut write) = stream.split();
 
         let writer = {
@@ -657,6 +863,92 @@ impl PeerConnection {
     }
 }
 
+pub struct SpawnPeerParams {
+    pub peer: PeerAddr,
+    pub info_hash: [u8; 20],
+    pub peer_id: [u8; 20],
+    pub piece_tx: flume::Sender<FullPiece>,
+    pub have_broadcast: Arc<tokio::sync::broadcast::Sender<u32>>,
+    pub torrent_downloaded_state: Arc<TorrentDownloadedState>,
+    pub peer_states: Arc<PeerStates>,
+    pub download_state: Arc<Mutex<DownloadState>>,
+    pub storage: Arc<Storage>,
+    pub uploaded: Arc<AtomicU64>,
+    pub torrent: Arc<Torrent>,
+    pub choke_notify: Arc<Notify>,
+    pub incoming: Option<TcpStream>,
+    pub global_peers: Arc<std::sync::atomic::AtomicUsize>,
+    pub max_peers_per_torrent: usize,
+    pub max_peers_global: usize,
+}
+
+pub fn try_spawn_peer(params: SpawnPeerParams) -> bool {
+    let global = params.global_peers.load(Ordering::Relaxed);
+    if global >= params.max_peers_global {
+        debug!(peer = %params.peer, "global connection cap reached");
+        return false;
+    }
+    if params.peer_states.len() >= params.max_peers_per_torrent {
+        debug!(peer = %params.peer, "per-torrent connection cap reached");
+        return false;
+    }
+
+    let (peer_writer_tx, peer_writer_rx) = flume::unbounded();
+    if !params
+        .peer_states
+        .insert_live(params.peer, peer_writer_tx.clone())
+    {
+        return false;
+    }
+    params.global_peers.fetch_add(1, Ordering::Relaxed);
+
+    tokio::spawn(async move {
+        let handler = Arc::new(PeerHandler::from_config(PeerHandlerConfig {
+            peer: params.peer,
+            piece_tx: params.piece_tx,
+            peer_writer_tx,
+            peers_state: params.peer_states.clone(),
+            torrent_downloaded_state: params.torrent_downloaded_state,
+            download_state: params.download_state,
+            storage: params.storage,
+            uploaded: params.uploaded,
+            torrent: params.torrent,
+            choke_notify: params.choke_notify,
+        }));
+        let connection = PeerConnection::new(
+            params.peer,
+            params.info_hash,
+            params.peer_id,
+            handler.clone(),
+        );
+        let requester = handler.task_peer_chunk_requester();
+        let uploader = handler.task_peer_uploader();
+        let have_rx = params.have_broadcast.subscribe();
+        let result = match params.incoming {
+            Some(stream) => {
+                tokio::select! {
+                    r = connection.manage_incoming_stream(stream, peer_writer_rx, have_rx) => r,
+                    r = requester => r,
+                    r = uploader => r,
+                }
+            }
+            None => {
+                tokio::select! {
+                    r = connection.manage_peer_incoming(peer_writer_rx, have_rx) => r,
+                    r = requester => r,
+                    r = uploader => r,
+                }
+            }
+        };
+        if let Err(e) = result {
+            debug!("error managing peer: {:#}", e);
+        }
+        handler.on_peer_died();
+        params.global_peers.fetch_sub(1, Ordering::Relaxed);
+    });
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -752,6 +1044,22 @@ mod tests {
         assert!(s.set_downloaded_if_all_chunks(1).is_some());
         assert!(s.pieces[1].downloaded.load(Ordering::Relaxed));
         assert!(s.is_complete());
+    }
+
+    #[test]
+    fn has_piece_and_bitfield_follow_downloaded_flags() {
+        let s = state(3, 16);
+        assert!(!s.has_piece(0));
+        assert_eq!(s.piece_length(1), Some(16));
+        assert_eq!(s.piece_count(), 3);
+        s.mark_downloaded(1);
+        assert!(s.has_piece(1));
+        let bf = s.our_bitfield();
+        assert!(!bf.has_piece(0));
+        assert!(bf.has_piece(1));
+        s.mark_all_downloaded();
+        assert!(s.is_complete());
+        assert!(s.has_piece(0) && s.has_piece(2));
     }
 
     #[test]

--- a/crates/bit_rev/src/peer_state.rs
+++ b/crates/bit_rev/src/peer_state.rs
@@ -1,8 +1,13 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
 use dashmap::DashMap;
+use tokio::sync::Notify;
 
-use crate::{bitfield::Bitfield, peer::PeerAddr};
+use crate::{bitfield::Bitfield, message::WriterRequest, peer::PeerAddr};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct PeerStates {
     pub states: DashMap<PeerAddr, PeerState>,
 }
@@ -18,22 +23,116 @@ impl PeerStates {
             }
         }
     }
+
+    pub fn insert_live(&self, peer: PeerAddr, writer_tx: flume::Sender<WriterRequest>) -> bool {
+        use dashmap::mapref::entry::Entry;
+        match self.states.entry(peer) {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(entry) => {
+                entry.insert(PeerState::live(writer_tx));
+                true
+            }
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.states.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.states.is_empty()
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct PeerState {
-    /// This is used to track if the peer is interested in us.
     pub peer_interested: bool,
-    /// This is used to track the pieces the peer has.
     pub bitfield: Bitfield,
+    pub am_choking: bool,
+    pub am_interested: bool,
+    pub peer_choking: bool,
+    pub connected_at: Instant,
+    pub last_unchoked: Option<Instant>,
+    pub is_optimistic: bool,
+    pub stats: Arc<PeerLiveStats>,
+    pub writer_tx: Option<flume::Sender<WriterRequest>>,
+}
+
+#[derive(Debug)]
+pub struct PeerLiveStats {
+    pub bytes_downloaded: AtomicU64,
+    pub bytes_uploaded: AtomicU64,
+    pub am_choking: AtomicBool,
+    pub peer_interested: AtomicBool,
+    pub am_interested: AtomicBool,
+    pub peer_choking: AtomicBool,
+    pub upload_notify: Notify,
+}
+
+impl Default for PeerLiveStats {
+    fn default() -> Self {
+        Self {
+            bytes_downloaded: AtomicU64::new(0),
+            bytes_uploaded: AtomicU64::new(0),
+            am_choking: AtomicBool::new(true),
+            peer_interested: AtomicBool::new(false),
+            am_interested: AtomicBool::new(false),
+            peer_choking: AtomicBool::new(true),
+            upload_notify: Notify::new(),
+        }
+    }
 }
 
 impl Default for PeerState {
     fn default() -> Self {
+        Self::live_unwired()
+    }
+}
+
+impl PeerState {
+    fn live_unwired() -> Self {
         Self {
-            peer_interested: true,
+            peer_interested: false,
             bitfield: Bitfield::new(vec![]),
+            am_choking: true,
+            am_interested: false,
+            peer_choking: true,
+            connected_at: Instant::now(),
+            last_unchoked: None,
+            is_optimistic: false,
+            stats: Arc::new(PeerLiveStats::default()),
+            writer_tx: None,
         }
+    }
+
+    pub fn live(writer_tx: flume::Sender<WriterRequest>) -> Self {
+        let mut state = Self::live_unwired();
+        state.writer_tx = Some(writer_tx);
+        state
+    }
+
+    pub fn set_peer_interested(&mut self, interested: bool) {
+        self.peer_interested = interested;
+        self.stats
+            .peer_interested
+            .store(interested, Ordering::Relaxed);
+    }
+
+    pub fn set_am_interested(&mut self, interested: bool) {
+        self.am_interested = interested;
+        self.stats
+            .am_interested
+            .store(interested, Ordering::Relaxed);
+    }
+
+    pub fn set_am_choking(&mut self, choking: bool) {
+        self.am_choking = choking;
+        self.stats.am_choking.store(choking, Ordering::Relaxed);
+    }
+
+    pub fn set_peer_choking(&mut self, choking: bool) {
+        self.peer_choking = choking;
+        self.stats.peer_choking.store(choking, Ordering::Relaxed);
     }
 }
 

--- a/crates/bit_rev/src/protocol.rs
+++ b/crates/bit_rev/src/protocol.rs
@@ -128,6 +128,68 @@ impl Protocol {
             .map_err(ProtocolError::Io)
     }
 
+    pub async fn send_choke(
+        &self,
+        mut stream: impl AsyncWriteExt + Unpin,
+    ) -> Result<(), ProtocolError> {
+        let msg = message::Message::Choke;
+        let msg_bytes = message::serialize(Some(msg));
+        stream
+            .write_all(&msg_bytes)
+            .await
+            .map_err(ProtocolError::Io)
+    }
+
+    pub async fn send_bitfield(
+        &self,
+        mut stream: impl AsyncWriteExt + Unpin,
+        bitfield: &[u8],
+    ) -> Result<(), ProtocolError> {
+        let msg = message::Message::Bitfield(bitfield.to_vec());
+        let msg_bytes = message::serialize(Some(msg));
+        stream
+            .write_all(&msg_bytes)
+            .await
+            .map_err(ProtocolError::Io)
+    }
+
+    pub async fn read_handshake(
+        stream: &mut (impl AsyncReadExt + Unpin),
+    ) -> Result<Handshake, ProtocolError> {
+        let timeout = tokio::time::timeout(Duration::from_secs(HANDSHAKE_TIMEOUT), async {
+            let protocol_str_len_buf = &mut [0u8; 1];
+            stream
+                .read_exact(protocol_str_len_buf)
+                .await
+                .map_err(ProtocolError::Io)?;
+            let protocol_str_len = protocol_str_len_buf[0] as usize;
+            let handshake_bytes = &mut vec![0u8; protocol_str_len + 48];
+            stream
+                .read_exact(handshake_bytes)
+                .await
+                .map_err(ProtocolError::Io)?;
+            Handshake::read(protocol_str_len, handshake_bytes.to_vec())
+                .map_err(ProtocolError::Handshake)
+        })
+        .await;
+
+        match timeout {
+            Ok(Ok(h)) => Ok(h),
+            Ok(Err(e)) => Err(e),
+            Err(e) => Err(ProtocolError::Timeout(e)),
+        }
+    }
+
+    pub async fn write_handshake(
+        stream: &mut (impl AsyncWriteExt + Unpin),
+        handshake: &Handshake,
+    ) -> Result<(), ProtocolError> {
+        stream
+            .write_all(&handshake.serialize())
+            .await
+            .map_err(ProtocolError::Io)
+    }
+
     pub async fn send_have(
         &self,
         mut stream: impl AsyncWriteExt + Unpin,
@@ -293,6 +355,23 @@ mod tests {
         reader.read_exact(&mut buf).await.unwrap();
         assert_eq!(buf, expected);
         assert_eq!(buf[4], message::MessageId::MsgInterested as u8);
+    }
+
+    #[tokio::test]
+    async fn read_write_handshake_round_trip() {
+        let (mut client, mut server) = tokio::io::duplex(128);
+        let expected = Handshake::new(INFO_HASH, REMOTE_PEER_ID);
+        let reply = expected.clone();
+
+        let server_task = tokio::spawn(async move {
+            Protocol::write_handshake(&mut server, &reply)
+                .await
+                .unwrap();
+        });
+
+        let got = Protocol::read_handshake(&mut client).await.unwrap();
+        assert_eq!(got, expected);
+        server_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/bit_rev/src/seeding_tests.rs
+++ b/crates/bit_rev/src/seeding_tests.rs
@@ -1,0 +1,292 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde_bytes::ByteBuf;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use crate::file::{Info, TorrentFile, TorrentMeta};
+use crate::handshake::Handshake;
+use crate::message::{self, BlockRequest, Message, MAX_INCOMING_REQUEST_LENGTH};
+use crate::protocol::Protocol;
+use crate::session::{AddTorrentOptions, Session, SessionOptions};
+use crate::utils;
+
+fn sha1(data: &[u8]) -> [u8; 20] {
+    let mut hasher = sha1_smol::Sha1::new();
+    hasher.update(data);
+    hasher.digest().bytes()
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "bitrev-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn generated_payload(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+fn torrent_meta(name: &str, data: &[u8], piece_length: i64) -> TorrentMeta {
+    let mut pieces = Vec::new();
+    for chunk in data.chunks(piece_length as usize) {
+        pieces.extend_from_slice(&sha1(chunk));
+    }
+    TorrentMeta::new(TorrentFile {
+        info: Info {
+            name: name.into(),
+            pieces: ByteBuf::from(pieces),
+            piece_length,
+            md5sum: None,
+            length: Some(data.len() as i64),
+            files: None,
+            private: None,
+            path: None,
+            root_hash: None,
+        },
+        announce: None,
+        nodes: None,
+        encoding: None,
+        httpseeds: None,
+        announce_list: None,
+        creation_date: None,
+        comment: None,
+        created_by: None,
+    })
+    .expect("torrent meta")
+}
+
+async fn start_seeder(
+    data: &[u8],
+    piece_length: i64,
+) -> (Session, std::net::SocketAddr, TorrentMeta) {
+    let dir = unique_temp_dir("seed");
+    let file_path = dir.join("tiny.bin");
+    std::fs::write(&file_path, data).unwrap();
+    let meta = torrent_meta("tiny.bin", data, piece_length);
+
+    let session = Session::with_options(SessionOptions {
+        listen_port: 0,
+        ..SessionOptions::default()
+    });
+    let addr = tokio::time::timeout(Duration::from_secs(2), session.wait_listening())
+        .await
+        .expect("listener bound");
+
+    session
+        .add_torrent(
+            AddTorrentOptions::from(meta.clone())
+                .output_dir(file_path)
+                .seed(true),
+        )
+        .await
+        .expect("add seeder torrent");
+
+    (session, addr, meta)
+}
+
+async fn handshake_with(
+    addr: std::net::SocketAddr,
+    info_hash: [u8; 20],
+    peer_id: [u8; 20],
+) -> (TcpStream, Protocol) {
+    let mut stream = TcpStream::connect(addr).await.expect("connect seeder");
+    let local = Handshake::new(info_hash, peer_id);
+    stream.write_all(&local.serialize()).await.unwrap();
+    let proto = Protocol::connect(addr, info_hash, peer_id).await.unwrap();
+    let reply = Protocol::read_handshake(&mut stream).await.unwrap();
+    assert_eq!(reply.info_hash, info_hash);
+    (stream, proto)
+}
+
+async fn write_msg(stream: &mut TcpStream, msg: Message) {
+    stream
+        .write_all(&message::serialize(Some(msg)))
+        .await
+        .unwrap();
+}
+
+async fn drain_until_bitfield(proto: &Protocol, stream: &mut TcpStream) {
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(2), proto.read(&mut *stream))
+            .await
+            .expect("bitfield timeout")
+            .expect("bitfield read");
+        match msg {
+            Some(Message::Bitfield(_)) => return,
+            Some(Message::KeepAlive) | None => continue,
+            Some(other) => panic!("expected bitfield first, got {other:?}"),
+        }
+    }
+}
+
+async fn expect_disconnect(proto: &Protocol, stream: &mut TcpStream) {
+    let result = tokio::time::timeout(Duration::from_secs(2), proto.read(&mut *stream)).await;
+    match result {
+        Ok(Ok(None)) | Ok(Err(_)) | Err(_) => {}
+        Ok(Ok(Some(msg))) => panic!("expected disconnect, got {msg:?}"),
+    }
+}
+
+#[tokio::test]
+async fn seeder_serves_full_torrent_to_in_process_leecher() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(40_000);
+    let (session, addr, meta) = start_seeder(&data, PIECE_LEN).await;
+    let info_hash = meta.info_hash;
+    let peer_id = *b"-LC0001-0123456789ab";
+
+    let (mut stream, proto) = handshake_with(addr, info_hash, peer_id).await;
+
+    let mut have = vec![false; meta.piece_hashes.len()];
+    let mut unchoked = false;
+    let mut requested = false;
+    let mut assembled = vec![0u8; data.len()];
+    let mut received = 0usize;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+
+    while received < data.len() {
+        if tokio::time::Instant::now() > deadline {
+            panic!("leecher timed out after {received} bytes");
+        }
+        let msg = tokio::time::timeout(Duration::from_secs(2), proto.read(&mut stream))
+            .await
+            .expect("read timeout")
+            .expect("read error");
+        let Some(msg) = msg else {
+            continue;
+        };
+        match msg {
+            Message::Bitfield(bytes) => {
+                let bf = crate::bitfield::Bitfield::new(bytes);
+                for (i, slot) in have.iter_mut().enumerate() {
+                    *slot = bf.has_piece(i);
+                }
+            }
+            Message::Have(index) => {
+                if let Some(slot) = have.get_mut(index as usize) {
+                    *slot = true;
+                }
+            }
+            Message::Unchoke => {
+                unchoked = true;
+            }
+            Message::Piece(chunk) => {
+                let start = chunk.index as usize * PIECE_LEN as usize + chunk.start as usize;
+                assembled[start..start + chunk.data.len()].copy_from_slice(&chunk.data);
+                received += chunk.data.len();
+            }
+            Message::Choke => {
+                unchoked = false;
+            }
+            _ => {}
+        }
+
+        if have.iter().any(|h| *h) && !requested {
+            write_msg(&mut stream, Message::Interested).await;
+        }
+        if unchoked && !requested {
+            let mut offset = 0u32;
+            let total = data.len() as u32;
+            let mut index = 0u32;
+            while offset < total {
+                let piece_start = index * PIECE_LEN as u32;
+                let piece_len = utils::calculate_piece_size(
+                    &crate::torrent::Torrent::new(&meta).unwrap(),
+                    index as usize,
+                ) as u32;
+                let mut begin = 0u32;
+                while begin < piece_len {
+                    let length = utils::calculate_block_size(piece_len, begin);
+                    write_msg(&mut stream, message::format_request(index, begin, length)).await;
+                    begin += length;
+                    offset = piece_start + begin;
+                }
+                index += 1;
+            }
+            requested = true;
+        }
+    }
+
+    assert_eq!(assembled, data);
+    for (i, hash) in meta.piece_hashes.iter().enumerate() {
+        let start = i * PIECE_LEN as usize;
+        let end = (start + PIECE_LEN as usize).min(data.len());
+        assert!(utils::check_integrity(hash, &assembled[start..end]));
+    }
+    assert!(
+        session.uploaded() >= data.len() as u64,
+        "uploaded counter should grow, got {}",
+        session.uploaded()
+    );
+    assert_eq!(
+        session.torrent_uploaded(&info_hash),
+        Some(session.uploaded())
+    );
+}
+
+#[tokio::test]
+async fn seeder_disconnects_on_oversized_request() {
+    let data = generated_payload(16_384);
+    let (session, addr, meta) = start_seeder(&data, 16_384).await;
+    let (mut stream, proto) = handshake_with(addr, meta.info_hash, *b"-LC0001-oversize0001").await;
+    drain_until_bitfield(&proto, &mut stream).await;
+
+    write_msg(
+        &mut stream,
+        message::format_request(0, 0, MAX_INCOMING_REQUEST_LENGTH + 1),
+    )
+    .await;
+
+    expect_disconnect(&proto, &mut stream).await;
+    drop(session);
+}
+
+#[tokio::test]
+async fn seeder_disconnects_on_out_of_bounds_request() {
+    let data = generated_payload(16_384);
+    let (session, addr, meta) = start_seeder(&data, 16_384).await;
+    let (mut stream, proto) = handshake_with(addr, meta.info_hash, *b"-LC0001-outofbound01").await;
+    drain_until_bitfield(&proto, &mut stream).await;
+
+    write_msg(
+        &mut stream,
+        Message::Request(
+            BlockRequest {
+                index: 0,
+                begin: 16_384,
+                length: 1,
+            }
+            .to_payload(),
+        ),
+    )
+    .await;
+
+    expect_disconnect(&proto, &mut stream).await;
+    drop(session);
+}
+
+#[tokio::test]
+async fn incoming_unknown_info_hash_is_closed() {
+    let data = generated_payload(16_384);
+    let (session, addr, _meta) = start_seeder(&data, 16_384).await;
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let hs = Handshake::new([0xABu8; 20], *b"-LC0001-unknown00001");
+    stream.write_all(&hs.serialize()).await.unwrap();
+
+    let mut buf = [0u8; 1];
+    let result = tokio::time::timeout(Duration::from_secs(2), stream.read_exact(&mut buf)).await;
+    assert!(
+        matches!(result, Ok(Err(_)) | Err(_) | Ok(Ok(0))),
+        "unknown hash should close, got {result:?}"
+    );
+    drop(session);
+}

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -1,13 +1,26 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::file::{self, TorrentMeta};
+use crate::handshake::Handshake;
+use crate::peer_connection::{
+    try_spawn_peer, PieceWorkState, SpawnPeerParams, TorrentDownloadedState,
+};
 use crate::peer_state::PeerStates;
+use crate::protocol::Protocol;
+use crate::storage::Storage;
 use crate::torrent::Torrent;
 use crate::tracker_peers::TrackerPeers;
 use crate::utils;
 use dashmap::DashMap;
 use flume::Receiver;
-use tracing::info;
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DownloadState {
@@ -27,7 +40,41 @@ pub struct PieceWork {
 pub struct PieceResult {
     pub index: u32,
     pub length: u32,
-    pub buf: Vec<u8>,
+}
+
+pub const DEFAULT_LISTEN_PORT: u16 = 6881;
+pub const DEFAULT_MAX_PEERS_PER_TORRENT: usize = 55;
+pub const DEFAULT_MAX_PEERS_GLOBAL: usize = 200;
+
+#[derive(Debug, Clone)]
+pub struct SessionOptions {
+    pub listen_port: u16,
+    pub max_peers_per_torrent: usize,
+    pub max_peers_global: usize,
+}
+
+impl Default for SessionOptions {
+    fn default() -> Self {
+        Self {
+            listen_port: DEFAULT_LISTEN_PORT,
+            max_peers_per_torrent: DEFAULT_MAX_PEERS_PER_TORRENT,
+            max_peers_global: DEFAULT_MAX_PEERS_GLOBAL,
+        }
+    }
+}
+
+pub struct TorrentSession {
+    pub tracker: TrackerPeers,
+    pub storage: Arc<Storage>,
+    pub downloaded_state: Arc<TorrentDownloadedState>,
+    pub peer_states: Arc<PeerStates>,
+    pub piece_tx: flume::Sender<crate::peer_connection::FullPiece>,
+    pub have_broadcast: Arc<tokio::sync::broadcast::Sender<u32>>,
+    pub download_state: Arc<Mutex<DownloadState>>,
+    pub uploaded: Arc<AtomicU64>,
+    pub torrent: Arc<Torrent>,
+    pub torrent_meta: TorrentMeta,
+    pub choke_notify: Arc<Notify>,
 }
 
 #[derive(Debug, Clone)]
@@ -38,23 +85,43 @@ pub struct State {
 }
 
 pub struct Session {
-    pub streams: DashMap<[u8; 20], TrackerPeers>,
+    pub torrents: Arc<DashMap<[u8; 20], Arc<TorrentSession>>>,
     pub download_state: Arc<Mutex<DownloadState>>,
     peer_id: [u8; 20],
+    options: SessionOptions,
+    listen_addr: Arc<Mutex<Option<SocketAddr>>>,
+    global_peers: Arc<AtomicUsize>,
+    cancel: CancellationToken,
 }
 
 pub struct AddTorrentOptions {
     torrent_meta: TorrentMeta,
+    output_dir: Option<PathBuf>,
+    seed: bool,
 }
 
 impl AddTorrentOptions {
     fn from_meta(torrent_meta: TorrentMeta) -> Self {
-        Self { torrent_meta }
+        Self {
+            torrent_meta,
+            output_dir: None,
+            seed: false,
+        }
     }
 
     fn from_path(path: &str) -> Self {
         let torrent_meta = file::from_filename(path).unwrap();
-        Self { torrent_meta }
+        Self::from_meta(torrent_meta)
+    }
+
+    pub fn output_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.output_dir = Some(dir.into());
+        self
+    }
+
+    pub fn seed(mut self, seed: bool) -> Self {
+        self.seed = seed;
+        self
     }
 }
 
@@ -78,11 +145,120 @@ pub struct AddTorrentResult {
 
 impl Session {
     pub fn new() -> Self {
-        Self {
-            streams: DashMap::new(),
+        Self::with_options(SessionOptions::default())
+    }
+
+    pub fn with_options(options: SessionOptions) -> Self {
+        let session = Self {
+            torrents: Arc::new(DashMap::new()),
             download_state: Arc::new(Mutex::new(DownloadState::Init)),
             peer_id: utils::generate_peer_id(),
+            options,
+            listen_addr: Arc::new(Mutex::new(None)),
+            global_peers: Arc::new(AtomicUsize::new(0)),
+            cancel: CancellationToken::new(),
+        };
+        session.spawn_listener();
+        session
+    }
+
+    pub fn listen_port(&self) -> u16 {
+        self.listen_addr
+            .lock()
+            .unwrap()
+            .map(|addr| addr.port())
+            .unwrap_or(self.options.listen_port)
+    }
+
+    pub async fn wait_listening(&self) -> SocketAddr {
+        loop {
+            if let Some(addr) = *self.listen_addr.lock().unwrap() {
+                return addr;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
+    }
+
+    pub fn uploaded(&self) -> u64 {
+        self.torrents
+            .iter()
+            .map(|entry| entry.value().uploaded.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub fn torrent_uploaded(&self, info_hash: &[u8; 20]) -> Option<u64> {
+        self.torrents
+            .get(info_hash)
+            .map(|entry| entry.uploaded.load(Ordering::Relaxed))
+    }
+
+    pub fn options(&self) -> &SessionOptions {
+        &self.options
+    }
+
+    pub fn peer_id(&self) -> [u8; 20] {
+        self.peer_id
+    }
+
+    fn spawn_listener(&self) {
+        let port = self.options.listen_port;
+        let torrents = self.torrents.clone();
+        let peer_id = self.peer_id;
+        let listen_addr = self.listen_addr.clone();
+        let global_peers = self.global_peers.clone();
+        let cancel = self.cancel.clone();
+        let max_peers_per_torrent = self.options.max_peers_per_torrent;
+        let max_peers_global = self.options.max_peers_global;
+
+        tokio::spawn(async move {
+            let bind_addr = SocketAddr::from(([0, 0, 0, 0], port));
+            let listener = match TcpListener::bind(bind_addr).await {
+                Ok(listener) => listener,
+                Err(e) => {
+                    warn!(port, error = %e, "failed to bind listen port");
+                    return;
+                }
+            };
+            match listener.local_addr() {
+                Ok(addr) => {
+                    info!(%addr, "listening for incoming peers");
+                    *listen_addr.lock().unwrap() = Some(addr);
+                }
+                Err(e) => {
+                    warn!(error = %e, "failed to read listen address");
+                    return;
+                }
+            }
+
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    accepted = listener.accept() => {
+                        let (stream, addr) = match accepted {
+                            Ok(pair) => pair,
+                            Err(e) => {
+                                debug!(error = %e, "accept failed");
+                                continue;
+                            }
+                        };
+                        let torrents = torrents.clone();
+                        let global_peers = global_peers.clone();
+                        tokio::spawn(async move {
+                            handle_incoming(
+                                stream,
+                                addr,
+                                peer_id,
+                                torrents,
+                                global_peers,
+                                max_peers_per_torrent,
+                                max_peers_global,
+                            )
+                            .await;
+                        });
+                    }
+                }
+            }
+        });
     }
 
     pub fn start_downloading(&self) {
@@ -90,8 +266,11 @@ impl Session {
             let mut state = self.download_state.lock().unwrap();
             *state = DownloadState::Downloading;
         }
-        for entry in self.streams.iter() {
-            entry.value().set_download_state(DownloadState::Downloading);
+        for entry in self.torrents.iter() {
+            entry
+                .value()
+                .tracker
+                .set_download_state(DownloadState::Downloading);
         }
     }
 
@@ -100,8 +279,11 @@ impl Session {
             let mut state = self.download_state.lock().unwrap();
             *state = DownloadState::Paused;
         }
-        for entry in self.streams.iter() {
-            entry.value().set_download_state(DownloadState::Paused);
+        for entry in self.torrents.iter() {
+            entry
+                .value()
+                .tracker
+                .set_download_state(DownloadState::Paused);
         }
     }
 
@@ -110,8 +292,11 @@ impl Session {
             let mut state = self.download_state.lock().unwrap();
             *state = DownloadState::Downloading;
         }
-        for entry in self.streams.iter() {
-            entry.value().set_download_state(DownloadState::Downloading);
+        for entry in self.torrents.iter() {
+            entry
+                .value()
+                .tracker
+                .set_download_state(DownloadState::Downloading);
         }
     }
 
@@ -132,14 +317,15 @@ impl Session {
     }
 
     pub fn shutdown(&self) {
-        for entry in self.streams.iter() {
-            entry.value().shutdown();
+        self.cancel.cancel();
+        for entry in self.torrents.iter() {
+            entry.value().tracker.shutdown();
         }
     }
 
     pub fn remove_torrent(&self, info_hash: &[u8; 20]) {
-        if let Some((_, tracker)) = self.streams.remove(info_hash) {
-            tracker.shutdown();
+        if let Some((_, torrent)) = self.torrents.remove(info_hash) {
+            torrent.tracker.shutdown();
         }
     }
 
@@ -160,63 +346,290 @@ impl Session {
                 "private torrent: non-tracker peer sources are disabled"
             );
         }
+        let torrent = Arc::new(torrent);
         let torrent_meta = add_torrent.torrent_meta.clone();
-        let (pr_tx, pr_rx) = flume::bounded::<PieceResult>(torrent.piece_hashes.len());
+        let output_dir = add_torrent
+            .output_dir
+            .unwrap_or_else(|| PathBuf::from(&torrent.name));
+        let storage = Storage::open(&torrent, &output_dir).await?;
+
+        let (pr_tx, pr_rx) = flume::bounded::<PieceResult>(torrent.piece_hashes.len().max(1));
         let have_broadcast = Arc::new(tokio::sync::broadcast::channel(128).0);
         let peer_states = Arc::new(PeerStates::default());
+        let uploaded = Arc::new(AtomicU64::new(0));
+        let choke_notify = Arc::new(Notify::new());
+
+        let pieces_of_work = (0..torrent.piece_hashes.len())
+            .map(|index| {
+                let length = utils::calculate_piece_size(&torrent, index);
+                PieceWork {
+                    index: index as u32,
+                    length: length as u32,
+                    hash: torrent.piece_hashes[index],
+                }
+            })
+            .collect::<Vec<PieceWork>>();
+
+        let downloaded_state = Arc::new(TorrentDownloadedState {
+            semaphore: Semaphore::new(1),
+            pieces: pieces_of_work
+                .into_iter()
+                .map(|pw| PieceWorkState {
+                    piece_work: pw,
+                    chuncks: Mutex::new(vec![]),
+                    downloaded: std::sync::atomic::AtomicBool::new(false),
+                    reserved: Mutex::new(None),
+                })
+                .collect(),
+        });
+        if add_torrent.seed {
+            downloaded_state.mark_all_downloaded();
+        }
+
         let tracker_stream = TrackerPeers::new(
             torrent_meta.clone(),
             15,
             self.peer_id,
-            peer_states,
+            peer_states.clone(),
             have_broadcast.clone(),
             pr_rx.clone(),
             self.download_state.clone(),
         );
 
-        let pieces_of_work = (0..(torrent.piece_hashes.len()) as u64)
-            .map(|index| {
-                let length = utils::calculate_piece_size(&torrent, index as usize);
-                PieceWork {
-                    index: index as u32,
-                    length: length as u32,
-                    hash: torrent.piece_hashes[index as usize],
-                }
+        let listen_port =
+            tokio::time::timeout(std::time::Duration::from_millis(250), self.wait_listening())
+                .await
+                .map(|addr| addr.port())
+                .unwrap_or_else(|_| self.listen_port());
+        tracker_stream
+            .connect(crate::tracker_peers::PeerSpawnRuntime {
+                info_hash: torrent.info_hash,
+                peer_id: self.peer_id,
+                storage: storage.clone(),
+                downloaded_state: downloaded_state.clone(),
+                uploaded: uploaded.clone(),
+                torrent: torrent.clone(),
+                choke_notify: choke_notify.clone(),
+                global_peers: self.global_peers.clone(),
+                max_peers_per_torrent: self.options.max_peers_per_torrent,
+                max_peers_global: self.options.max_peers_global,
+                listen_port,
             })
-            .collect::<Vec<PieceWork>>();
+            .await;
 
-        tracker_stream.connect(pieces_of_work).await;
+        spawn_choke_loop(
+            peer_states.clone(),
+            downloaded_state.clone(),
+            choke_notify.clone(),
+            tracker_stream.cancel_token(),
+        );
 
-        let have_broadcast = have_broadcast.clone();
+        let have_broadcast_writer = have_broadcast.clone();
         let piece_rx = tracker_stream.piece_rx.clone();
-
+        let storage_writer = storage.clone();
+        let downloaded_writer = downloaded_state.clone();
         tokio::spawn(async move {
             loop {
-                let pr_tx = pr_tx.clone();
-                let piece_rx = piece_rx.clone();
-                let piece = piece_rx.recv_async().await.unwrap();
-                have_broadcast.send(piece.index).unwrap();
-
-                let pr = PieceResult {
-                    index: piece.index,
-                    length: piece.length,
-                    buf: piece.buf,
+                let piece = match piece_rx.recv_async().await {
+                    Ok(piece) => piece,
+                    Err(_) => break,
                 };
-                pr_tx.send_async(pr).await.unwrap();
+                if let Err(e) = storage_writer.write_piece(piece.index, &piece.buf).await {
+                    debug!(index = piece.index, error = %e, "failed to write piece");
+                    downloaded_writer.remove_downloaded(piece.index);
+                    continue;
+                }
+                let _ = have_broadcast_writer.send(piece.index);
+                if pr_tx
+                    .send_async(PieceResult {
+                        index: piece.index,
+                        length: piece.length,
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
             }
         });
 
-        self.streams
-            .insert(torrent.info_hash, tracker_stream.clone());
+        let piece_tx = tracker_stream.piece_tx.clone();
+        self.torrents.insert(
+            torrent.info_hash,
+            Arc::new(TorrentSession {
+                tracker: tracker_stream,
+                storage,
+                downloaded_state,
+                peer_states,
+                piece_tx,
+                have_broadcast,
+                download_state: self.download_state.clone(),
+                uploaded,
+                torrent: torrent.clone(),
+                torrent_meta: torrent_meta.clone(),
+                choke_notify,
+            }),
+        );
 
-        // Start downloading
         self.start_downloading();
 
         Ok(AddTorrentResult {
-            torrent,
+            torrent: (*torrent).clone(),
             torrent_meta,
             pr_rx,
         })
+    }
+}
+
+async fn handle_incoming(
+    mut stream: tokio::net::TcpStream,
+    addr: SocketAddr,
+    peer_id: [u8; 20],
+    torrents: Arc<DashMap<[u8; 20], Arc<TorrentSession>>>,
+    global_peers: Arc<AtomicUsize>,
+    max_peers_per_torrent: usize,
+    max_peers_global: usize,
+) {
+    let handshake = match Protocol::read_handshake(&mut stream).await {
+        Ok(handshake) => handshake,
+        Err(e) => {
+            debug!(%addr, error = %e, "incoming handshake failed");
+            return;
+        }
+    };
+    let Some(torrent) = torrents
+        .get(&handshake.info_hash)
+        .map(|entry| entry.clone())
+    else {
+        debug!(%addr, "incoming peer for unknown info hash");
+        return;
+    };
+    let reply = Handshake::new(handshake.info_hash, peer_id);
+    if let Err(e) = Protocol::write_handshake(&mut stream, &reply).await {
+        debug!(%addr, error = %e, "failed to write handshake reply");
+        return;
+    }
+
+    try_spawn_peer(SpawnPeerParams {
+        peer: addr,
+        info_hash: handshake.info_hash,
+        peer_id,
+        piece_tx: torrent.piece_tx.clone(),
+        have_broadcast: torrent.have_broadcast.clone(),
+        torrent_downloaded_state: torrent.downloaded_state.clone(),
+        peer_states: torrent.peer_states.clone(),
+        download_state: torrent.download_state.clone(),
+        storage: torrent.storage.clone(),
+        uploaded: torrent.uploaded.clone(),
+        torrent: torrent.torrent.clone(),
+        choke_notify: torrent.choke_notify.clone(),
+        incoming: Some(stream),
+        global_peers,
+        max_peers_per_torrent,
+        max_peers_global,
+    });
+}
+
+fn spawn_choke_loop(
+    peer_states: Arc<PeerStates>,
+    downloaded_state: Arc<TorrentDownloadedState>,
+    choke_notify: Arc<Notify>,
+    cancel: CancellationToken,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(crate::choke::CHOKE_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut last_optimistic = std::time::Instant::now() - crate::choke::OPTIMISTIC_INTERVAL;
+        loop {
+            let reset_rates = tokio::select! {
+                _ = cancel.cancelled() => break,
+                _ = choke_notify.notified() => false,
+                _ = interval.tick() => true,
+            };
+            apply_choke(
+                &peer_states,
+                downloaded_state.is_complete(),
+                &mut last_optimistic,
+                reset_rates,
+            );
+        }
+    });
+}
+
+fn apply_choke(
+    peer_states: &PeerStates,
+    seeding: bool,
+    last_optimistic: &mut std::time::Instant,
+    reset_rates: bool,
+) {
+    use crate::choke::{
+        choke_transitions, select_unchoked, ChokeAction, ChokePeer, OPTIMISTIC_INTERVAL,
+    };
+    use crate::message::{Message, WriterRequest};
+
+    let now = std::time::Instant::now();
+    let pick_optimistic = now.duration_since(*last_optimistic) >= OPTIMISTIC_INTERVAL;
+    let snapshots: Vec<ChokePeer> = peer_states
+        .states
+        .iter()
+        .map(|entry| {
+            let state = entry.value();
+            ChokePeer {
+                addr: *entry.key(),
+                peer_interested: state.stats.peer_interested.load(Ordering::Relaxed),
+                currently_unchoked: !state.stats.am_choking.load(Ordering::Relaxed),
+                download_bytes: if reset_rates {
+                    state.stats.bytes_downloaded.swap(0, Ordering::Relaxed)
+                } else {
+                    state.stats.bytes_downloaded.load(Ordering::Relaxed)
+                },
+                last_unchoked: state.last_unchoked,
+                connected_at: state.connected_at,
+                is_optimistic: state.is_optimistic,
+            }
+        })
+        .collect();
+
+    let previous: std::collections::HashSet<_> = snapshots
+        .iter()
+        .filter(|peer| peer.currently_unchoked)
+        .map(|peer| peer.addr)
+        .collect();
+    let next = select_unchoked(
+        &snapshots,
+        seeding,
+        pick_optimistic,
+        now,
+        &mut rand::thread_rng(),
+    );
+    if pick_optimistic {
+        *last_optimistic = now;
+    }
+
+    let regular = select_unchoked(&snapshots, seeding, false, now, &mut rand::thread_rng());
+
+    for (addr, action) in choke_transitions(&previous, &next) {
+        let Some(mut state) = peer_states.states.get_mut(&addr) else {
+            continue;
+        };
+        match action {
+            ChokeAction::Choke => {
+                state.set_am_choking(true);
+                state.is_optimistic = false;
+                if let Some(tx) = &state.writer_tx {
+                    let _ = tx.send(WriterRequest::Message(Message::Choke));
+                }
+            }
+            ChokeAction::Unchoke => {
+                state.set_am_choking(false);
+                state.last_unchoked = Some(now);
+                state.is_optimistic = !regular.contains(&addr);
+                if let Some(tx) = &state.writer_tx {
+                    let _ = tx.send(WriterRequest::Message(Message::Unchoke));
+                }
+                state.stats.upload_notify.notify_waiters();
+            }
+        }
     }
 }
 

--- a/crates/bit_rev/src/storage/mod.rs
+++ b/crates/bit_rev/src/storage/mod.rs
@@ -1,0 +1,329 @@
+use std::io::SeekFrom;
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::fs::{File, OpenOptions};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+
+use crate::torrent::Torrent;
+use crate::utils::{calculate_piece_size, map_piece_to_files};
+
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("piece {0} out of range")]
+    PieceOutOfRange(u32),
+    #[error("block out of bounds: piece={index} begin={begin} length={length}")]
+    BlockOutOfBounds { index: u32, begin: u32, length: u32 },
+}
+
+pub struct Storage {
+    torrent: Torrent,
+    files: Vec<Mutex<File>>,
+}
+
+impl Storage {
+    /// Open (or create) files under `output_dir` without truncating existing data.
+    /// Single-file torrent: `output_dir` is the file path (may be a file name, not a directory).
+    /// Multi-file torrent: `output_dir` is the root directory; join each file's path components.
+    /// Create parent directories as needed.
+    /// Use OpenOptions: read+write+create, do NOT truncate.
+    pub async fn open(
+        torrent: &Torrent,
+        output_dir: impl AsRef<Path>,
+    ) -> Result<Arc<Self>, StorageError> {
+        let output_dir = output_dir.as_ref();
+        let mut files = Vec::with_capacity(torrent.files.len());
+
+        for file_info in &torrent.files {
+            let file_path = if torrent.files.len() == 1 {
+                output_dir.to_path_buf()
+            } else {
+                let mut path = output_dir.to_path_buf();
+                for component in &file_info.path {
+                    path.push(component);
+                }
+                path
+            };
+
+            if let Some(parent) = file_path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    tokio::fs::create_dir_all(parent).await?;
+                }
+            }
+
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&file_path)
+                .await?;
+            files.push(Mutex::new(file));
+        }
+
+        Ok(Arc::new(Self {
+            torrent: torrent.clone(),
+            files,
+        }))
+    }
+
+    pub async fn write_piece(&self, index: u32, buf: &[u8]) -> Result<(), StorageError> {
+        self.check_piece_index(index)?;
+
+        let expected = calculate_piece_size(&self.torrent, index as usize);
+        if buf.len() != expected {
+            return Err(StorageError::BlockOutOfBounds {
+                index,
+                begin: 0,
+                length: buf.len() as u32,
+            });
+        }
+
+        let mappings = map_piece_to_files(&self.torrent, index as usize);
+        let mut buf_offset = 0;
+        for mapping in mappings {
+            let slice = &buf[buf_offset..buf_offset + mapping.length];
+            {
+                let mut file = self.files[mapping.file_index].lock().await;
+                file.seek(SeekFrom::Start(mapping.file_offset as u64))
+                    .await?;
+                file.write_all(slice).await?;
+            }
+            buf_offset += mapping.length;
+        }
+
+        Ok(())
+    }
+
+    pub async fn read_block(
+        &self,
+        index: u32,
+        begin: u32,
+        length: u32,
+    ) -> Result<Vec<u8>, StorageError> {
+        self.check_piece_index(index)?;
+
+        let piece_size = calculate_piece_size(&self.torrent, index as usize);
+        let begin_us = begin as usize;
+        let length_us = length as usize;
+        if length == 0 || begin_us.saturating_add(length_us) > piece_size {
+            return Err(StorageError::BlockOutOfBounds {
+                index,
+                begin,
+                length,
+            });
+        }
+
+        let window_start = begin_us;
+        let window_end = begin_us + length_us;
+        let mappings = map_piece_to_files(&self.torrent, index as usize);
+
+        let mut out = Vec::with_capacity(length_us);
+        let mut piece_offset = 0;
+        for mapping in mappings {
+            let map_start = piece_offset;
+            let map_end = piece_offset + mapping.length;
+            let overlap_start = map_start.max(window_start);
+            let overlap_end = map_end.min(window_end);
+
+            if overlap_start < overlap_end {
+                let file_offset = mapping.file_offset + (overlap_start - map_start);
+                let read_len = overlap_end - overlap_start;
+                let mut chunk = vec![0u8; read_len];
+                {
+                    let mut file = self.files[mapping.file_index].lock().await;
+                    file.seek(SeekFrom::Start(file_offset as u64)).await?;
+                    file.read_exact(&mut chunk).await?;
+                }
+                out.extend_from_slice(&chunk);
+            }
+
+            piece_offset = map_end;
+        }
+
+        Ok(out)
+    }
+
+    pub fn torrent(&self) -> &Torrent {
+        &self.torrent
+    }
+
+    fn check_piece_index(&self, index: u32) -> Result<(), StorageError> {
+        if (index as usize) >= self.torrent.piece_hashes.len() {
+            return Err(StorageError::PieceOutOfRange(index));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::torrent::{Torrent, TorrentFileInfo};
+    use rand::RngCore;
+    use std::path::{Path, PathBuf};
+
+    fn torrent(files: &[i64], piece_length: i64) -> Torrent {
+        let mut offset = 0i64;
+        let files = files
+            .iter()
+            .enumerate()
+            .map(|(i, &len)| {
+                let f = TorrentFileInfo {
+                    path: vec![format!("f{i}")],
+                    length: len,
+                    offset,
+                };
+                offset += len;
+                f
+            })
+            .collect();
+        let piece_count = if piece_length <= 0 || offset <= 0 {
+            0
+        } else {
+            ((offset + piece_length - 1) / piece_length) as usize
+        };
+        Torrent {
+            info_hash: [0; 20],
+            piece_hashes: vec![[0u8; 20]; piece_count],
+            piece_length,
+            length: offset,
+            files,
+            name: "t".into(),
+            private: false,
+        }
+    }
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let mut suffix = [0u8; 8];
+            rand::thread_rng().fill_bytes(&mut suffix);
+            let dir = std::env::temp_dir().join(format!(
+                "bitrev-storage-{}-{}",
+                std::process::id(),
+                suffix
+                    .iter()
+                    .map(|b| format!("{b:02x}"))
+                    .collect::<String>()
+            ));
+            std::fs::create_dir_all(&dir).expect("create temp dir");
+            Self(dir)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn write_and_read_single_file_piece() {
+        let t = torrent(&[100], 40);
+        let tmp = TempDir::new();
+        let path = tmp.path().join("out.bin");
+        let storage = Storage::open(&t, &path).await.unwrap();
+
+        let data: Vec<u8> = (0..40)
+            .map(|i| (i as u8).wrapping_mul(3).wrapping_add(1))
+            .collect();
+        storage.write_piece(0, &data).await.unwrap();
+
+        let block = storage.read_block(0, 10, 15).await.unwrap();
+        assert_eq!(block, &data[10..25]);
+        assert_eq!(storage.torrent().name, "t");
+    }
+
+    #[tokio::test]
+    async fn write_and_read_block_spanning_two_files() {
+        let t = torrent(&[30, 30], 40);
+        let tmp = TempDir::new();
+        let storage = Storage::open(&t, tmp.path()).await.unwrap();
+
+        let data: Vec<u8> = (0..40).collect();
+        storage.write_piece(0, &data).await.unwrap();
+
+        let block = storage.read_block(0, 20, 20).await.unwrap();
+        assert_eq!(block, &data[20..40]);
+        assert_eq!(&block[..10], &data[20..30]);
+        assert_eq!(&block[10..], &data[30..40]);
+    }
+
+    #[tokio::test]
+    async fn read_block_out_of_bounds_errors() {
+        let t = torrent(&[100], 40);
+        let tmp = TempDir::new();
+        let path = tmp.path().join("out.bin");
+        let storage = Storage::open(&t, &path).await.unwrap();
+        storage.write_piece(0, &[7u8; 40]).await.unwrap();
+
+        let past_end = storage.read_block(0, 30, 20).await.unwrap_err();
+        assert!(matches!(
+            past_end,
+            StorageError::BlockOutOfBounds {
+                index: 0,
+                begin: 30,
+                length: 20
+            }
+        ));
+
+        let zero_len = storage.read_block(0, 0, 0).await.unwrap_err();
+        assert!(matches!(
+            zero_len,
+            StorageError::BlockOutOfBounds {
+                index: 0,
+                begin: 0,
+                length: 0
+            }
+        ));
+
+        let bad_index = storage.read_block(99, 0, 1).await.unwrap_err();
+        assert!(matches!(bad_index, StorageError::PieceOutOfRange(99)));
+    }
+
+    #[tokio::test]
+    async fn write_piece_out_of_range_errors() {
+        let t = torrent(&[100], 40);
+        let tmp = TempDir::new();
+        let path = tmp.path().join("out.bin");
+        let storage = Storage::open(&t, &path).await.unwrap();
+
+        let err = storage.write_piece(99, &[0u8; 40]).await.unwrap_err();
+        assert!(matches!(err, StorageError::PieceOutOfRange(99)));
+    }
+
+    #[tokio::test]
+    async fn open_does_not_truncate_existing() {
+        let t = torrent(&[40], 40);
+        let tmp = TempDir::new();
+        let path = tmp.path().join("existing.bin");
+        let expected: Vec<u8> = (0..40).map(|i| (i as u8).wrapping_add(9)).collect();
+        std::fs::write(&path, &expected).unwrap();
+
+        let storage = Storage::open(&t, &path).await.unwrap();
+        let got = storage.read_block(0, 0, 40).await.unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[tokio::test]
+    async fn three_file_span() {
+        let t = torrent(&[10, 10, 10], 25);
+        let tmp = TempDir::new();
+        let storage = Storage::open(&t, tmp.path()).await.unwrap();
+
+        let data: Vec<u8> = (0..25).map(|i| (i as u8).wrapping_add(50)).collect();
+        storage.write_piece(0, &data).await.unwrap();
+
+        let got = storage.read_block(0, 0, 25).await.unwrap();
+        assert_eq!(got, data);
+    }
+}

--- a/crates/bit_rev/src/tracker.rs
+++ b/crates/bit_rev/src/tracker.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::{Arc, Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, OnceLock,
+    },
     time::Duration,
 };
 
@@ -126,6 +129,7 @@ pub struct HttpAnnounceContext {
     pub port: u16,
     pub download_state: Arc<Mutex<DownloadState>>,
     pub torrent_downloaded_state: Arc<TorrentDownloadedState>,
+    pub uploaded: Arc<AtomicU64>,
 }
 
 impl HttpAnnounceContext {
@@ -310,8 +314,7 @@ fn current_announce_params(
     tracker_id: Option<Vec<u8>>,
 ) -> AnnounceParams {
     AnnounceParams {
-        // TODO(#8): wire uploaded from the session upload counter once seeding exists
-        uploaded: 0,
+        uploaded: ctx.uploaded.load(Ordering::Relaxed),
         downloaded: ctx.torrent_downloaded_state.downloaded_bytes(),
         left: ctx.torrent_downloaded_state.left_bytes(),
         port: ctx.port,
@@ -328,7 +331,7 @@ async fn send_stopped(
     udp: Option<&mut UdpTracker>,
 ) {
     let params = AnnounceParams {
-        uploaded: 0,
+        uploaded: ctx.uploaded.load(Ordering::Relaxed),
         downloaded: ctx.torrent_downloaded_state.downloaded_bytes(),
         left: ctx.torrent_downloaded_state.left_bytes(),
         port: ctx.port,
@@ -470,6 +473,7 @@ mod tests {
                 semaphore: tokio::sync::Semaphore::new(1),
                 pieces: vec![],
             }),
+            uploaded: Arc::new(AtomicU64::new(0)),
         };
 
         assert!(!ctx.switch_tracker("http://a.example/announce"));

--- a/crates/bit_rev/src/tracker_peers.rs
+++ b/crates/bit_rev/src/tracker_peers.rs
@@ -1,5 +1,8 @@
-use std::sync::{atomic::AtomicBool, Arc, Mutex};
-use tokio::{select, sync::Semaphore};
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize},
+    Arc, Mutex,
+};
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
@@ -8,13 +11,27 @@ use crate::{
     file::TorrentMeta,
     identity::TrackerIdentity,
     peer::BencodeResponse,
-    peer_connection::{
-        FullPiece, PeerConnection, PeerHandler, PieceWorkState, TorrentDownloadedState,
-    },
+    peer_connection::{try_spawn_peer, FullPiece, SpawnPeerParams, TorrentDownloadedState},
     peer_state::PeerStates,
-    session::{DownloadState, PieceResult, PieceWork},
+    session::{DownloadState, PieceResult},
+    storage::Storage,
+    torrent::Torrent,
     tracker::{self, HttpAnnounceContext, TrackerError},
 };
+
+pub struct PeerSpawnRuntime {
+    pub info_hash: [u8; 20],
+    pub peer_id: [u8; 20],
+    pub storage: Arc<Storage>,
+    pub downloaded_state: Arc<TorrentDownloadedState>,
+    pub uploaded: Arc<AtomicU64>,
+    pub torrent: Arc<Torrent>,
+    pub choke_notify: Arc<Notify>,
+    pub global_peers: Arc<AtomicUsize>,
+    pub max_peers_per_torrent: usize,
+    pub max_peers_global: usize,
+    pub listen_port: u16,
+}
 
 #[derive(Debug, Clone)]
 pub struct TrackerPeers {
@@ -68,6 +85,10 @@ impl TrackerPeers {
         self.cancel.cancel();
     }
 
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
     pub fn set_download_state(&self, state: DownloadState) {
         let mut current_state = self.download_state.lock().unwrap();
         *current_state = state;
@@ -89,10 +110,7 @@ impl TrackerPeers {
         self.get_download_state() == DownloadState::Init
     }
 
-    pub async fn connect(&self, pieces_of_work: Vec<PieceWork>) {
-        let info_hash = self.torrent_meta.info_hash;
-        let peer_id = self.peer_id;
-
+    pub async fn connect(&self, runtime: PeerSpawnRuntime) {
         let all_tracker_urls = all_trackers(&self.torrent_meta);
         debug!(trackers = ?all_tracker_urls, "connecting to trackers");
         let torrent_meta = self.torrent_meta.clone();
@@ -102,18 +120,6 @@ impl TrackerPeers {
         let download_state = self.download_state.clone();
         let cancel = self.cancel.clone();
         let http_client = tracker::http_client();
-        let torrent_downloaded_state = Arc::new(TorrentDownloadedState {
-            semaphore: Semaphore::new(1),
-            pieces: pieces_of_work
-                .into_iter()
-                .map(|pw| PieceWorkState {
-                    piece_work: pw,
-                    chuncks: Mutex::new(vec![]),
-                    downloaded: AtomicBool::new(false),
-                    reserved: Mutex::new(None),
-                })
-                .collect(),
-        });
 
         if let Err(denied) = self.register_source(DiscoverySource::Tracker) {
             debug!(error = %denied, "refused tracker source");
@@ -121,43 +127,63 @@ impl TrackerPeers {
         }
 
         for tracker_url in all_tracker_urls {
-            // One key per tracker URL. Issue #19 should call switch_url on fallback.
             let identity = TrackerIdentity::new(tracker_url);
             let ctx = HttpAnnounceContext {
                 client: http_client.clone(),
                 torrent_meta: torrent_meta.clone(),
-                peer_id,
+                peer_id: self.peer_id,
                 tracker_url: identity.url().to_string(),
                 announce_key: identity.key(),
-                port: 6881,
+                port: runtime.listen_port,
                 download_state: download_state.clone(),
-                torrent_downloaded_state: torrent_downloaded_state.clone(),
+                torrent_downloaded_state: runtime.downloaded_state.clone(),
+                uploaded: runtime.uploaded.clone(),
             };
             let peer_states = peer_states.clone();
             let piece_tx = piece_tx.clone();
             let have_broadcast = have_broadcast.clone();
             let download_state = download_state.clone();
-            let torrent_downloaded_state = torrent_downloaded_state.clone();
             let shutdown = cancel.clone();
+            let runtime = PeerSpawnRuntime {
+                info_hash: runtime.info_hash,
+                peer_id: runtime.peer_id,
+                storage: runtime.storage.clone(),
+                downloaded_state: runtime.downloaded_state.clone(),
+                uploaded: runtime.uploaded.clone(),
+                torrent: runtime.torrent.clone(),
+                choke_notify: runtime.choke_notify.clone(),
+                global_peers: runtime.global_peers.clone(),
+                max_peers_per_torrent: runtime.max_peers_per_torrent,
+                max_peers_global: runtime.max_peers_global,
+                listen_port: runtime.listen_port,
+            };
             tokio::spawn(async move {
                 tracker::run_announce_loop(ctx, shutdown, |new_peers| {
                     let peer_states = peer_states.clone();
                     let piece_tx = piece_tx.clone();
                     let have_broadcast = have_broadcast.clone();
-                    let torrent_downloaded_state = torrent_downloaded_state.clone();
                     let download_state = download_state.clone();
+                    let runtime = PeerSpawnRuntime {
+                        info_hash: runtime.info_hash,
+                        peer_id: runtime.peer_id,
+                        storage: runtime.storage.clone(),
+                        downloaded_state: runtime.downloaded_state.clone(),
+                        uploaded: runtime.uploaded.clone(),
+                        torrent: runtime.torrent.clone(),
+                        choke_notify: runtime.choke_notify.clone(),
+                        global_peers: runtime.global_peers.clone(),
+                        max_peers_per_torrent: runtime.max_peers_per_torrent,
+                        max_peers_global: runtime.max_peers_global,
+                        listen_port: runtime.listen_port,
+                    };
                     async move {
                         process_peers(
                             new_peers,
-                            PeerProcessorConfig {
-                                info_hash,
-                                peer_id,
-                                peer_states,
-                                piece_tx,
-                                have_broadcast,
-                                torrent_downloaded_state,
-                                download_state,
-                            },
+                            peer_states,
+                            piece_tx,
+                            have_broadcast,
+                            download_state,
+                            runtime,
                         )
                         .await;
                     }
@@ -168,79 +194,40 @@ impl TrackerPeers {
     }
 }
 
-struct PeerProcessorConfig {
-    info_hash: [u8; 20],
-    peer_id: [u8; 20],
+async fn process_peers(
+    new_peers: Vec<std::net::SocketAddr>,
     peer_states: Arc<PeerStates>,
     piece_tx: flume::Sender<FullPiece>,
     have_broadcast: Arc<tokio::sync::broadcast::Sender<u32>>,
-    torrent_downloaded_state: Arc<TorrentDownloadedState>,
     download_state: Arc<Mutex<DownloadState>>,
-}
-
-async fn process_peers(new_peers: Vec<std::net::SocketAddr>, config: PeerProcessorConfig) {
-    let info_hash = config.info_hash;
-    let peer_id = config.peer_id;
-
+    runtime: PeerSpawnRuntime,
+) {
     for peer in new_peers {
-        // Skip processing new peers if not downloading
-        let current_state = *config.download_state.lock().unwrap();
+        let current_state = *download_state.lock().unwrap();
         if current_state != DownloadState::Downloading {
             continue;
         }
-
-        if !config.peer_states.add_if_not_seen(peer) {
+        if peer_states.states.contains_key(&peer) {
             continue;
         }
 
-        let piece_tx = config.piece_tx.clone();
-        let have_broadcast = config.have_broadcast.clone();
-        let torrent_downloaded_state = config.torrent_downloaded_state.clone();
-        let peer_states = config.peer_states.clone();
-        let download_state = config.download_state.clone();
-
-        tokio::spawn(async move {
-            let unchoke_notify = tokio::sync::Notify::new();
-            let (peer_writer_tx, peer_writer_rx) = flume::unbounded();
-
-            let peer_handler = Arc::new(PeerHandler::new(
-                peer,
-                unchoke_notify,
-                piece_tx.clone(),
-                peer_writer_tx.clone(),
-                peer_states.clone(),
-                torrent_downloaded_state.clone(),
-                download_state.clone(),
-            ));
-
-            let peer_connection =
-                PeerConnection::new(peer, info_hash, peer_id, peer_handler.clone());
-
-            let task_peer_chunk_req_fut = peer_handler.task_peer_chunk_requester();
-            let connect_peer_fut =
-                peer_connection.manage_peer_incoming(peer_writer_rx, have_broadcast.subscribe());
-
-            let req = select! {
-                r = connect_peer_fut => {
-                    debug!("connect_peer_fut: {:#?}", r);
-                    r
-                }
-                r = task_peer_chunk_req_fut => {
-                    debug!("task_peer_chunk_req_fut: {:#?}", r);
-                    r
-                }
-            };
-
-            match req {
-                Ok(_) => {
-                    // We disconnected the peer ourselves as we don't need it
-                    peer_handler.on_peer_died();
-                }
-                Err(e) => {
-                    debug!("error managing peer: {:#}", e);
-                    peer_handler.on_peer_died();
-                }
-            }
+        try_spawn_peer(SpawnPeerParams {
+            peer,
+            info_hash: runtime.info_hash,
+            peer_id: runtime.peer_id,
+            piece_tx: piece_tx.clone(),
+            have_broadcast: have_broadcast.clone(),
+            torrent_downloaded_state: runtime.downloaded_state.clone(),
+            peer_states: peer_states.clone(),
+            download_state: download_state.clone(),
+            storage: runtime.storage.clone(),
+            uploaded: runtime.uploaded.clone(),
+            torrent: runtime.torrent.clone(),
+            choke_notify: runtime.choke_notify.clone(),
+            incoming: None,
+            global_peers: runtime.global_peers.clone(),
+            max_peers_per_torrent: runtime.max_peers_per_torrent,
+            max_peers_global: runtime.max_peers_global,
         });
     }
 }

--- a/crates/bit_rev/tests/tracker_http.rs
+++ b/crates/bit_rev/tests/tracker_http.rs
@@ -250,6 +250,7 @@ fn announce_ctx(url: String, download: Arc<TorrentDownloadedState>) -> HttpAnnou
         port: 6881,
         download_state: Arc::new(Mutex::new(DownloadState::Downloading)),
         torrent_downloaded_state: download,
+        uploaded: Arc::new(std::sync::atomic::AtomicU64::new(0)),
     }
 }
 

--- a/crates/bit_rev/tests/tracker_udp.rs
+++ b/crates/bit_rev/tests/tracker_udp.rs
@@ -83,6 +83,7 @@ fn announce_ctx(url: String, download: Arc<TorrentDownloadedState>) -> HttpAnnou
         port: 6881,
         download_state: Arc::new(Mutex::new(DownloadState::Downloading)),
         torrent_downloaded_state: download,
+        uploaded: Arc::new(std::sync::atomic::AtomicU64::new(0)),
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,17 +1,10 @@
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use std::{
-    collections::HashMap,
     fmt::Write,
-    io::SeekFrom,
     sync::{atomic::AtomicU64, Arc},
 };
-use tokio::{
-    fs::{create_dir_all, File},
-    io::{AsyncSeekExt, AsyncWriteExt},
-};
-use tracing::trace;
 
-use bit_rev::{session::Session, utils};
+use bit_rev::session::{AddTorrentOptions, Session};
 
 #[tokio::main]
 async fn main() {
@@ -32,9 +25,13 @@ async fn main() {
 pub async fn download_file(filename: &str, out_file: Option<String>) -> anyhow::Result<()> {
     let session = Session::new();
 
-    let add_torrent_result = session.add_torrent(filename.into()).await?;
+    let mut add_opts = AddTorrentOptions::from(filename);
+    if let Some(output) = out_file {
+        add_opts = add_opts.output_dir(output);
+    }
+
+    let add_torrent_result = session.add_torrent(add_opts).await?;
     let torrent = add_torrent_result.torrent.clone();
-    let _torrent_meta = add_torrent_result.torrent_meta;
 
     let total_size = torrent.length as u64;
     let pb = ProgressBar::new(total_size);
@@ -47,41 +44,6 @@ pub async fn download_file(filename: &str, out_file: Option<String>) -> anyhow::
             | state: &ProgressState, w: &mut dyn Write | write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
         ).progress_chars("#>-")
     );
-
-    // Determine the output directory
-    let output_dir = match out_file {
-        Some(name) => name,
-        None => torrent.name.clone(),
-    };
-
-    // Create output directory and prepare file handles
-    let mut file_handles: HashMap<usize, File> = HashMap::new();
-
-    // Create directories and prepare files for multi-file torrents
-    for (file_index, file_info) in torrent.files.iter().enumerate() {
-        let file_path = if torrent.files.len() == 1 {
-            // Single file torrent - use output_dir as filename
-            std::path::PathBuf::from(&output_dir)
-        } else {
-            // Multi-file torrent - create subdirectory structure
-            let mut path = std::path::PathBuf::from(&output_dir);
-            for component in &file_info.path {
-                path.push(component);
-            }
-            path
-        };
-
-        // Create parent directories if needed
-        if let Some(parent) = file_path.parent() {
-            create_dir_all(parent).await?;
-        }
-
-        // Create the file
-        let file = File::create(&file_path).await?;
-        file_handles.insert(file_index, file);
-
-        trace!("Created file: {:?}", file_path);
-    }
 
     let total_downloaded = Arc::new(AtomicU64::new(0));
     let total_downloaded_clone = total_downloaded.clone();
@@ -98,42 +60,8 @@ pub async fn download_file(filename: &str, out_file: Option<String>) -> anyhow::
     let mut hashset = std::collections::HashSet::new();
     while hashset.len() < torrent.piece_hashes.len() {
         let pr = add_torrent_result.pr_rx.recv_async().await?;
-
         hashset.insert(pr.index);
-
-        // Map piece to files and write data accordingly
-        let file_mappings = utils::map_piece_to_files(&torrent, pr.index as usize);
-        let mut piece_offset = 0;
-
-        for mapping in file_mappings {
-            let file = file_handles.get_mut(&mapping.file_index).ok_or_else(|| {
-                anyhow::anyhow!("File handle not found for index {}", mapping.file_index)
-            })?;
-
-            // Seek to correct position in file
-            file.seek(SeekFrom::Start(mapping.file_offset as u64))
-                .await?;
-
-            // Write the portion of the piece that belongs to this file
-            let piece_data = &pr.buf[piece_offset..piece_offset + mapping.length];
-            file.write_all(piece_data).await?;
-
-            piece_offset += mapping.length;
-
-            trace!(
-                "Wrote {} bytes to file {} at offset {}",
-                mapping.length,
-                mapping.file_index,
-                mapping.file_offset
-            );
-        }
-
         total_downloaded.fetch_add(pr.length as u64, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    // Sync all files
-    for (_, file) in file_handles {
-        file.sync_all().await?;
     }
 
     session.shutdown();


### PR DESCRIPTION
Move piece I/O into the engine, accept incoming peers, serve requests with a choke algorithm, and report uploaded bytes on announce.