### PR TITLE
feat: persist resume data and pause state across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "util",
 ]
 
 [[package]]

--- a/crates/bit_rev/Cargo.toml
+++ b/crates/bit_rev/Cargo.toml
@@ -22,6 +22,9 @@ sha1_smol.workspace = true
 dashmap.workspace = true
 rand.workspace = true
 tokio-util.workspace = true
+util = { path = "../util" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+tokio-util.workspace = true
+serde_bytes.workspace = true

--- a/crates/bit_rev/src/lib.rs
+++ b/crates/bit_rev/src/lib.rs
@@ -10,6 +10,7 @@ pub mod peer_connection;
 pub mod peer_state;
 pub mod protocol;
 pub mod protocol_udp;
+pub mod resume;
 pub mod session;
 pub mod storage;
 pub mod torrent;

--- a/crates/bit_rev/src/peer_connection.rs
+++ b/crates/bit_rev/src/peer_connection.rs
@@ -381,8 +381,8 @@ impl PeerHandler {
         validate_request(&req, piece_length, have_piece)
             .map_err(|e| anyhow::anyhow!("invalid request {:?}: {:?}", req, e))?;
 
-        if self.am_choking() {
-            debug!("ignoring request while choking {:?}", req);
+        if !self.is_downloading() || self.am_choking() {
+            debug!("ignoring request while paused or choking {:?}", req);
             return Ok(());
         }
 
@@ -401,6 +401,12 @@ impl PeerHandler {
 
     pub async fn task_peer_uploader(&self) -> Result<(), anyhow::Error> {
         loop {
+            if !self.is_downloading() {
+                self.upload_queue.lock().unwrap().clear();
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+
             let stats = self
                 .peers_state
                 .states
@@ -414,7 +420,7 @@ impl PeerHandler {
             }
 
             loop {
-                if self.am_choking() {
+                if !self.is_downloading() || self.am_choking() {
                     self.upload_queue.lock().unwrap().clear();
                     break;
                 }
@@ -481,8 +487,11 @@ impl PeerHandler {
         };
 
         loop {
-            while !self.is_downloading() {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            if !self.is_downloading() {
+                update_interest(self, false)?;
+                while !self.is_downloading() {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
             }
 
             if self.torrent_downloaded_state.is_complete() || !self.peer_has_needed_piece() {
@@ -528,9 +537,8 @@ impl PeerHandler {
 
             let mut offset: u32 = 0;
             while offset < piece.length {
-                // Check download state before requesting each block
                 if !self.is_downloading() {
-                    // Wait while not downloading
+                    update_interest(self, false)?;
                     while !self.is_downloading() {
                         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                     }

--- a/crates/bit_rev/src/protocol_udp.rs
+++ b/crates/bit_rev/src/protocol_udp.rs
@@ -709,6 +709,12 @@ mod tests {
         }
     }
 
+    static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_tests() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     async fn recv_from_mock(socket: &UdpSocket) -> (Vec<u8>, SocketAddr) {
         let mut buf = vec![0u8; 512];
         let (len, from) = socket.recv_from(&mut buf).await.expect("mock recv");
@@ -901,7 +907,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn announce_round_trip_peers_and_interval() {
+        let _lock = lock_tests();
         let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
         let url = tracker_url(mock.local_addr().unwrap());
         let params = sample_params(Some(AnnounceEvent::Started));
@@ -945,7 +953,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn transaction_mismatch_is_ignored_until_matching_packet() {
+        let _lock = lock_tests();
         let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
         let url = tracker_url(mock.local_addr().unwrap());
         let params = sample_params(None);
@@ -1001,7 +1011,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn error_packet_is_typed_error() {
+        let _lock = lock_tests();
         let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
         let url = tracker_url(mock.local_addr().unwrap());
         let params = sample_params(Some(AnnounceEvent::Started));
@@ -1038,7 +1050,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn expired_connection_id_reconnects() {
+        let _lock = lock_tests();
         tokio::time::pause();
         let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
         let url = tracker_url(mock.local_addr().unwrap());
@@ -1103,7 +1117,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn server_rejects_old_connection_id_then_client_reconnects() {
+        let _lock = lock_tests();
         tokio::time::pause();
         let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
         let url = tracker_url(mock.local_addr().unwrap());
@@ -1168,7 +1184,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn announce_over_ipv6_parses_18_byte_peers() {
+        let _lock = lock_tests();
         let mock = match UdpSocket::bind(SocketAddr::V6(SocketAddrV6::new(
             Ipv6Addr::LOCALHOST,
             0,
@@ -1215,7 +1233,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn retransmit_on_dropped_announce() {
+        let _lock = lock_tests();
         tokio::time::pause();
         let mock = bind_mock(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await;
         let url = tracker_url(mock.local_addr().unwrap());

--- a/crates/bit_rev/src/resume.rs
+++ b/crates/bit_rev/src/resume.rs
@@ -1,0 +1,423 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
+use tracing::warn;
+
+use crate::bitfield::Bitfield;
+use crate::peer_connection::TorrentDownloadedState;
+use crate::storage;
+use crate::torrent::Torrent;
+use crate::utils;
+
+pub const RESUME_VERSION: i64 = 1;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ResumeError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("decode error: {0}")]
+    Decode(String),
+    #[error("unsupported resume version {0}")]
+    UnsupportedVersion(i64),
+    #[error("info hash mismatch")]
+    InfoHashMismatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResumeFile {
+    pub path: Vec<String>,
+    pub length: i64,
+    pub mtime: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResumeData {
+    pub version: i64,
+    pub info_hash: ByteBuf,
+    pub bitfield: ByteBuf,
+    pub output_dir: String,
+    pub files: Vec<ResumeFile>,
+    pub uploaded: i64,
+    pub downloaded: i64,
+    pub torrent_path: String,
+    pub paused: i64,
+    pub added_at: i64,
+    #[serde(default)]
+    pub completed_at: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumeStatus {
+    Fresh,
+    FastPath,
+    SlowPath,
+    Corrupt,
+}
+
+impl ResumeData {
+    pub fn info_hash(&self) -> Option<[u8; 20]> {
+        self.info_hash.as_ref().try_into().ok()
+    }
+
+    pub fn is_paused(&self) -> bool {
+        self.paused != 0
+    }
+
+    pub fn completed_at(&self) -> Option<i64> {
+        (self.completed_at > 0).then_some(self.completed_at)
+    }
+
+    pub fn bitfield(&self) -> Bitfield {
+        Bitfield::new(self.bitfield.to_vec())
+    }
+}
+
+pub fn info_hash_hex(info_hash: &[u8; 20]) -> String {
+    info_hash.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+pub fn resume_path(state_dir: &Path, info_hash: &[u8; 20]) -> PathBuf {
+    util::paths::resume_dir(state_dir).join(format!("{}.resume", info_hash_hex(info_hash)))
+}
+
+pub fn torrent_cache_path(state_dir: &Path, info_hash: &[u8; 20]) -> PathBuf {
+    util::paths::torrents_dir(state_dir).join(format!("{}.torrent", info_hash_hex(info_hash)))
+}
+
+pub fn tmp_path(path: &Path) -> PathBuf {
+    let mut tmp = path.as_os_str().to_os_string();
+    tmp.push(".tmp");
+    PathBuf::from(tmp)
+}
+
+pub fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+pub fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+pub fn encode(data: &ResumeData) -> Result<Vec<u8>, ResumeError> {
+    serde_bencode::to_bytes(data).map_err(|e| ResumeError::Decode(e.to_string()))
+}
+
+pub fn decode(bytes: &[u8]) -> Result<ResumeData, ResumeError> {
+    let data: ResumeData =
+        serde_bencode::from_bytes(bytes).map_err(|e| ResumeError::Decode(e.to_string()))?;
+    if data.version != RESUME_VERSION {
+        return Err(ResumeError::UnsupportedVersion(data.version));
+    }
+    if data.info_hash.len() != 20 {
+        return Err(ResumeError::Decode("info_hash must be 20 bytes".into()));
+    }
+    Ok(data)
+}
+
+pub fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), ResumeError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = tmp_path(path);
+    match std::fs::write(&tmp, bytes) {
+        Ok(()) => {}
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(e.into());
+        }
+    }
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e.into())
+        }
+    }
+}
+
+pub fn save(path: &Path, data: &ResumeData) -> Result<(), ResumeError> {
+    let bytes = encode(data)?;
+    write_atomic(path, &bytes)
+}
+
+pub fn load(path: &Path) -> Result<ResumeData, ResumeError> {
+    let bytes = std::fs::read(path)?;
+    decode(&bytes)
+}
+
+/// Load resume data if the file exists. Corrupt or unreadable files warn and yield `None`.
+pub fn load_optional(path: &Path) -> Result<Option<ResumeData>, ResumeError> {
+    match load(path) {
+        Ok(data) => Ok(Some(data)),
+        Err(ResumeError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "ignoring corrupt resume file");
+            Ok(None)
+        }
+    }
+}
+
+pub fn collect_file_layout(torrent: &Torrent, output_dir: &Path) -> Vec<ResumeFile> {
+    torrent
+        .files
+        .iter()
+        .enumerate()
+        .map(|(i, file)| {
+            let path = storage::file_path(torrent, output_dir, i);
+            let (length, mtime) = match std::fs::metadata(&path) {
+                Ok(meta) => (meta.len() as i64, mtime_secs(&meta)),
+                Err(_) => (0, 0),
+            };
+            ResumeFile {
+                path: file.path.clone(),
+                length,
+                mtime,
+            }
+        })
+        .collect()
+}
+
+pub fn files_match(recorded: &[ResumeFile], torrent: &Torrent, output_dir: &Path) -> bool {
+    if recorded.len() != torrent.files.len() {
+        return false;
+    }
+    recorded.iter().enumerate().all(|(i, rec)| {
+        if rec.path != torrent.files[i].path {
+            return false;
+        }
+        let path = storage::file_path(torrent, output_dir, i);
+        let Ok(meta) = std::fs::metadata(&path) else {
+            return false;
+        };
+        meta.len() as i64 == rec.length && mtime_secs(&meta) == rec.mtime
+    })
+}
+
+pub fn apply_bitfield(state: &TorrentDownloadedState, bitfield: &Bitfield) {
+    for i in 0..state.piece_count() {
+        if bitfield.has_piece(i) {
+            state.mark_downloaded(i as u32);
+        }
+    }
+}
+
+pub async fn verify_existing_pieces(storage: &storage::Storage, state: &TorrentDownloadedState) {
+    let torrent = storage.torrent();
+    for i in 0..torrent.piece_hashes.len() {
+        let length = utils::calculate_piece_size(torrent, i) as u32;
+        if length == 0 {
+            continue;
+        }
+        match storage.read_block(i as u32, 0, length).await {
+            Ok(buf) if utils::check_integrity(&torrent.piece_hashes[i], &buf) => {
+                state.mark_downloaded(i as u32);
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn cache_torrent_file(
+    state_dir: &Path,
+    info_hash: &[u8; 20],
+    torrent_file: &crate::file::TorrentFile,
+) -> PathBuf {
+    let path = torrent_cache_path(state_dir, info_hash);
+    match serde_bencode::to_bytes(torrent_file) {
+        Ok(bytes) => {
+            if let Err(e) = write_atomic(&path, &bytes) {
+                warn!(path = %path.display(), error = %e, "failed to cache torrent metainfo");
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, "failed to encode torrent metainfo for cache");
+        }
+    }
+    path
+}
+
+pub struct ResumeSnapshot<'a> {
+    pub info_hash: &'a [u8; 20],
+    pub output_dir: &'a Path,
+    pub torrent: &'a Torrent,
+    pub downloaded_state: &'a TorrentDownloadedState,
+    pub uploaded: u64,
+    pub paused: bool,
+    pub torrent_path: &'a Path,
+    pub added_at: i64,
+    pub completed_at: Option<i64>,
+}
+
+pub fn snapshot(snap: ResumeSnapshot<'_>) -> ResumeData {
+    let bitfield = snap.downloaded_state.our_bitfield();
+    ResumeData {
+        version: RESUME_VERSION,
+        info_hash: ByteBuf::from(snap.info_hash.to_vec()),
+        bitfield: ByteBuf::from(bitfield.as_bytes().to_vec()),
+        output_dir: snap.output_dir.to_string_lossy().into_owned(),
+        files: collect_file_layout(snap.torrent, snap.output_dir),
+        uploaded: snap.uploaded as i64,
+        downloaded: snap.downloaded_state.downloaded_bytes() as i64,
+        torrent_path: snap.torrent_path.to_string_lossy().into_owned(),
+        paused: i64::from(snap.paused),
+        added_at: snap.added_at,
+        completed_at: snap.completed_at.unwrap_or(0),
+    }
+}
+
+pub fn persist(state_dir: &Path, snap: ResumeSnapshot<'_>) -> Result<PathBuf, ResumeError> {
+    let path = resume_path(state_dir, snap.info_hash);
+    let data = snapshot(snap);
+    save(&path, &data)?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::torrent::TorrentFileInfo;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "bitrev-resume-{label}-{}-{}",
+            std::process::id(),
+            now_unix()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn sample_data() -> ResumeData {
+        ResumeData {
+            version: RESUME_VERSION,
+            info_hash: ByteBuf::from(vec![0xab; 20]),
+            bitfield: ByteBuf::from(vec![0b1010_0000]),
+            output_dir: "/tmp/out.bin".into(),
+            files: vec![ResumeFile {
+                path: vec!["out.bin".into()],
+                length: 16,
+                mtime: 1_700_000_000,
+            }],
+            uploaded: 11,
+            downloaded: 16,
+            torrent_path: "/tmp/torrents/ab.torrent".into(),
+            paused: 1,
+            added_at: 1_700_000_000,
+            completed_at: 0,
+        }
+    }
+
+    fn torrent_one_file(name: &str, length: i64) -> Torrent {
+        Torrent {
+            info_hash: [0xab; 20],
+            piece_hashes: vec![[0u8; 20]],
+            piece_length: length,
+            length,
+            files: vec![TorrentFileInfo {
+                path: vec![name.into()],
+                length,
+                offset: 0,
+            }],
+            name: name.into(),
+            private: false,
+        }
+    }
+
+    #[test]
+    fn encode_roundtrip() {
+        let data = sample_data();
+        let bytes = encode(&data).unwrap();
+        let loaded = decode(&bytes).unwrap();
+        assert_eq!(loaded, data);
+        assert!(loaded.is_paused());
+        assert_eq!(loaded.info_hash().unwrap(), [0xab; 20]);
+    }
+
+    #[test]
+    fn atomic_write_leaves_no_partial_file() {
+        let dir = temp_dir("atomic");
+        let path = dir.join("deadbeef.resume");
+        let data = sample_data();
+        save(&path, &data).unwrap();
+
+        assert!(path.exists());
+        assert!(!tmp_path(&path).exists());
+        assert_eq!(load(&path).unwrap(), data);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_optional_missing_is_none() {
+        let dir = temp_dir("missing");
+        let path = dir.join("nope.resume");
+        assert!(load_optional(&path).unwrap().is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn corrupt_resume_is_ignored() {
+        let dir = temp_dir("corrupt");
+        let path = dir.join("bad.resume");
+        std::fs::write(&path, b"not bencode!!!!").unwrap();
+        assert!(load_optional(&path).unwrap().is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unsupported_version_is_error() {
+        let mut data = sample_data();
+        data.version = 99;
+        let bytes = serde_bencode::to_bytes(&data).unwrap();
+        assert!(matches!(
+            decode(&bytes),
+            Err(ResumeError::UnsupportedVersion(99))
+        ));
+    }
+
+    #[test]
+    fn files_match_requires_size_and_mtime() {
+        let dir = temp_dir("mtime");
+        let file = dir.join("out.bin");
+        std::fs::write(&file, [1u8; 8]).unwrap();
+        let torrent = torrent_one_file("out.bin", 8);
+        let layout = collect_file_layout(&torrent, &file);
+        assert!(files_match(&layout, &torrent, &file));
+
+        let mut mismatch = layout.clone();
+        mismatch[0].mtime += 1;
+        assert!(!files_match(&mismatch, &torrent, &file));
+
+        mismatch = layout;
+        mismatch[0].length += 1;
+        assert!(!files_match(&mismatch, &torrent, &file));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn resume_and_cache_paths_use_hex_hash() {
+        let hash = [
+            0x0f, 0xab, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+            0xcc, 0xdd, 0xee, 0xff, 0x01, 0x02,
+        ];
+        let hex = info_hash_hex(&hash);
+        assert_eq!(hex.len(), 40);
+        let state = Path::new("/tmp/state");
+        assert_eq!(
+            resume_path(state, &hash),
+            PathBuf::from("/tmp/state/resume").join(format!("{hex}.resume"))
+        );
+        assert_eq!(
+            torrent_cache_path(state, &hash),
+            PathBuf::from("/tmp/state/torrents").join(format!("{hex}.torrent"))
+        );
+    }
+}

--- a/crates/bit_rev/src/seeding_tests.rs
+++ b/crates/bit_rev/src/seeding_tests.rs
@@ -75,6 +75,7 @@ async fn start_seeder(
 
     let session = Session::with_options(SessionOptions {
         listen_port: 0,
+        state_dir: None,
         ..SessionOptions::default()
     });
     let addr = tokio::time::timeout(Duration::from_secs(2), session.wait_listening())

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -5,11 +5,15 @@ use std::sync::{Arc, Mutex};
 
 use crate::file::{self, TorrentMeta};
 use crate::handshake::Handshake;
+use crate::message::{Message, WriterRequest};
 use crate::peer_connection::{
     try_spawn_peer, PieceWorkState, SpawnPeerParams, TorrentDownloadedState,
 };
 use crate::peer_state::PeerStates;
 use crate::protocol::Protocol;
+use crate::resume::{self, ResumeSnapshot};
+
+pub use crate::resume::ResumeStatus;
 use crate::storage::Storage;
 use crate::torrent::Torrent;
 use crate::tracker_peers::TrackerPeers;
@@ -45,12 +49,15 @@ pub struct PieceResult {
 pub const DEFAULT_LISTEN_PORT: u16 = 6881;
 pub const DEFAULT_MAX_PEERS_PER_TORRENT: usize = 55;
 pub const DEFAULT_MAX_PEERS_GLOBAL: usize = 200;
+pub const RESUME_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 pub struct SessionOptions {
     pub listen_port: u16,
     pub max_peers_per_torrent: usize,
     pub max_peers_global: usize,
+    /// Directory for resume data and cached torrents. `None` disables persistence.
+    pub state_dir: Option<PathBuf>,
 }
 
 impl Default for SessionOptions {
@@ -59,6 +66,7 @@ impl Default for SessionOptions {
             listen_port: DEFAULT_LISTEN_PORT,
             max_peers_per_torrent: DEFAULT_MAX_PEERS_PER_TORRENT,
             max_peers_global: DEFAULT_MAX_PEERS_GLOBAL,
+            state_dir: Some(util::paths::state_dir()),
         }
     }
 }
@@ -75,6 +83,10 @@ pub struct TorrentSession {
     pub torrent: Arc<Torrent>,
     pub torrent_meta: TorrentMeta,
     pub choke_notify: Arc<Notify>,
+    pub output_dir: PathBuf,
+    pub added_at: i64,
+    pub completed_at: Arc<Mutex<Option<i64>>>,
+    pub torrent_cache_path: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -98,6 +110,7 @@ pub struct AddTorrentOptions {
     torrent_meta: TorrentMeta,
     output_dir: Option<PathBuf>,
     seed: bool,
+    verify: bool,
 }
 
 impl AddTorrentOptions {
@@ -106,6 +119,7 @@ impl AddTorrentOptions {
             torrent_meta,
             output_dir: None,
             seed: false,
+            verify: false,
         }
     }
 
@@ -121,6 +135,11 @@ impl AddTorrentOptions {
 
     pub fn seed(mut self, seed: bool) -> Self {
         self.seed = seed;
+        self
+    }
+
+    pub fn verify(mut self, verify: bool) -> Self {
+        self.verify = verify;
         self
     }
 }
@@ -141,6 +160,8 @@ pub struct AddTorrentResult {
     pub torrent: Torrent,
     pub torrent_meta: TorrentMeta,
     pub pr_rx: Receiver<PieceResult>,
+    pub resume_status: ResumeStatus,
+    pub already_have: Vec<PieceResult>,
 }
 
 impl Session {
@@ -280,11 +301,11 @@ impl Session {
             *state = DownloadState::Paused;
         }
         for entry in self.torrents.iter() {
-            entry
-                .value()
-                .tracker
-                .set_download_state(DownloadState::Paused);
+            let torrent = entry.value();
+            torrent.tracker.set_download_state(DownloadState::Paused);
+            choke_all_peers(&torrent.peer_states);
         }
+        self.spawn_flush_resume();
     }
 
     pub fn resume(&self) {
@@ -293,11 +314,13 @@ impl Session {
             *state = DownloadState::Downloading;
         }
         for entry in self.torrents.iter() {
-            entry
-                .value()
+            let torrent = entry.value();
+            torrent
                 .tracker
                 .set_download_state(DownloadState::Downloading);
+            torrent.choke_notify.notify_waiters();
         }
+        self.spawn_flush_resume();
     }
 
     pub fn get_download_state(&self) -> DownloadState {
@@ -321,6 +344,81 @@ impl Session {
         for entry in self.torrents.iter() {
             entry.value().tracker.shutdown();
         }
+    }
+
+    pub async fn flush_resume(&self) {
+        let Some(state_dir) = self.options.state_dir.as_ref() else {
+            return;
+        };
+        let torrents: Vec<Arc<TorrentSession>> = self
+            .torrents
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        for torrent in torrents {
+            if let Err(e) = persist_torrent(state_dir, &torrent) {
+                warn!(
+                    name = %torrent.torrent.name,
+                    error = %e,
+                    "failed to flush resume data"
+                );
+            }
+        }
+    }
+
+    pub async fn shutdown_graceful(&self) {
+        self.flush_resume().await;
+        self.shutdown();
+    }
+
+    fn spawn_flush_resume(&self) {
+        let Some(state_dir) = self.options.state_dir.clone() else {
+            return;
+        };
+        let torrents: Vec<Arc<TorrentSession>> = self
+            .torrents
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        tokio::spawn(async move {
+            for torrent in torrents {
+                if let Err(e) = persist_torrent(&state_dir, &torrent) {
+                    warn!(
+                        name = %torrent.torrent.name,
+                        error = %e,
+                        "failed to persist resume data"
+                    );
+                }
+            }
+        });
+    }
+
+    pub fn connect_peer(&self, info_hash: &[u8; 20], addr: SocketAddr) -> bool {
+        let Some(torrent) = self.torrents.get(info_hash).map(|entry| entry.clone()) else {
+            return false;
+        };
+        try_spawn_peer(SpawnPeerParams {
+            peer: addr,
+            info_hash: *info_hash,
+            peer_id: self.peer_id,
+            piece_tx: torrent.piece_tx.clone(),
+            have_broadcast: torrent.have_broadcast.clone(),
+            torrent_downloaded_state: torrent.downloaded_state.clone(),
+            peer_states: torrent.peer_states.clone(),
+            download_state: torrent.download_state.clone(),
+            storage: torrent.storage.clone(),
+            uploaded: torrent.uploaded.clone(),
+            torrent: torrent.torrent.clone(),
+            choke_notify: torrent.choke_notify.clone(),
+            incoming: None,
+            global_peers: self.global_peers.clone(),
+            max_peers_per_torrent: self.options.max_peers_per_torrent,
+            max_peers_global: self.options.max_peers_global,
+        })
+    }
+
+    pub fn torrent_session(&self, info_hash: &[u8; 20]) -> Option<Arc<TorrentSession>> {
+        self.torrents.get(info_hash).map(|entry| entry.clone())
     }
 
     pub fn remove_torrent(&self, info_hash: &[u8; 20]) {
@@ -351,13 +449,58 @@ impl Session {
         let output_dir = add_torrent
             .output_dir
             .unwrap_or_else(|| PathBuf::from(&torrent.name));
+
+        let torrent_cache_path = if let Some(state_dir) = self.options.state_dir.as_ref() {
+            resume::cache_torrent_file(state_dir, &torrent.info_hash, &torrent_meta.torrent_file)
+        } else {
+            PathBuf::new()
+        };
+
+        let resume_file = self
+            .options
+            .state_dir
+            .as_ref()
+            .map(|dir| resume::resume_path(dir, &torrent.info_hash));
+        let loaded_resume = match resume_file.as_ref() {
+            Some(path) => resume::load_optional(path)?,
+            None => None,
+        };
+        let loaded_resume = loaded_resume.filter(|data| match data.info_hash() {
+            Some(hash) if hash == torrent.info_hash => true,
+            _ => {
+                warn!("resume file info hash does not match torrent, starting fresh");
+                false
+            }
+        });
+        let resume_existed = resume_file.as_ref().is_some_and(|path| path.exists());
+        let resume_unreadable = resume_existed && loaded_resume.is_none();
+
+        let fast_path = match &loaded_resume {
+            Some(data) if !add_torrent.verify => {
+                resume::files_match(&data.files, &torrent, &output_dir)
+            }
+            _ => false,
+        };
+
         let storage = Storage::open(&torrent, &output_dir).await?;
 
         let (pr_tx, pr_rx) = flume::bounded::<PieceResult>(torrent.piece_hashes.len().max(1));
         let have_broadcast = Arc::new(tokio::sync::broadcast::channel(128).0);
         let peer_states = Arc::new(PeerStates::default());
-        let uploaded = Arc::new(AtomicU64::new(0));
+        let uploaded = Arc::new(AtomicU64::new(
+            loaded_resume
+                .as_ref()
+                .map(|data| data.uploaded.max(0) as u64)
+                .unwrap_or(0),
+        ));
         let choke_notify = Arc::new(Notify::new());
+        let added_at = loaded_resume
+            .as_ref()
+            .map(|data| data.added_at)
+            .unwrap_or_else(resume::now_unix);
+        let completed_at = Arc::new(Mutex::new(
+            loaded_resume.as_ref().and_then(|data| data.completed_at()),
+        ));
 
         let pieces_of_work = (0..torrent.piece_hashes.len())
             .map(|index| {
@@ -382,9 +525,42 @@ impl Session {
                 })
                 .collect(),
         });
-        if add_torrent.seed {
+
+        let resume_status = if add_torrent.seed {
             downloaded_state.mark_all_downloaded();
+            ResumeStatus::Fresh
+        } else if let Some(data) = &loaded_resume {
+            if fast_path {
+                resume::apply_bitfield(&downloaded_state, &data.bitfield());
+                ResumeStatus::FastPath
+            } else {
+                resume::verify_existing_pieces(&storage, &downloaded_state).await;
+                ResumeStatus::SlowPath
+            }
+        } else if resume_unreadable {
+            ResumeStatus::Corrupt
+        } else {
+            ResumeStatus::Fresh
+        };
+
+        let already_have: Vec<PieceResult> = downloaded_state
+            .pieces
+            .iter()
+            .filter(|pw| pw.downloaded.load(Ordering::Relaxed))
+            .map(|pw| PieceResult {
+                index: pw.piece_work.index,
+                length: pw.piece_work.length,
+            })
+            .collect();
+
+        if downloaded_state.is_complete() {
+            let mut done = completed_at.lock().unwrap();
+            if done.is_none() {
+                *done = Some(resume::now_unix());
+            }
         }
+
+        let start_paused = loaded_resume.as_ref().is_some_and(|data| data.is_paused());
 
         let tracker_stream = TrackerPeers::new(
             torrent_meta.clone(),
@@ -428,6 +604,14 @@ impl Session {
         let piece_rx = tracker_stream.piece_rx.clone();
         let storage_writer = storage.clone();
         let downloaded_writer = downloaded_state.clone();
+        let persist_state_dir = self.options.state_dir.clone();
+        let persist_output_dir = output_dir.clone();
+        let persist_torrent = torrent.clone();
+        let persist_uploaded = uploaded.clone();
+        let persist_download_state = self.download_state.clone();
+        let persist_added_at = added_at;
+        let persist_completed_at = completed_at.clone();
+        let persist_cache_path = torrent_cache_path.clone();
         tokio::spawn(async move {
             loop {
                 let piece = match piece_rx.recv_async().await {
@@ -438,6 +622,28 @@ impl Session {
                     debug!(index = piece.index, error = %e, "failed to write piece");
                     downloaded_writer.remove_downloaded(piece.index);
                     continue;
+                }
+                if downloaded_writer.is_complete() {
+                    let mut done = persist_completed_at.lock().unwrap();
+                    if done.is_none() {
+                        *done = Some(resume::now_unix());
+                    }
+                }
+                if let Some(state_dir) = persist_state_dir.as_ref() {
+                    if let Err(e) = persist_from_parts(
+                        state_dir,
+                        &persist_torrent.info_hash,
+                        &persist_output_dir,
+                        &persist_torrent,
+                        &downloaded_writer,
+                        persist_uploaded.load(Ordering::Relaxed),
+                        *persist_download_state.lock().unwrap() == DownloadState::Paused,
+                        &persist_cache_path,
+                        persist_added_at,
+                        *persist_completed_at.lock().unwrap(),
+                    ) {
+                        debug!(error = %e, "failed to persist resume after piece write");
+                    }
                 }
                 let _ = have_broadcast_writer.send(piece.index);
                 if pr_tx
@@ -454,30 +660,126 @@ impl Session {
         });
 
         let piece_tx = tracker_stream.piece_tx.clone();
-        self.torrents.insert(
-            torrent.info_hash,
-            Arc::new(TorrentSession {
-                tracker: tracker_stream,
-                storage,
-                downloaded_state,
-                peer_states,
-                piece_tx,
-                have_broadcast,
-                download_state: self.download_state.clone(),
-                uploaded,
-                torrent: torrent.clone(),
-                torrent_meta: torrent_meta.clone(),
-                choke_notify,
-            }),
-        );
+        let torrent_session = Arc::new(TorrentSession {
+            tracker: tracker_stream,
+            storage,
+            downloaded_state,
+            peer_states,
+            piece_tx,
+            have_broadcast,
+            download_state: self.download_state.clone(),
+            uploaded,
+            torrent: torrent.clone(),
+            torrent_meta: torrent_meta.clone(),
+            choke_notify,
+            output_dir,
+            added_at,
+            completed_at,
+            torrent_cache_path,
+        });
+        self.torrents
+            .insert(torrent.info_hash, torrent_session.clone());
 
-        self.start_downloading();
+        if let Some(state_dir) = self.options.state_dir.clone() {
+            spawn_resume_timer(torrent_session, state_dir, self.cancel.clone());
+        }
+
+        if start_paused {
+            self.pause();
+        } else {
+            self.start_downloading();
+        }
 
         Ok(AddTorrentResult {
             torrent: (*torrent).clone(),
             torrent_meta,
             pr_rx,
+            resume_status,
+            already_have,
         })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn persist_from_parts(
+    state_dir: &std::path::Path,
+    info_hash: &[u8; 20],
+    output_dir: &std::path::Path,
+    torrent: &Torrent,
+    downloaded_state: &TorrentDownloadedState,
+    uploaded: u64,
+    paused: bool,
+    torrent_path: &std::path::Path,
+    added_at: i64,
+    completed_at: Option<i64>,
+) -> Result<PathBuf, resume::ResumeError> {
+    resume::persist(
+        state_dir,
+        ResumeSnapshot {
+            info_hash,
+            output_dir,
+            torrent,
+            downloaded_state,
+            uploaded,
+            paused,
+            torrent_path,
+            added_at,
+            completed_at,
+        },
+    )
+}
+
+fn persist_torrent(
+    state_dir: &std::path::Path,
+    torrent: &TorrentSession,
+) -> Result<PathBuf, resume::ResumeError> {
+    persist_from_parts(
+        state_dir,
+        &torrent.torrent.info_hash,
+        &torrent.output_dir,
+        &torrent.torrent,
+        &torrent.downloaded_state,
+        torrent.uploaded.load(Ordering::Relaxed),
+        *torrent.download_state.lock().unwrap() == DownloadState::Paused,
+        &torrent.torrent_cache_path,
+        torrent.added_at,
+        *torrent.completed_at.lock().unwrap(),
+    )
+}
+
+fn spawn_resume_timer(torrent: Arc<TorrentSession>, state_dir: PathBuf, cancel: CancellationToken) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(RESUME_FLUSH_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        interval.tick().await;
+        let torrent_cancel = torrent.tracker.cancel_token();
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => break,
+                _ = torrent_cancel.cancelled() => break,
+                _ = interval.tick() => {
+                    let downloading =
+                        *torrent.download_state.lock().unwrap() == DownloadState::Downloading;
+                    if downloading {
+                        if let Err(e) = persist_torrent(&state_dir, &torrent) {
+                            debug!(error = %e, "periodic resume persist failed");
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn choke_all_peers(peer_states: &PeerStates) {
+    for mut state in peer_states.states.iter_mut() {
+        if !state.stats.am_choking.load(Ordering::Relaxed) {
+            state.set_am_choking(true);
+            state.is_optimistic = false;
+            if let Some(tx) = &state.writer_tx {
+                let _ = tx.send(WriterRequest::Message(Message::Choke));
+            }
+        }
     }
 }
 

--- a/crates/bit_rev/src/storage/mod.rs
+++ b/crates/bit_rev/src/storage/mod.rs
@@ -1,5 +1,5 @@
 use std::io::SeekFrom;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::fs::{File, OpenOptions};
@@ -24,6 +24,23 @@ pub struct Storage {
     files: Vec<Mutex<File>>,
 }
 
+/// Resolve the on-disk path for torrent file `file_index`.
+/// Single-file torrent: `output_dir` is the file path.
+/// Multi-file torrent: `output_dir` is the root directory.
+pub fn file_path(torrent: &Torrent, output_dir: &Path, file_index: usize) -> PathBuf {
+    if torrent.files.len() == 1 {
+        output_dir.to_path_buf()
+    } else {
+        let mut path = output_dir.to_path_buf();
+        if let Some(file_info) = torrent.files.get(file_index) {
+            for component in &file_info.path {
+                path.push(component);
+            }
+        }
+        path
+    }
+}
+
 impl Storage {
     /// Open (or create) files under `output_dir` without truncating existing data.
     /// Single-file torrent: `output_dir` is the file path (may be a file name, not a directory).
@@ -37,18 +54,10 @@ impl Storage {
         let output_dir = output_dir.as_ref();
         let mut files = Vec::with_capacity(torrent.files.len());
 
-        for file_info in &torrent.files {
-            let file_path = if torrent.files.len() == 1 {
-                output_dir.to_path_buf()
-            } else {
-                let mut path = output_dir.to_path_buf();
-                for component in &file_info.path {
-                    path.push(component);
-                }
-                path
-            };
+        for file_index in 0..torrent.files.len() {
+            let disk_path = file_path(torrent, output_dir, file_index);
 
-            if let Some(parent) = file_path.parent() {
+            if let Some(parent) = disk_path.parent() {
                 if !parent.as_os_str().is_empty() {
                     tokio::fs::create_dir_all(parent).await?;
                 }
@@ -59,7 +68,7 @@ impl Storage {
                 .write(true)
                 .create(true)
                 .truncate(false)
-                .open(&file_path)
+                .open(&disk_path)
                 .await?;
             files.push(Mutex::new(file));
         }

--- a/crates/bit_rev/src/tracker.rs
+++ b/crates/bit_rev/src/tracker.rs
@@ -148,6 +148,7 @@ impl HttpAnnounceContext {
 enum Wake {
     IntervalElapsed,
     Completed,
+    Paused,
     Shutdown,
 }
 
@@ -229,10 +230,18 @@ pub async fn run_announce_loop<F, Fut>(
                     &shutdown,
                     &ctx.torrent_downloaded_state,
                     sent_completed,
+                    &ctx.download_state,
                 )
                 .await
                 {
                     Wake::Shutdown => break,
+                    Wake::Paused => {
+                        let params = current_announce_params(&ctx, None, tracker_id.clone());
+                        let _ = dispatch_announce(&ctx, &params, udp.as_mut()).await;
+                        if !wait_until_downloading(&ctx.download_state, &shutdown).await {
+                            break;
+                        }
+                    }
                     Wake::Completed | Wake::IntervalElapsed => {}
                 }
             }
@@ -245,10 +254,16 @@ pub async fn run_announce_loop<F, Fut>(
                     &shutdown,
                     &ctx.torrent_downloaded_state,
                     sent_completed,
+                    &ctx.download_state,
                 )
                 .await
                 {
                     Wake::Shutdown => break,
+                    Wake::Paused => {
+                        if !wait_until_downloading(&ctx.download_state, &shutdown).await {
+                            break;
+                        }
+                    }
                     Wake::Completed | Wake::IntervalElapsed => {}
                 }
             }
@@ -390,6 +405,7 @@ async fn wait_reannounce(
     shutdown: &CancellationToken,
     torrent_downloaded_state: &TorrentDownloadedState,
     sent_completed: bool,
+    download_state: &Arc<Mutex<DownloadState>>,
 ) -> Wake {
     if shutdown.is_cancelled() {
         return Wake::Shutdown;
@@ -408,6 +424,9 @@ async fn wait_reannounce(
             _ = shutdown.cancelled() => return Wake::Shutdown,
             _ = &mut sleep => return Wake::IntervalElapsed,
             _ = tick.tick() => {
+                if *download_state.lock().unwrap() == DownloadState::Paused {
+                    return Wake::Paused;
+                }
                 if !sent_completed && torrent_downloaded_state.is_complete() {
                     return Wake::Completed;
                 }

--- a/crates/bit_rev/tests/resume.rs
+++ b/crates/bit_rev/tests/resume.rs
@@ -1,0 +1,581 @@
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_bytes::ByteBuf;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::sync::CancellationToken;
+
+use bit_rev::bitfield::Bitfield;
+use bit_rev::file::{Info, TorrentFile, TorrentMeta};
+use bit_rev::handshake::Handshake;
+use bit_rev::message::{self, BlockRequest, Message};
+use bit_rev::protocol::Protocol;
+use bit_rev::resume::{self, ResumeData, ResumeStatus};
+use bit_rev::session::{AddTorrentOptions, Session, SessionOptions};
+use bit_rev::torrent::Torrent;
+use bit_rev::utils;
+
+fn sha1(data: &[u8]) -> [u8; 20] {
+    let mut hasher = sha1_smol::Sha1::new();
+    hasher.update(data);
+    hasher.digest().bytes()
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "bitrev-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn generated_payload(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+fn torrent_meta(name: &str, data: &[u8], piece_length: i64) -> TorrentMeta {
+    let mut pieces = Vec::new();
+    for chunk in data.chunks(piece_length as usize) {
+        pieces.extend_from_slice(&sha1(chunk));
+    }
+    TorrentMeta::new(TorrentFile {
+        info: Info {
+            name: name.into(),
+            pieces: ByteBuf::from(pieces),
+            piece_length,
+            md5sum: None,
+            length: Some(data.len() as i64),
+            files: None,
+            private: None,
+            path: None,
+            root_hash: None,
+        },
+        announce: None,
+        nodes: None,
+        encoding: None,
+        httpseeds: None,
+        announce_list: None,
+        creation_date: None,
+        comment: None,
+        created_by: None,
+    })
+    .expect("torrent meta")
+}
+
+fn test_session(state_dir: Option<PathBuf>) -> Session {
+    Session::with_options(SessionOptions {
+        listen_port: 0,
+        state_dir,
+        ..SessionOptions::default()
+    })
+}
+
+fn bitfield_with(piece_count: usize, have: &[usize]) -> Bitfield {
+    let mut bitfield = Bitfield::with_piece_count(piece_count);
+    for &i in have {
+        bitfield.set_piece(i);
+    }
+    bitfield
+}
+
+async fn write_msg(stream: &mut TcpStream, msg: Message) {
+    stream
+        .write_all(&message::serialize(Some(msg)))
+        .await
+        .unwrap();
+}
+
+struct RecordingSeeder {
+    addr: SocketAddr,
+    requested: Arc<Mutex<Vec<u32>>>,
+    cancel: CancellationToken,
+}
+
+impl Drop for RecordingSeeder {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+async fn start_recording_seeder(
+    data: Vec<u8>,
+    piece_length: i64,
+    info_hash: [u8; 20],
+    allowed_pieces: Option<HashSet<u32>>,
+) -> RecordingSeeder {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let requested = Arc::new(Mutex::new(Vec::new()));
+    let cancel = CancellationToken::new();
+    let requested_task = requested.clone();
+    let cancel_task = cancel.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cancel_task.cancelled() => break,
+                accepted = listener.accept() => {
+                    let Ok((stream, _)) = accepted else { break };
+                    let data = data.clone();
+                    let requested = requested_task.clone();
+                    let allowed = allowed_pieces.clone();
+                    let cancel = cancel_task.clone();
+                    tokio::spawn(async move {
+                        let _ = serve_recording_peer(
+                            stream,
+                            info_hash,
+                            &data,
+                            piece_length,
+                            requested,
+                            allowed,
+                            cancel,
+                        )
+                        .await;
+                    });
+                }
+            }
+        }
+    });
+    RecordingSeeder {
+        addr,
+        requested,
+        cancel,
+    }
+}
+
+async fn serve_recording_peer(
+    mut stream: TcpStream,
+    info_hash: [u8; 20],
+    data: &[u8],
+    piece_length: i64,
+    requested: Arc<Mutex<Vec<u32>>>,
+    allowed_pieces: Option<HashSet<u32>>,
+    cancel: CancellationToken,
+) -> anyhow::Result<()> {
+    let _hs = Protocol::read_handshake(&mut stream).await?;
+    let reply = Handshake::new(info_hash, *b"-RV0001-0123456789ab");
+    Protocol::write_handshake(&mut stream, &reply).await?;
+
+    let piece_count = data.len().div_ceil(piece_length as usize);
+    let mut bf = Bitfield::with_piece_count(piece_count);
+    for i in 0..piece_count {
+        bf.set_piece(i);
+    }
+    write_msg(&mut stream, Message::Bitfield(bf.as_bytes().to_vec())).await;
+    write_msg(&mut stream, Message::Unchoke).await;
+
+    let proto = Protocol::connect(
+        stream.peer_addr().unwrap(),
+        info_hash,
+        *b"-RV0001-0123456789ab",
+    )
+    .await?;
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            msg = proto.read(&mut stream) => {
+                let msg = match msg {
+                    Ok(Some(msg)) => msg,
+                    Ok(None) => continue,
+                    Err(_) => break,
+                };
+                match msg {
+                    Message::Interested => {
+                        write_msg(&mut stream, Message::Unchoke).await;
+                    }
+                    Message::Request(payload) => {
+                        let Some(req) = BlockRequest::from_payload(&payload) else {
+                            continue;
+                        };
+                        requested.lock().unwrap().push(req.index);
+                        if let Some(allowed) = &allowed_pieces {
+                            if !allowed.contains(&req.index) {
+                                continue;
+                            }
+                        }
+                        let start = req.index as usize * piece_length as usize + req.begin as usize;
+                        let end = (start + req.length as usize).min(data.len());
+                        if start >= data.len() || start >= end {
+                            continue;
+                        }
+                        write_msg(
+                            &mut stream,
+                            message::format_piece(req.index, req.begin, data[start..end].to_vec()),
+                        )
+                        .await;
+                    }
+                    Message::NotInterested | Message::Bitfield(_) | Message::Have(_) | Message::KeepAlive | Message::Choke | Message::Unchoke => {}
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn assert_file_hash(path: &std::path::Path, expected: &[u8]) {
+    let got = std::fs::read(path).expect("read output");
+    assert_eq!(got.len(), expected.len());
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+async fn kill_and_restart_continues_from_persisted_bitfield() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(PIECE_LEN as usize * 4 + 100);
+    let meta = torrent_meta("resume.bin", &data, PIECE_LEN);
+    let piece_count = meta.piece_hashes.len();
+    assert!(piece_count > 2);
+
+    let state_dir = unique_temp_dir("resume-kill");
+    let output = state_dir.join("out.bin");
+    let first_seeder = start_recording_seeder(
+        data.clone(),
+        PIECE_LEN,
+        meta.info_hash,
+        Some(HashSet::from([0])),
+    )
+    .await;
+
+    let first = test_session(Some(state_dir.clone()));
+    let _ = tokio::time::timeout(Duration::from_secs(2), first.wait_listening()).await;
+    let add = first
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output.clone()))
+        .await
+        .expect("add first leecher");
+    assert!(first.connect_peer(&meta.info_hash, first_seeder.addr));
+
+    let first_piece = tokio::time::timeout(Duration::from_secs(5), add.pr_rx.recv_async())
+        .await
+        .expect("first piece timeout")
+        .expect("first piece");
+    assert_eq!(first_piece.index, 0);
+
+    first.flush_resume().await;
+    drop(first);
+    drop(first_seeder);
+
+    let second = test_session(Some(state_dir.clone()));
+    let _ = tokio::time::timeout(Duration::from_secs(2), second.wait_listening()).await;
+    let add = second
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output.clone()))
+        .await
+        .expect("add second leecher");
+    assert_eq!(add.resume_status, ResumeStatus::FastPath);
+    assert!(
+        add.already_have.iter().any(|pr| pr.index == 0),
+        "restart should trust persisted piece 0"
+    );
+    let already: HashSet<u32> = add.already_have.iter().map(|pr| pr.index).collect();
+    assert!(!already.contains(&1));
+
+    let second_seeder = start_recording_seeder(data.clone(), PIECE_LEN, meta.info_hash, None).await;
+    assert!(second.connect_peer(&meta.info_hash, second_seeder.addr));
+
+    let mut have = already.clone();
+    while have.len() < piece_count {
+        let pr = tokio::time::timeout(Duration::from_secs(5), add.pr_rx.recv_async())
+            .await
+            .expect("resume piece timeout")
+            .expect("resume piece");
+        have.insert(pr.index);
+    }
+
+    second.flush_resume().await;
+    let requested: HashSet<u32> = second_seeder
+        .requested
+        .lock()
+        .unwrap()
+        .iter()
+        .copied()
+        .collect();
+    for index in &already {
+        assert!(
+            !requested.contains(index),
+            "already-have piece {index} was requested after resume"
+        );
+    }
+    assert!(
+        requested.iter().any(|i| !already.contains(i)),
+        "expected requests for missing pieces, got {requested:?}"
+    );
+
+    assert_file_hash(&output, &data);
+    for (i, hash) in meta.piece_hashes.iter().enumerate() {
+        let start = i * PIECE_LEN as usize;
+        let end = (start + PIECE_LEN as usize).min(data.len());
+        assert!(utils::check_integrity(hash, &data[start..end]));
+    }
+    drop(second);
+    let _ = std::fs::remove_dir_all(&state_dir);
+}
+
+#[tokio::test]
+async fn crash_without_flush_does_not_corrupt_output() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(PIECE_LEN as usize * 3);
+    let meta = torrent_meta("crash.bin", &data, PIECE_LEN);
+    let state_dir = unique_temp_dir("resume-crash");
+    let output = state_dir.join("out.bin");
+
+    let seeder = start_recording_seeder(data.clone(), PIECE_LEN, meta.info_hash, None).await;
+    let first = test_session(Some(state_dir.clone()));
+    let _ = tokio::time::timeout(Duration::from_secs(2), first.wait_listening()).await;
+    let add = first
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output.clone()))
+        .await
+        .unwrap();
+    assert!(first.connect_peer(&meta.info_hash, seeder.addr));
+
+    let mut have = HashSet::new();
+    while have.len() < 2 {
+        let pr = tokio::time::timeout(Duration::from_secs(5), add.pr_rx.recv_async())
+            .await
+            .expect("piece timeout")
+            .unwrap();
+        have.insert(pr.index);
+    }
+    drop(first);
+    drop(seeder);
+
+    let on_disk = std::fs::read(&output).unwrap();
+    assert!(on_disk.len() >= PIECE_LEN as usize);
+
+    let second = test_session(Some(state_dir.clone()));
+    let add = second
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output.clone()))
+        .await
+        .unwrap();
+    assert!(matches!(
+        add.resume_status,
+        ResumeStatus::FastPath | ResumeStatus::SlowPath
+    ));
+    let seeder = start_recording_seeder(data.clone(), PIECE_LEN, meta.info_hash, None).await;
+    assert!(second.connect_peer(&meta.info_hash, seeder.addr));
+
+    let mut have: HashSet<u32> = add.already_have.iter().map(|pr| pr.index).collect();
+    while have.len() < meta.piece_hashes.len() {
+        let pr = tokio::time::timeout(Duration::from_secs(5), add.pr_rx.recv_async())
+            .await
+            .expect("finish timeout")
+            .unwrap();
+        have.insert(pr.index);
+    }
+    assert_file_hash(&output, &data);
+    drop(second);
+    let _ = std::fs::remove_dir_all(&state_dir);
+}
+
+#[tokio::test]
+async fn fast_path_trusts_bitfield_when_mtimes_match() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(PIECE_LEN as usize * 2);
+    let meta = torrent_meta("fast.bin", &data, PIECE_LEN);
+    let torrent = Torrent::new(&meta).unwrap();
+    let state_dir = unique_temp_dir("resume-fast");
+    let output = state_dir.join("out.bin");
+    std::fs::write(&output, &data).unwrap();
+
+    let layout = resume::collect_file_layout(&torrent, &output);
+    let bitfield = bitfield_with(meta.piece_hashes.len(), &[0]);
+    let resume_data = ResumeData {
+        version: resume::RESUME_VERSION,
+        info_hash: ByteBuf::from(meta.info_hash.to_vec()),
+        bitfield: ByteBuf::from(bitfield.as_bytes().to_vec()),
+        output_dir: output.to_string_lossy().into_owned(),
+        files: layout,
+        uploaded: 99,
+        downloaded: PIECE_LEN,
+        torrent_path: resume::torrent_cache_path(&state_dir, &meta.info_hash)
+            .to_string_lossy()
+            .into_owned(),
+        paused: 0,
+        added_at: 1,
+        completed_at: 0,
+    };
+    resume::save(
+        &resume::resume_path(&state_dir, &meta.info_hash),
+        &resume_data,
+    )
+    .unwrap();
+
+    let session = test_session(Some(state_dir.clone()));
+    let add = session
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output.clone()))
+        .await
+        .unwrap();
+    assert_eq!(add.resume_status, ResumeStatus::FastPath);
+    assert_eq!(add.already_have.len(), 1);
+    assert_eq!(add.already_have[0].index, 0);
+    assert_eq!(session.torrent_uploaded(&meta.info_hash), Some(99));
+    drop(session);
+    let _ = std::fs::remove_dir_all(&state_dir);
+}
+
+#[tokio::test]
+async fn slow_path_on_mtime_mismatch_rehashes() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(PIECE_LEN as usize * 2);
+    let meta = torrent_meta("slow.bin", &data, PIECE_LEN);
+    let torrent = Torrent::new(&meta).unwrap();
+    let state_dir = unique_temp_dir("resume-slow");
+    let output = state_dir.join("out.bin");
+    std::fs::write(&output, &data).unwrap();
+
+    let mut layout = resume::collect_file_layout(&torrent, &output);
+    layout[0].mtime += 5;
+    let bitfield = bitfield_with(meta.piece_hashes.len(), &[0]);
+    let resume_data = ResumeData {
+        version: resume::RESUME_VERSION,
+        info_hash: ByteBuf::from(meta.info_hash.to_vec()),
+        bitfield: ByteBuf::from(bitfield.as_bytes().to_vec()),
+        output_dir: output.to_string_lossy().into_owned(),
+        files: layout,
+        uploaded: 0,
+        downloaded: PIECE_LEN,
+        torrent_path: String::new(),
+        paused: 0,
+        added_at: 1,
+        completed_at: 0,
+    };
+    resume::save(
+        &resume::resume_path(&state_dir, &meta.info_hash),
+        &resume_data,
+    )
+    .unwrap();
+
+    let session = test_session(Some(state_dir.clone()));
+    let add = session
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output.clone()))
+        .await
+        .unwrap();
+    assert_eq!(add.resume_status, ResumeStatus::SlowPath);
+    assert_eq!(add.already_have.len(), meta.piece_hashes.len());
+    drop(session);
+    let _ = std::fs::remove_dir_all(&state_dir);
+}
+
+#[tokio::test]
+async fn verify_flag_forces_slow_path() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(PIECE_LEN as usize);
+    let meta = torrent_meta("verify.bin", &data, PIECE_LEN);
+    let torrent = Torrent::new(&meta).unwrap();
+    let state_dir = unique_temp_dir("resume-verify");
+    let output = state_dir.join("out.bin");
+    std::fs::write(&output, &data).unwrap();
+
+    let layout = resume::collect_file_layout(&torrent, &output);
+    let bitfield = bitfield_with(1, &[0]);
+    let resume_data = ResumeData {
+        version: resume::RESUME_VERSION,
+        info_hash: ByteBuf::from(meta.info_hash.to_vec()),
+        bitfield: ByteBuf::from(bitfield.as_bytes().to_vec()),
+        output_dir: output.to_string_lossy().into_owned(),
+        files: layout,
+        uploaded: 0,
+        downloaded: PIECE_LEN,
+        torrent_path: String::new(),
+        paused: 0,
+        added_at: 1,
+        completed_at: 0,
+    };
+    resume::save(
+        &resume::resume_path(&state_dir, &meta.info_hash),
+        &resume_data,
+    )
+    .unwrap();
+
+    let session = test_session(Some(state_dir.clone()));
+    let add = session
+        .add_torrent(
+            AddTorrentOptions::from(meta.clone())
+                .output_dir(output)
+                .verify(true),
+        )
+        .await
+        .unwrap();
+    assert_eq!(add.resume_status, ResumeStatus::SlowPath);
+    drop(session);
+    let _ = std::fs::remove_dir_all(&state_dir);
+}
+
+#[tokio::test]
+async fn corrupt_resume_file_starts_fresh() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(PIECE_LEN as usize);
+    let meta = torrent_meta("corrupt.bin", &data, PIECE_LEN);
+    let state_dir = unique_temp_dir("resume-corrupt-add");
+    let output = state_dir.join("out.bin");
+    std::fs::write(&output, &data).unwrap();
+    let path = resume::resume_path(&state_dir, &meta.info_hash);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, b"{{{{not-bencode").unwrap();
+
+    let session = test_session(Some(state_dir.clone()));
+    let add = session
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output))
+        .await
+        .unwrap();
+    assert_eq!(add.resume_status, ResumeStatus::Corrupt);
+    assert!(add.already_have.is_empty());
+    drop(session);
+    let _ = std::fs::remove_dir_all(&state_dir);
+}
+
+#[tokio::test]
+async fn paused_flag_survives_restart() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(PIECE_LEN as usize);
+    let meta = torrent_meta("paused.bin", &data, PIECE_LEN);
+    let state_dir = unique_temp_dir("resume-paused");
+    let output = state_dir.join("out.bin");
+
+    let first = test_session(Some(state_dir.clone()));
+    first
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output.clone()))
+        .await
+        .unwrap();
+    first.pause();
+    first.flush_resume().await;
+    assert!(first.is_paused());
+    drop(first);
+
+    let second = test_session(Some(state_dir.clone()));
+    second
+        .add_torrent(AddTorrentOptions::from(meta).output_dir(output))
+        .await
+        .unwrap();
+    assert!(second.is_paused());
+    drop(second);
+    let _ = std::fs::remove_dir_all(&state_dir);
+}
+
+#[tokio::test]
+async fn torrent_metainfo_is_cached_on_add() {
+    const PIECE_LEN: i64 = 16_384;
+    let data = generated_payload(32);
+    let meta = torrent_meta("cache.bin", &data, PIECE_LEN);
+    let state_dir = unique_temp_dir("resume-cache");
+    let output = state_dir.join("out.bin");
+    let session = test_session(Some(state_dir.clone()));
+    session
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(output))
+        .await
+        .unwrap();
+    let cached = resume::torrent_cache_path(&state_dir, &meta.info_hash);
+    assert!(cached.exists());
+    let loaded = bit_rev::file::from_filename(cached.to_str().unwrap()).unwrap();
+    assert_eq!(loaded.info_hash, meta.info_hash);
+    drop(session);
+    let _ = std::fs::remove_dir_all(&state_dir);
+}

--- a/crates/bit_rev/tests/tracker_udp.rs
+++ b/crates/bit_rev/tests/tracker_udp.rs
@@ -29,6 +29,12 @@ const ACTION_CONNECT: u32 = 0;
 const ACTION_ANNOUNCE: u32 = 1;
 const ACTION_ERROR: u32 = 3;
 
+static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock_tests() -> std::sync::MutexGuard<'static, ()> {
+    TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 fn test_meta(announce: String) -> TorrentMeta {
     TorrentMeta {
         torrent_file: TorrentFile {
@@ -239,7 +245,9 @@ async fn settle() {
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn announce_loop_round_trips_started_and_interval() {
+    let _lock = lock_tests();
     let (url, mut rx, handle) = spawn_udp_mock(vec![AnnounceReply::Peers { interval: 1800 }]).await;
     let peer_states = Arc::new(PeerStates::default());
     let shutdown = CancellationToken::new();
@@ -276,7 +284,9 @@ async fn announce_loop_round_trips_started_and_interval() {
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn announce_loop_respects_interval_and_sends_stopped() {
+    let _lock = lock_tests();
     tokio::time::pause();
     let (url, mut rx, handle) = spawn_udp_mock(vec![AnnounceReply::Peers { interval: 1800 }]).await;
     let shutdown = CancellationToken::new();
@@ -312,7 +322,9 @@ async fn announce_loop_respects_interval_and_sends_stopped() {
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn announce_loop_retries_error_packet_with_backoff() {
+    let _lock = lock_tests();
     tokio::time::pause();
     let (url, mut rx, handle) = spawn_udp_mock(vec![
         AnnounceReply::Error,
@@ -346,7 +358,9 @@ async fn announce_loop_retries_error_packet_with_backoff() {
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn announce_loop_reuses_connection_id_until_expiry() {
+    let _lock = lock_tests();
     let (url, mut rx, handle) = spawn_udp_mock(vec![
         AnnounceReply::Peers { interval: 1800 },
         AnnounceReply::Peers { interval: 1800 },

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -14,18 +14,46 @@ async fn main() {
     #[cfg(feature = "tokio-console")]
     console_subscriber::init();
 
-    let filename = std::env::args().nth(1).expect("No torrent path given");
-    let output = std::env::args().nth(2);
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let verify = args.iter().any(|arg| arg == "--verify");
+    let positional: Vec<&str> = args
+        .iter()
+        .filter(|arg| !arg.starts_with('-'))
+        .map(String::as_str)
+        .collect();
+    let filename = positional.first().copied().expect("No torrent path given");
+    let output = positional.get(1).map(|s| (*s).to_string());
 
-    if let Err(err) = download_file(&filename, output).await {
+    if let Err(err) = download_file(filename, output, verify).await {
         eprintln!("Error: {:?}", err);
     }
 }
 
-pub async fn download_file(filename: &str, out_file: Option<String>) -> anyhow::Result<()> {
+async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+    #[cfg(unix)]
+    {
+        let mut term = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("install SIGTERM handler");
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = ctrl_c.await;
+    }
+}
+
+pub async fn download_file(
+    filename: &str,
+    out_file: Option<String>,
+    verify: bool,
+) -> anyhow::Result<()> {
     let session = Session::new();
 
-    let mut add_opts = AddTorrentOptions::from(filename);
+    let mut add_opts = AddTorrentOptions::from(filename).verify(verify);
     if let Some(output) = out_file {
         add_opts = add_opts.output_dir(output);
     }
@@ -58,14 +86,37 @@ pub async fn download_file(filename: &str, out_file: Option<String>) -> anyhow::
     });
 
     let mut hashset = std::collections::HashSet::new();
-    while hashset.len() < torrent.piece_hashes.len() {
-        let pr = add_torrent_result.pr_rx.recv_async().await?;
+    for pr in &add_torrent_result.already_have {
         hashset.insert(pr.index);
         total_downloaded.fetch_add(pr.length as u64, std::sync::atomic::Ordering::Relaxed);
     }
 
-    session.shutdown();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let download = async {
+        while hashset.len() < torrent.piece_hashes.len() {
+            let pr = add_torrent_result.pr_rx.recv_async().await?;
+            hashset.insert(pr.index);
+            total_downloaded.fetch_add(pr.length as u64, std::sync::atomic::Ordering::Relaxed);
+        }
+        anyhow::Ok(())
+    };
+
+    tokio::select! {
+        result = download => {
+            result?;
+            session.shutdown_graceful().await;
+        }
+        _ = shutdown_signal() => {
+            eprintln!("Shutting down...");
+            session.shutdown_graceful().await;
+            tokio::select! {
+                _ = shutdown_signal() => {
+                    eprintln!("Forced exit");
+                    std::process::exit(130);
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_secs(8)) => {}
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 
 lazy_static::lazy_static! {
     pub static ref HOME: PathBuf = dirs::home_dir().expect("failed to determine home directory");
+    /// Client state directory. Hardcoded until the config system (issue #21) lands.
+    pub static ref STATE_DIR: PathBuf = HOME.join(".bitrev");
     pub static ref CONFIG_DIR: PathBuf = HOME.join(".config").join("bit_rev");
     pub static ref CONVERSATIONS_DIR: PathBuf = CONFIG_DIR.join("conversations");
     pub static ref EMBEDDINGS_DIR: PathBuf = CONFIG_DIR.join("embeddings");
@@ -38,6 +40,21 @@ lazy_static::lazy_static! {
     pub static ref TASKS: PathBuf = CONFIG_DIR.join("tasks.json");
     pub static ref LOG: PathBuf = LOGS_DIR.join("BitRev.log");
     pub static ref OLD_LOG: PathBuf = LOGS_DIR.join("BitRev.log.old");
+}
+
+/// Default client state directory (`~/.bitrev`).
+pub fn state_dir() -> PathBuf {
+    STATE_DIR.clone()
+}
+
+/// Resume files: `<state_dir>/resume/<info_hash_hex>.resume`.
+pub fn resume_dir(state_dir: &Path) -> PathBuf {
+    state_dir.join("resume")
+}
+
+/// Cached torrent metainfo: `<state_dir>/torrents/<info_hash_hex>.torrent`.
+pub fn torrents_dir(state_dir: &Path) -> PathBuf {
+    state_dir.join("torrents")
 }
 
 pub trait PathExt {
@@ -379,6 +396,19 @@ mod tests {
                 "For special case input str '{input}', got a parse mismatch"
             );
         }
+    }
+
+    #[test]
+    fn state_dir_is_home_bitrev() {
+        assert_eq!(state_dir(), HOME.join(".bitrev"));
+        assert_eq!(
+            resume_dir(&state_dir()),
+            HOME.join(".bitrev").join("resume")
+        );
+        assert_eq!(
+            torrents_dir(&state_dir()),
+            HOME.join(".bitrev").join("torrents")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #9.

Persist per-torrent resume data so killing the process no longer restarts the download from zero. Implements [spec 12](spec/12-resume-persistence.md).

## What changed

- Versioned bencode resume files at `<state_dir>/resume/<info_hash>.resume` (`~/.bitrev` by default via `util::paths`).
- Atomic writes (temp + rename) after each verified piece, every 30s while downloading, on pause/resume/complete, and on graceful shutdown.
- Cached metainfo at `<state_dir>/torrents/<hash>.torrent`.
- Startup validation:
  - fast path when recorded file sizes/mtimes match (trust the bitfield)
  - slow path on mismatch or `--verify` (re-hash pieces)
  - corrupt/unreadable resume files warn and start fresh
- `pause()` persists so a paused torrent stays paused across restarts. New block requests stop, peers stay connected but not-interested/choked, and the announce loop sends a final announce then waits.
- CLI handles SIGINT/SIGTERM: flush resume, best-effort `event=stopped`, exit. A second signal force-exits.

## Tests

- Kill-and-restart against an in-process seeder: only missing pieces are requested and the output hash-verifies.
- Crash without an extra flush does not corrupt output.
- Fast vs slow path, `--verify`, atomic write, corrupt resume fallback, pause flag across restart.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` pass.