### PR TITLE
feat: implement BEP-0006 Fast Extension

### DIFF
--- a/crates/bit_rev/src/allowed_fast.rs
+++ b/crates/bit_rev/src/allowed_fast.rs
@@ -1,0 +1,114 @@
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr};
+
+pub const DEFAULT_ALLOWED_FAST_SET_SIZE: usize = 10;
+
+pub fn generate_allowed_fast(
+    ip: Ipv4Addr,
+    info_hash: &[u8; 20],
+    piece_count: u32,
+    k: usize,
+) -> Vec<u32> {
+    if piece_count == 0 || k == 0 {
+        return Vec::new();
+    }
+
+    // BEP-0006 zeros the last IPv4 octet so nearby addresses share a set.
+    let mut octets = ip.octets();
+    octets[3] = 0;
+
+    let mut x = Vec::with_capacity(24);
+    x.extend_from_slice(&octets);
+    x.extend_from_slice(info_hash);
+
+    let target = k.min(piece_count as usize);
+    let mut set = Vec::with_capacity(target);
+    let mut seen = HashSet::with_capacity(target);
+
+    while set.len() < target {
+        let mut hasher = sha1_smol::Sha1::new();
+        hasher.update(&x);
+        let digest = hasher.digest().bytes();
+        x.clear();
+        x.extend_from_slice(&digest);
+
+        for i in 0..5 {
+            if set.len() >= target {
+                break;
+            }
+            let j = i * 4;
+            let y = u32::from_be_bytes([digest[j], digest[j + 1], digest[j + 2], digest[j + 3]]);
+            let index = (y as u64 % piece_count as u64) as u32;
+            if seen.insert(index) {
+                set.push(index);
+            }
+        }
+    }
+
+    set
+}
+
+pub fn generate_allowed_fast_for_ip(
+    ip: IpAddr,
+    info_hash: &[u8; 20],
+    piece_count: u32,
+    k: usize,
+) -> Vec<u32> {
+    match ip {
+        IpAddr::V4(v4) => generate_allowed_fast(v4, info_hash, piece_count, k),
+        IpAddr::V6(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv6Addr;
+
+    fn bep6_info_hash() -> [u8; 20] {
+        [0xaa; 20]
+    }
+
+    fn bep6_ip() -> Ipv4Addr {
+        Ipv4Addr::new(80, 4, 4, 200)
+    }
+
+    #[test]
+    fn bep6_seven_piece_set() {
+        let set = generate_allowed_fast(bep6_ip(), &bep6_info_hash(), 1313, 7);
+        assert_eq!(set, vec![1059, 431, 808, 1217, 287, 376, 1188]);
+    }
+
+    #[test]
+    fn bep6_nine_piece_set() {
+        let set = generate_allowed_fast(bep6_ip(), &bep6_info_hash(), 1313, 9);
+        assert_eq!(set, vec![1059, 431, 808, 1217, 287, 376, 1188, 353, 508]);
+    }
+
+    #[test]
+    fn empty_when_k_or_piece_count_is_zero() {
+        let ip = bep6_ip();
+        let hash = bep6_info_hash();
+        assert!(generate_allowed_fast(ip, &hash, 1313, 0).is_empty());
+        assert!(generate_allowed_fast(ip, &hash, 0, 10).is_empty());
+        assert!(generate_allowed_fast(ip, &hash, 0, 0).is_empty());
+    }
+
+    #[test]
+    fn ipv6_returns_empty() {
+        let ip = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        let set = generate_allowed_fast_for_ip(ip, &bep6_info_hash(), 1313, 10);
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn k_larger_than_piece_count_yields_at_most_piece_count_unique() {
+        let set = generate_allowed_fast(bep6_ip(), &bep6_info_hash(), 5, 20);
+        assert_eq!(set.len(), 5);
+        let mut unique = set.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), 5);
+        assert!(set.iter().all(|&index| index < 5));
+    }
+}

--- a/crates/bit_rev/src/bitfield.rs
+++ b/crates/bit_rev/src/bitfield.rs
@@ -15,6 +15,14 @@ impl Bitfield {
         }
     }
 
+    pub fn filled(piece_count: usize) -> Bitfield {
+        let mut bitfield = Self::with_piece_count(piece_count);
+        for index in 0..piece_count {
+            bitfield.set_piece(index);
+        }
+        bitfield
+    }
+
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }
@@ -134,5 +142,15 @@ mod tests {
         bitfield.set_piece(9);
         assert!(bitfield.has_piece(9));
         assert!(!bitfield.has_piece(0));
+    }
+
+    #[test]
+    fn filled_sets_only_piece_count_bits() {
+        let bitfield = Bitfield::filled(10);
+        for index in 0..10 {
+            assert!(bitfield.has_piece(index));
+        }
+        assert!(!bitfield.has_piece(10));
+        assert_eq!(bitfield.as_bytes(), &[0b1111_1111, 0b1100_0000]);
     }
 }

--- a/crates/bit_rev/src/handshake.rs
+++ b/crates/bit_rev/src/handshake.rs
@@ -1,11 +1,22 @@
 use thiserror::Error;
 
+/// Fast extension (BEP-0006): reserved[7] |= 0x04
+pub const FAST_EXTENSION_FLAG: u8 = 0x04;
+/// Extension protocol (BEP-0010): reserved[5] |= 0x10
+pub const EXTENSION_PROTOCOL_FLAG: u8 = 0x10;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Handshake {
     pub pstr: String,
     pub reserved: [u8; 8],
     pub info_hash: [u8; 20],
     pub peer_id: [u8; 20],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HandshakeCapabilities {
+    pub fast_extension: bool,
+    pub extension_protocol: bool,
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
@@ -23,6 +34,35 @@ impl Handshake {
             reserved: [0u8; 8],
             info_hash,
             peer_id,
+        }
+    }
+
+    pub fn outgoing(info_hash: [u8; 20], peer_id: [u8; 20]) -> Self {
+        let mut handshake = Self::new(info_hash, peer_id);
+        handshake.enable_fast_extension();
+        handshake
+    }
+
+    pub fn supports_fast_extension(&self) -> bool {
+        self.reserved[7] & FAST_EXTENSION_FLAG != 0
+    }
+
+    pub fn enable_fast_extension(&mut self) {
+        self.reserved[7] |= FAST_EXTENSION_FLAG;
+    }
+
+    pub fn supports_extension_protocol(&self) -> bool {
+        self.reserved[5] & EXTENSION_PROTOCOL_FLAG != 0
+    }
+
+    pub fn enable_extension_protocol(&mut self) {
+        self.reserved[5] |= EXTENSION_PROTOCOL_FLAG;
+    }
+
+    pub fn capabilities(&self) -> HandshakeCapabilities {
+        HandshakeCapabilities {
+            fast_extension: self.supports_fast_extension(),
+            extension_protocol: self.supports_extension_protocol(),
         }
     }
 
@@ -213,5 +253,52 @@ mod tests {
         assert_eq!(handshake.reserved[0], 0b1000_0001);
         assert_eq!(handshake.reserved[1], 0b1000_0000);
         assert_eq!(handshake.reserved[7], 0b0000_0001);
+    }
+
+    #[test]
+    fn new_handshake_has_zeroed_reserved() {
+        let handshake = Handshake::new(HASH_INFO, PEER_ID);
+        assert_eq!(handshake.reserved, [0u8; 8]);
+        assert!(!handshake.supports_fast_extension());
+        assert!(!handshake.supports_extension_protocol());
+        assert_eq!(handshake.capabilities(), HandshakeCapabilities::default());
+    }
+
+    #[test]
+    fn outgoing_sets_only_fast_extension_bit() {
+        let handshake = Handshake::outgoing(HASH_INFO, PEER_ID);
+        assert_eq!(handshake.reserved[7], FAST_EXTENSION_FLAG);
+        assert_eq!(&handshake.reserved[..7], &[0u8; 7]);
+        assert!(handshake.supports_fast_extension());
+        assert!(!handshake.supports_extension_protocol());
+        assert_eq!(
+            handshake.capabilities(),
+            HandshakeCapabilities {
+                fast_extension: true,
+                extension_protocol: false,
+            }
+        );
+    }
+
+    #[test]
+    fn enable_fast_extension_round_trip() {
+        let mut handshake = Handshake::new(HASH_INFO, PEER_ID);
+        assert!(!handshake.supports_fast_extension());
+        handshake.enable_fast_extension();
+        assert!(handshake.supports_fast_extension());
+        assert_eq!(handshake.reserved[7], FAST_EXTENSION_FLAG);
+        handshake.enable_fast_extension();
+        assert_eq!(handshake.reserved[7], FAST_EXTENSION_FLAG);
+    }
+
+    #[test]
+    fn enable_extension_protocol_round_trip() {
+        let mut handshake = Handshake::new(HASH_INFO, PEER_ID);
+        assert!(!handshake.supports_extension_protocol());
+        handshake.enable_extension_protocol();
+        assert!(handshake.supports_extension_protocol());
+        assert_eq!(handshake.reserved[5], EXTENSION_PROTOCOL_FLAG);
+        handshake.enable_extension_protocol();
+        assert_eq!(handshake.reserved[5], EXTENSION_PROTOCOL_FLAG);
     }
 }

--- a/crates/bit_rev/src/lib.rs
+++ b/crates/bit_rev/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod allowed_fast;
 pub mod bitfield;
 pub mod choke;
 pub mod discovery;

--- a/crates/bit_rev/src/message.rs
+++ b/crates/bit_rev/src/message.rs
@@ -11,7 +11,11 @@ pub enum MessageId {
     MsgRequest = 6,
     MsgPiece = 7,
     MsgCancel = 8,
-    MsgReject = 16,
+    MsgSuggestPiece = 13,
+    MsgHaveAll = 14,
+    MsgHaveNone = 15,
+    MsgRejectRequest = 16,
+    MsgAllowedFast = 17,
     MsgHashRequest = 21,
     MsgHashes = 22,
     MsgHashReject = 23,
@@ -35,7 +39,11 @@ pub enum Message {
     Request(Vec<u8>),
     Piece(PieceChunk),
     Cancel(Vec<u8>),
-    Reject,
+    SuggestPiece(u32),
+    HaveAll,
+    HaveNone,
+    RejectRequest { index: u32, begin: u32, length: u32 },
+    AllowedFast(u32),
     HashRequest,
     Hashes(Vec<u8>),
     HashReject,
@@ -66,7 +74,22 @@ impl From<MessageInner> for Message {
                 })
             }
             MessageId::MsgCancel => Message::Cancel(inner.payload[0..12].to_vec()),
-            MessageId::MsgReject => Message::Reject,
+            MessageId::MsgSuggestPiece => {
+                Message::SuggestPiece(u32::from_be_bytes(inner.payload[0..4].try_into().unwrap()))
+            }
+            MessageId::MsgHaveAll => Message::HaveAll,
+            MessageId::MsgHaveNone => Message::HaveNone,
+            MessageId::MsgRejectRequest => {
+                let req = BlockRequest::from_payload(&inner.payload).unwrap();
+                Message::RejectRequest {
+                    index: req.index,
+                    begin: req.begin,
+                    length: req.length,
+                }
+            }
+            MessageId::MsgAllowedFast => {
+                Message::AllowedFast(u32::from_be_bytes(inner.payload[0..4].try_into().unwrap()))
+            }
             MessageId::MsgHashRequest => Message::HashRequest,
             MessageId::MsgHashes => Message::Hashes(inner.payload),
             MessageId::MsgHashReject => Message::HashReject,
@@ -92,7 +115,11 @@ impl Display for MessageInner {
             MessageId::MsgRequest => "REQUEST",
             MessageId::MsgPiece => "PIECE",
             MessageId::MsgCancel => "CANCEL",
-            MessageId::MsgReject => "REJECT",
+            MessageId::MsgSuggestPiece => "SUGGEST_PIECE",
+            MessageId::MsgHaveAll => "HAVE_ALL",
+            MessageId::MsgHaveNone => "HAVE_NONE",
+            MessageId::MsgRejectRequest => "REJECT_REQUEST",
+            MessageId::MsgAllowedFast => "ALLOWED_FAST",
             MessageId::MsgHashRequest => "HASH_REQUEST",
             MessageId::MsgHashes => "HASHES",
             MessageId::MsgHashReject => "HASH_REJECT",
@@ -110,7 +137,7 @@ pub enum MessageError {
 pub const MAX_INCOMING_REQUEST_LENGTH: u32 = 128 * 1024;
 pub const MAX_UPLOAD_QUEUE: usize = 8;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BlockRequest {
     pub index: u32,
     pub begin: u32,
@@ -187,6 +214,27 @@ pub fn format_have(index: u32) -> Message {
     let mut payload = Vec::with_capacity(4);
     payload.extend_from_slice(&index.to_be_bytes());
     Message::Have(index)
+}
+
+pub fn format_reject_request(index: u32, begin: u32, length: u32) -> Message {
+    Message::RejectRequest {
+        index,
+        begin,
+        length,
+    }
+}
+
+impl Message {
+    pub fn is_fast_extension(&self) -> bool {
+        matches!(
+            self,
+            Message::SuggestPiece(_)
+                | Message::HaveAll
+                | Message::HaveNone
+                | Message::RejectRequest { .. }
+                | Message::AllowedFast(_)
+        )
+    }
 }
 
 //pub fn parse_piece(buf: &mut [u8]) -> Result<Piece, MessageError> {
@@ -285,7 +333,27 @@ pub fn serialize(msg: Option<Message>) -> Vec<u8> {
                     (MessageId::MsgPiece, payload)
                 }
                 Message::Cancel(payload) => (MessageId::MsgCancel, payload),
-                Message::Reject => (MessageId::MsgReject, vec![]),
+                Message::SuggestPiece(index) => {
+                    (MessageId::MsgSuggestPiece, index.to_be_bytes().to_vec())
+                }
+                Message::HaveAll => (MessageId::MsgHaveAll, vec![]),
+                Message::HaveNone => (MessageId::MsgHaveNone, vec![]),
+                Message::RejectRequest {
+                    index,
+                    begin,
+                    length,
+                } => (
+                    MessageId::MsgRejectRequest,
+                    BlockRequest {
+                        index,
+                        begin,
+                        length,
+                    }
+                    .to_payload(),
+                ),
+                Message::AllowedFast(index) => {
+                    (MessageId::MsgAllowedFast, index.to_be_bytes().to_vec())
+                }
                 Message::HashRequest => (MessageId::MsgHashRequest, vec![]),
                 Message::Hashes(payload) => (MessageId::MsgHashes, payload),
                 Message::HashReject => (MessageId::MsgHashReject, vec![]),
@@ -326,7 +394,11 @@ pub fn read(length_buf: &[u8], message_buf: &[u8]) -> Option<Message> {
         6 => MessageId::MsgRequest,
         7 => MessageId::MsgPiece,
         8 => MessageId::MsgCancel,
-        16 => MessageId::MsgReject,
+        13 => MessageId::MsgSuggestPiece,
+        14 => MessageId::MsgHaveAll,
+        15 => MessageId::MsgHaveNone,
+        16 => MessageId::MsgRejectRequest,
+        17 => MessageId::MsgAllowedFast,
         21 => MessageId::MsgHashRequest,
         22 => MessageId::MsgHashes,
         23 => MessageId::MsgHashReject,
@@ -334,8 +406,16 @@ pub fn read(length_buf: &[u8], message_buf: &[u8]) -> Option<Message> {
     };
 
     match message_id {
-        MessageId::MsgHave if payload.len() < 4 => return None,
-        MessageId::MsgRequest | MessageId::MsgCancel if payload.len() < 12 => return None,
+        MessageId::MsgHave | MessageId::MsgSuggestPiece | MessageId::MsgAllowedFast
+            if payload.len() < 4 =>
+        {
+            return None
+        }
+        MessageId::MsgRequest | MessageId::MsgCancel | MessageId::MsgRejectRequest
+            if payload.len() < 12 =>
+        {
+            return None
+        }
         MessageId::MsgPiece if payload.len() < 8 => return None,
         _ => {}
     }
@@ -542,7 +622,15 @@ mod tests {
             Message::Cancel(vec![
                 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
             ]),
-            Message::Reject,
+            Message::SuggestPiece(42),
+            Message::HaveAll,
+            Message::HaveNone,
+            Message::RejectRequest {
+                index: 4,
+                begin: 567,
+                length: 4321,
+            },
+            Message::AllowedFast(7),
             Message::HashRequest,
             Message::Hashes(vec![0x01, 0x02, 0x03]),
             Message::HashReject,
@@ -556,6 +644,34 @@ mod tests {
         // Keep-alive serializes to a zero length prefix. read maps length 0 to None.
         assert_eq!(serialize(Some(Message::KeepAlive)), vec![0, 0, 0, 0]);
         assert_eq!(round_trip(Message::KeepAlive), None);
+    }
+
+    #[test]
+    fn fast_extension_wire_bytes() {
+        assert_eq!(
+            serialize(Some(Message::HaveAll)),
+            vec![0x00, 0x00, 0x00, 0x01, 14]
+        );
+        assert_eq!(
+            serialize(Some(Message::HaveNone)),
+            vec![0x00, 0x00, 0x00, 0x01, 15]
+        );
+        assert_eq!(
+            serialize(Some(Message::SuggestPiece(42))),
+            vec![0x00, 0x00, 0x00, 0x05, 13, 0x00, 0x00, 0x00, 0x2a]
+        );
+        assert_eq!(
+            serialize(Some(Message::AllowedFast(7))),
+            vec![0x00, 0x00, 0x00, 0x05, 17, 0x00, 0x00, 0x00, 0x07]
+        );
+
+        let reject = format_reject_request(4, 567, 4321);
+        let Message::Request(request_payload) = format_request(4, 567, 4321) else {
+            panic!("format_request should produce Request");
+        };
+        let mut expected = vec![0x00, 0x00, 0x00, 0x0d, 16];
+        expected.extend_from_slice(&request_payload);
+        assert_eq!(serialize(Some(reject)), expected);
     }
 
     #[test]
@@ -576,6 +692,15 @@ mod tests {
             // Request payload shorter than 12 bytes
             (&[0, 0, 0, 9], &[6, 0, 0, 0, 1, 0, 0, 0, 0]),
             (&[0, 0, 0, 12], &[6, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]),
+            // SuggestPiece payload shorter than 4 bytes
+            (&[0, 0, 0, 5], &[13]),
+            (&[0, 0, 0, 2], &[13, 0]),
+            // AllowedFast payload shorter than 4 bytes
+            (&[0, 0, 0, 5], &[17]),
+            (&[0, 0, 0, 2], &[17, 0]),
+            // RejectRequest payload shorter than 12 bytes
+            (&[0, 0, 0, 9], &[16, 0, 0, 0, 1, 0, 0, 0, 0]),
+            (&[0, 0, 0, 12], &[16, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]),
         ];
 
         for (length_buf, message_buf) in cases {

--- a/crates/bit_rev/src/peer_connection.rs
+++ b/crates/bit_rev/src/peer_connection.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::VecDeque,
+    collections::{HashSet, VecDeque},
     future,
     sync::{
         atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
@@ -17,8 +17,12 @@ use tokio::{
 use tracing::{debug, error, trace};
 
 use crate::{
+    allowed_fast::{generate_allowed_fast_for_ip, DEFAULT_ALLOWED_FAST_SET_SIZE},
     bitfield::Bitfield,
-    message::{self, validate_request, BlockRequest, Message, WriterRequest, MAX_UPLOAD_QUEUE},
+    message::{
+        self, format_reject_request, validate_request, BlockRequest, Message, RequestError,
+        WriterRequest, MAX_UPLOAD_QUEUE,
+    },
     peer::PeerAddr,
     peer_state::PeerStates,
     protocol::{Protocol, ProtocolError},
@@ -171,6 +175,43 @@ impl TorrentDownloadedState {
 
         None
     }
+
+    pub fn try_reserve_piece(&self, index: u32, peer: PeerAddr) -> Option<&PieceWorkState> {
+        let pw = self.pieces.get(index as usize)?;
+        if pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
+            return None;
+        }
+        let mut reserved = pw.reserved.lock().unwrap();
+        if reserved.is_some() {
+            return None;
+        }
+        reserved.replace(peer);
+        Some(pw)
+    }
+
+    pub fn reserve_first_available(
+        &self,
+        peer: PeerAddr,
+        candidates: &[u32],
+    ) -> Option<&PieceWorkState> {
+        for &index in candidates {
+            if let Some(pw) = self.try_reserve_piece(index, peer) {
+                return Some(pw);
+            }
+        }
+        None
+    }
+
+    pub async fn get_and_reserve_piece_preferring(
+        &self,
+        peer: PeerAddr,
+        preferred: &[u32],
+    ) -> Option<&PieceWorkState> {
+        if let Some(pw) = self.reserve_first_available(peer, preferred) {
+            return Some(pw);
+        }
+        self.get_and_reserve_piece(peer).await
+    }
     pub fn remove_downloaded(&self, index: u32) {
         for pw in self.pieces.iter() {
             if pw.piece_work.index == index {
@@ -194,6 +235,19 @@ impl TorrentDownloadedState {
                     //self.semaphore.add_permits(1);
                 }
             }
+        }
+    }
+
+    pub fn release_reservation(&self, index: u32, peer: PeerAddr) -> bool {
+        let Some(pw) = self.pieces.get(index as usize) else {
+            return false;
+        };
+        let mut reserved = pw.reserved.lock().unwrap();
+        if reserved.as_ref() == Some(&peer) {
+            reserved.take();
+            true
+        } else {
+            false
         }
     }
 
@@ -306,6 +360,11 @@ pub struct PeerHandler {
     _torrent: Arc<Torrent>,
     choke_notify: Arc<Notify>,
     upload_queue: Mutex<VecDeque<BlockRequest>>,
+    fast_extension: AtomicBool,
+    peer_allowed_fast: Mutex<HashSet<u32>>,
+    our_allowed_fast: Mutex<HashSet<u32>>,
+    suggested_pieces: Mutex<Vec<u32>>,
+    outstanding_requests: Mutex<HashSet<BlockRequest>>,
 }
 
 impl PeerHandler {
@@ -327,7 +386,98 @@ impl PeerHandler {
             _torrent: config.torrent,
             choke_notify: config.choke_notify,
             upload_queue: Mutex::new(VecDeque::new()),
+            fast_extension: AtomicBool::new(false),
+            peer_allowed_fast: Mutex::new(HashSet::new()),
+            our_allowed_fast: Mutex::new(HashSet::new()),
+            suggested_pieces: Mutex::new(Vec::new()),
+            outstanding_requests: Mutex::new(HashSet::new()),
         }
+    }
+
+    fn fast_extension(&self) -> bool {
+        self.fast_extension.load(Ordering::Relaxed)
+    }
+
+    fn set_fast_extension(&self, enabled: bool) {
+        self.fast_extension.store(enabled, Ordering::Relaxed);
+        if let Some(mut state) = self.peers_state.states.get_mut(&self.peer) {
+            state.fast_extension = enabled;
+        }
+    }
+
+    fn require_fast(&self) -> Result<(), anyhow::Error> {
+        if !self.fast_extension() {
+            anyhow::bail!("fast extension message without negotiation");
+        }
+        Ok(())
+    }
+
+    fn send_reject(&self, req: BlockRequest) {
+        if !self.fast_extension() {
+            return;
+        }
+        let _ = self
+            .peer_writer_tx
+            .send(WriterRequest::Message(format_reject_request(
+                req.index, req.begin, req.length,
+            )));
+    }
+
+    fn reject_upload_queue(&self, keep_allowed_fast: bool) {
+        let mut queue = self.upload_queue.lock().unwrap();
+        if !self.fast_extension() {
+            queue.clear();
+            return;
+        }
+        let allowed = self.our_allowed_fast.lock().unwrap().clone();
+        let mut keep = VecDeque::new();
+        while let Some(req) = queue.pop_front() {
+            if keep_allowed_fast && allowed.contains(&req.index) {
+                keep.push_back(req);
+            } else {
+                let _ = self
+                    .peer_writer_tx
+                    .send(WriterRequest::Message(format_reject_request(
+                        req.index, req.begin, req.length,
+                    )));
+            }
+        }
+        *queue = keep;
+    }
+
+    fn requeue_outstanding(&self) {
+        let outstanding: Vec<BlockRequest> =
+            self.outstanding_requests.lock().unwrap().drain().collect();
+        let mut pieces = HashSet::new();
+        for req in outstanding {
+            pieces.insert(req.index);
+            self.requests_sem.add_permits(1);
+        }
+        for index in pieces {
+            self.torrent_downloaded_state
+                .release_reservation(index, self.peer);
+        }
+    }
+
+    fn on_reject_request(&self, req: BlockRequest) -> Result<(), anyhow::Error> {
+        let known = self.outstanding_requests.lock().unwrap().remove(&req);
+        if !known {
+            anyhow::bail!("reject for request that was never sent");
+        }
+        self.torrent_downloaded_state
+            .release_reservation(req.index, self.peer);
+        self.requests_sem.add_permits(1);
+        Ok(())
+    }
+
+    fn is_allowed_fast_for_peer(&self, index: u32) -> bool {
+        self.our_allowed_fast.lock().unwrap().contains(&index)
+    }
+
+    fn preferred_piece_indices(&self) -> Vec<u32> {
+        let mut preferred = self.suggested_pieces.lock().unwrap().clone();
+        preferred.extend(self.peer_allowed_fast.lock().unwrap().iter().copied());
+        preferred
     }
 
     pub fn on_peer_died(&self) {
@@ -378,17 +528,34 @@ impl PeerHandler {
             .piece_length(req.index)
             .ok_or_else(|| anyhow::anyhow!("request for unknown piece {}", req.index))?;
         let have_piece = self.torrent_downloaded_state.has_piece(req.index);
-        validate_request(&req, piece_length, have_piece)
-            .map_err(|e| anyhow::anyhow!("invalid request {:?}: {:?}", req, e))?;
+        match validate_request(&req, piece_length, have_piece) {
+            Ok(()) => {}
+            Err(RequestError::MissingPiece) if self.fast_extension() => {
+                self.send_reject(req);
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!("invalid request {:?}: {:?}", req, e));
+            }
+        }
 
-        if !self.is_downloading() || self.am_choking() {
-            debug!("ignoring request while paused or choking {:?}", req);
+        if !self.is_downloading() {
+            debug!("rejecting request while paused {:?}", req);
+            self.send_reject(req);
+            return Ok(());
+        }
+
+        if self.am_choking() && !(self.fast_extension() && self.is_allowed_fast_for_peer(req.index))
+        {
+            debug!("ignoring request while choking {:?}", req);
+            self.send_reject(req);
             return Ok(());
         }
 
         let mut queue = self.upload_queue.lock().unwrap();
         if queue.len() >= MAX_UPLOAD_QUEUE {
             debug!("upload queue full, dropping request {:?}", req);
+            self.send_reject(req);
             return Ok(());
         }
         queue.push_back(req);
@@ -402,7 +569,7 @@ impl PeerHandler {
     pub async fn task_peer_uploader(&self) -> Result<(), anyhow::Error> {
         loop {
             if !self.is_downloading() {
-                self.upload_queue.lock().unwrap().clear();
+                self.reject_upload_queue(false);
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 continue;
             }
@@ -420,18 +587,36 @@ impl PeerHandler {
             }
 
             loop {
-                if !self.is_downloading() || self.am_choking() {
-                    self.upload_queue.lock().unwrap().clear();
+                if !self.is_downloading() {
+                    self.reject_upload_queue(false);
                     break;
+                }
+                if self.am_choking() {
+                    self.reject_upload_queue(true);
+                    if self.upload_queue.lock().unwrap().is_empty() {
+                        break;
+                    }
                 }
                 let req = self.upload_queue.lock().unwrap().pop_front();
                 let Some(req) = req else {
                     break;
                 };
-                let data = self
+                if self.am_choking() && !self.is_allowed_fast_for_peer(req.index) {
+                    self.send_reject(req);
+                    continue;
+                }
+                let data = match self
                     .storage
                     .read_block(req.index, req.begin, req.length)
-                    .await?;
+                    .await
+                {
+                    Ok(data) => data,
+                    Err(e) => {
+                        debug!("failed to read block {:?}: {:#}", req, e);
+                        self.send_reject(req);
+                        continue;
+                    }
+                };
                 let length = data.len() as u64;
                 if self
                     .peer_writer_tx
@@ -453,19 +638,73 @@ impl PeerHandler {
         }
     }
 
+    fn peer_has_piece(&self, index: u32) -> bool {
+        self.peers_state
+            .states
+            .get(&self.peer)
+            .map(|state| state.bitfield.has_piece(index as usize))
+            .unwrap_or(false)
+    }
+
+    fn needed_allowed_fast_pieces(&self) -> Vec<u32> {
+        self.peer_allowed_fast
+            .lock()
+            .unwrap()
+            .iter()
+            .copied()
+            .filter(|&index| {
+                !self.torrent_downloaded_state.has_piece(index) && self.peer_has_piece(index)
+            })
+            .collect()
+    }
+
+    async fn request_piece_blocks(&self, piece: PieceWork) -> Result<(), anyhow::Error> {
+        let mut offset: u32 = 0;
+        while offset < piece.length {
+            if !self.is_downloading() {
+                return Ok(());
+            }
+
+            loop {
+                match tokio::time::timeout(Duration::from_secs(5), self.requests_sem.acquire())
+                    .await
+                {
+                    Ok(acq) => break acq?.forget(),
+                    Err(_) => continue,
+                };
+            }
+            let block_size = utils::calculate_block_size(piece.length, offset);
+            let req = BlockRequest {
+                index: piece.index,
+                begin: offset,
+                length: block_size,
+            };
+            self.outstanding_requests.lock().unwrap().insert(req);
+
+            debug!(
+                "requesting piece index {} start {} length {}",
+                piece.index, offset, block_size
+            );
+            if self
+                .peer_writer_tx
+                .send(WriterRequest::Message(message::format_request(
+                    piece.index,
+                    offset,
+                    block_size,
+                )))
+                .is_err()
+            {
+                error!("error sending request to peer");
+                return Ok(());
+            }
+            offset += block_size;
+        }
+        Ok(())
+    }
+
     // The job of this is to request chunks and also to keep peer alive.
     // The moment this ends, the peer is disconnected.
     pub async fn task_peer_chunk_requester(&self) -> Result<(), anyhow::Error> {
-        let needs_bitfield = self
-            .peers_state
-            .states
-            .get(&self.peer)
-            .map(|state| state.bitfield.is_empty())
-            .unwrap_or(true);
-        if needs_bitfield {
-            self.on_bitfield_notify.notified().await;
-        }
-
         let mut update_interest = {
             let mut current = false;
             move |h: &PeerHandler, new_value: bool| -> anyhow::Result<()> {
@@ -494,7 +733,11 @@ impl PeerHandler {
                 }
             }
 
-            if self.torrent_downloaded_state.is_complete() || !self.peer_has_needed_piece() {
+            let choked = self.chocked.load(Ordering::Relaxed);
+            let can_request_fast = choked && !self.needed_allowed_fast_pieces().is_empty();
+            if self.torrent_downloaded_state.is_complete()
+                || (!self.peer_has_needed_piece() && !can_request_fast)
+            {
                 update_interest(self, false)?;
                 if self.torrent_downloaded_state.is_complete() {
                     trace!("torrent complete, staying connected to seed");
@@ -506,12 +749,20 @@ impl PeerHandler {
 
             update_interest(self, true)?;
 
-            trace!("waiting for unchoke");
-
-            if self.chocked.load(std::sync::atomic::Ordering::Relaxed) {
+            if choked {
+                let allowed = self.needed_allowed_fast_pieces();
+                if let Some(piece) = self
+                    .torrent_downloaded_state
+                    .reserve_first_available(self.peer, &allowed)
+                {
+                    let piece = piece.piece_work;
+                    self.request_piece_blocks(piece).await?;
+                    continue;
+                }
+                trace!("waiting for unchoke");
                 self.unchoke_notify.notified().await;
+                continue;
             }
-            trace!("unchoke received");
 
             if self.torrent_downloaded_state.is_complete() {
                 update_interest(self, false)?;
@@ -519,9 +770,10 @@ impl PeerHandler {
                 future::pending::<()>().await;
             }
 
+            let preferred = self.preferred_piece_indices();
             let piece = self
                 .torrent_downloaded_state
-                .get_and_reserve_piece(self.peer)
+                .get_and_reserve_piece_preferring(self.peer, &preferred)
                 .await;
 
             if piece.is_none() {
@@ -534,41 +786,7 @@ impl PeerHandler {
             }
 
             let piece = piece.unwrap().piece_work;
-
-            let mut offset: u32 = 0;
-            while offset < piece.length {
-                if !self.is_downloading() {
-                    update_interest(self, false)?;
-                    while !self.is_downloading() {
-                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                    }
-                }
-
-                loop {
-                    match (tokio::time::timeout(
-                        Duration::from_secs(5),
-                        self.requests_sem.acquire(),
-                    ))
-                    .await
-                    {
-                        Ok(acq) => break acq?.forget(),
-                        Err(_) => continue,
-                    };
-                }
-                let block_size = utils::calculate_block_size(piece.length, offset);
-
-                let r = message::format_request(piece.index, offset, block_size);
-
-                debug!(
-                    "requesting piece index {} start {} length {}",
-                    piece.index, offset, block_size
-                );
-                if self.peer_writer_tx.send(WriterRequest::Message(r)).is_err() {
-                    error!("error sending request to peer");
-                    return Ok(());
-                }
-                offset += block_size;
-            }
+            self.request_piece_blocks(piece).await?;
         }
     }
 
@@ -579,6 +797,9 @@ impl PeerHandler {
                 self.chocked.store(true, Ordering::Relaxed);
                 if let Some(mut state) = self.peers_state.states.get_mut(&self.peer) {
                     state.set_peer_choking(true);
+                }
+                if !self.fast_extension() {
+                    self.requeue_outstanding();
                 }
             }
             Message::Unchoke => {
@@ -623,7 +844,72 @@ impl PeerHandler {
             Message::Request(payload) => {
                 self.on_incoming_request(payload)?;
             }
+            Message::SuggestPiece(index) => {
+                self.require_fast()?;
+                debug!("peer suggested piece {}", index);
+                let mut suggested = self.suggested_pieces.lock().unwrap();
+                if !suggested.contains(&index) {
+                    suggested.push(index);
+                }
+                if let Some(mut state) = self.peers_state.states.get_mut(&self.peer) {
+                    if !state.suggested_pieces.contains(&index) {
+                        state.suggested_pieces.push(index);
+                    }
+                }
+            }
+            Message::HaveAll => {
+                self.require_fast()?;
+                debug!("peer sent have all");
+                let count = self.torrent_downloaded_state.piece_count();
+                if let Some(mut ps) = self.peers_state.states.get_mut(&self.peer) {
+                    ps.bitfield = Bitfield::filled(count);
+                }
+                self.on_bitfield_notify.notify_waiters();
+            }
+            Message::HaveNone => {
+                self.require_fast()?;
+                debug!("peer sent have none");
+                let count = self.torrent_downloaded_state.piece_count();
+                if let Some(mut ps) = self.peers_state.states.get_mut(&self.peer) {
+                    ps.bitfield = Bitfield::with_piece_count(count);
+                }
+                self.on_bitfield_notify.notify_waiters();
+            }
+            Message::RejectRequest {
+                index,
+                begin,
+                length,
+            } => {
+                self.require_fast()?;
+                debug!(
+                    "peer rejected request index {} begin {} length {}",
+                    index, begin, length
+                );
+                self.on_reject_request(BlockRequest {
+                    index,
+                    begin,
+                    length,
+                })?;
+            }
+            Message::AllowedFast(index) => {
+                self.require_fast()?;
+                debug!("peer allowed fast piece {}", index);
+                self.peer_allowed_fast.lock().unwrap().insert(index);
+                if let Some(mut state) = self.peers_state.states.get_mut(&self.peer) {
+                    state.peer_allowed_fast.insert(index);
+                }
+                self.on_bitfield_notify.notify_waiters();
+                self.unchoke_notify.notify_waiters();
+            }
             Message::Piece(piece_chunk) => {
+                self.outstanding_requests
+                    .lock()
+                    .unwrap()
+                    .remove(&BlockRequest {
+                        index: piece_chunk.index,
+                        begin: piece_chunk.start,
+                        length: piece_chunk.length,
+                    });
                 self.downloaded
                     .fetch_add(piece_chunk.length, Ordering::Relaxed);
                 if let Some(state) = self.peers_state.states.get(&self.peer) {
@@ -729,8 +1015,11 @@ impl PeerConnection {
         }?;
 
         let protocol = Arc::new(Protocol::connect(self.peer, self.info_hash, self.peer_id).await?);
-        let _handshake = protocol.complete_handshake(&mut stream).await?;
+        let handshake = protocol.complete_handshake(&mut stream).await?;
+        self.handler
+            .set_fast_extension(handshake.supports_fast_extension());
         self.send_initial_bitfield(&protocol, &mut stream).await?;
+        self.send_allowed_fast(&protocol, &mut stream).await?;
         self.manage_established(stream, protocol, peer_writer_rx, have_broadcast)
             .await
     }
@@ -743,6 +1032,7 @@ impl PeerConnection {
     ) -> anyhow::Result<()> {
         let protocol = Arc::new(Protocol::connect(self.peer, self.info_hash, self.peer_id).await?);
         self.send_initial_bitfield(&protocol, &mut stream).await?;
+        self.send_allowed_fast(&protocol, &mut stream).await?;
         self.manage_established(stream, protocol, peer_writer_rx, have_broadcast)
             .await
     }
@@ -753,8 +1043,47 @@ impl PeerConnection {
         stream: &mut TcpStream,
     ) -> anyhow::Result<()> {
         let bitfield = self.handler.torrent_downloaded_state.our_bitfield();
-        if !bitfield.is_empty() {
+        if self.handler.fast_extension() {
+            let msg = if self.handler.torrent_downloaded_state.is_complete() {
+                Message::HaveAll
+            } else if bitfield.is_empty() {
+                Message::HaveNone
+            } else {
+                Message::Bitfield(bitfield.as_bytes().to_vec())
+            };
+            protocol.send_message(stream, msg).await?;
+        } else if !bitfield.is_empty() {
             protocol.send_bitfield(stream, bitfield.as_bytes()).await?;
+        }
+        Ok(())
+    }
+
+    async fn send_allowed_fast(
+        &self,
+        protocol: &Protocol,
+        stream: &mut TcpStream,
+    ) -> anyhow::Result<()> {
+        if !self.handler.fast_extension() {
+            return Ok(());
+        }
+        let piece_count = self.handler.torrent_downloaded_state.piece_count() as u32;
+        let set = generate_allowed_fast_for_ip(
+            self.peer.ip(),
+            &self.info_hash,
+            piece_count,
+            DEFAULT_ALLOWED_FAST_SET_SIZE,
+        );
+        {
+            let mut ours = self.handler.our_allowed_fast.lock().unwrap();
+            ours.extend(set.iter().copied());
+        }
+        if let Some(mut state) = self.handler.peers_state.states.get_mut(&self.peer) {
+            state.our_allowed_fast.extend(set.iter().copied());
+        }
+        for index in set {
+            protocol
+                .send_message(&mut *stream, Message::AllowedFast(index))
+                .await?;
         }
         Ok(())
     }
@@ -885,6 +1214,7 @@ pub struct SpawnPeerParams {
     pub torrent: Arc<Torrent>,
     pub choke_notify: Arc<Notify>,
     pub incoming: Option<TcpStream>,
+    pub incoming_fast_extension: Option<bool>,
     pub global_peers: Arc<std::sync::atomic::AtomicUsize>,
     pub max_peers_per_torrent: usize,
     pub max_peers_global: usize,
@@ -923,6 +1253,9 @@ pub fn try_spawn_peer(params: SpawnPeerParams) -> bool {
             torrent: params.torrent,
             choke_notify: params.choke_notify,
         }));
+        if let Some(fast) = params.incoming_fast_extension {
+            handler.set_fast_extension(fast);
+        }
         let connection = PeerConnection::new(
             params.peer,
             params.info_hash,
@@ -1030,6 +1363,37 @@ mod tests {
         assert_eq!(*s.pieces[0].reserved.lock().unwrap(), Some(p1));
         assert!(s.pieces[1].reserved.lock().unwrap().is_none());
         assert_eq!(*s.pieces[2].reserved.lock().unwrap(), Some(p3));
+    }
+
+    #[tokio::test]
+    async fn rejected_request_releases_reservation_for_other_peers() {
+        let s = state(2, 16);
+        let p1 = peer(6881);
+        let p2 = peer(6882);
+
+        s.get_and_reserve_piece(p1).await.unwrap();
+        assert_eq!(*s.pieces[0].reserved.lock().unwrap(), Some(p1));
+        assert!(s.release_reservation(0, p1));
+        assert!(s.pieces[0].reserved.lock().unwrap().is_none());
+
+        let next = s.get_and_reserve_piece(p2).await.unwrap();
+        assert_eq!(next.piece_work.index, 0);
+        assert_eq!(*next.reserved.lock().unwrap(), Some(p2));
+        assert!(!s.release_reservation(0, p1));
+        assert_eq!(*s.pieces[0].reserved.lock().unwrap(), Some(p2));
+    }
+
+    #[tokio::test]
+    async fn preferring_reserves_suggested_piece_first() {
+        let s = state(3, 16);
+        let p1 = peer(6881);
+        let preferred = [2u32, 1];
+        let pw = s
+            .get_and_reserve_piece_preferring(p1, &preferred)
+            .await
+            .unwrap();
+        assert_eq!(pw.piece_work.index, 2);
+        assert_eq!(*pw.reserved.lock().unwrap(), Some(p1));
     }
 
     #[test]

--- a/crates/bit_rev/src/peer_state.rs
+++ b/crates/bit_rev/src/peer_state.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -54,6 +55,10 @@ pub struct PeerState {
     pub connected_at: Instant,
     pub last_unchoked: Option<Instant>,
     pub is_optimistic: bool,
+    pub fast_extension: bool,
+    pub peer_allowed_fast: HashSet<u32>,
+    pub our_allowed_fast: HashSet<u32>,
+    pub suggested_pieces: Vec<u32>,
     pub stats: Arc<PeerLiveStats>,
     pub writer_tx: Option<flume::Sender<WriterRequest>>,
 }
@@ -100,6 +105,10 @@ impl PeerState {
             connected_at: Instant::now(),
             last_unchoked: None,
             is_optimistic: false,
+            fast_extension: false,
+            peer_allowed_fast: HashSet::new(),
+            our_allowed_fast: HashSet::new(),
+            suggested_pieces: Vec::new(),
             stats: Arc::new(PeerLiveStats::default()),
             writer_tx: None,
         }

--- a/crates/bit_rev/src/protocol.rs
+++ b/crates/bit_rev/src/protocol.rs
@@ -20,10 +20,6 @@ pub enum ProtocolError {
     Io(std::io::Error),
     #[error("Info hash is not equal")]
     InfoHashIsNotEqual,
-    #[error("Expected bitfield id")]
-    ExpectedBitfieldId,
-    #[error("Message is none")]
-    MessageIsNone,
 }
 
 #[derive(Debug, Clone)]
@@ -208,7 +204,7 @@ impl Protocol {
         stream: &mut (impl AsyncReadExt + AsyncWriteExt + Unpin),
     ) -> Result<Handshake, ProtocolError> {
         let timeout = tokio::time::timeout(Duration::from_secs(HANDSHAKE_TIMEOUT), async {
-            let handshake = Handshake::new(self.info_hash, self.peer_id);
+            let handshake = Handshake::outgoing(self.info_hash, self.peer_id);
             let handshake_bytes = handshake.serialize();
             stream
                 .write_all(&handshake_bytes)
@@ -244,17 +240,27 @@ impl Protocol {
         }
     }
 
+    pub async fn send_message(
+        &self,
+        mut stream: impl AsyncWriteExt + Unpin,
+        msg: Message,
+    ) -> Result<(), ProtocolError> {
+        let msg_bytes = message::serialize(Some(msg));
+        stream
+            .write_all(&msg_bytes)
+            .await
+            .map_err(ProtocolError::Io)
+    }
+
     pub async fn recv_bitfield(
         &self,
         stream: &mut (impl AsyncReadExt + Unpin),
     ) -> Result<Vec<u8>, ProtocolError> {
         let func = async {
             match self.read(stream).await? {
-                None => Err(ProtocolError::MessageIsNone),
-                Some(msg) => match msg {
-                    Message::Bitfield(b) => Ok(b),
-                    _ => Err(ProtocolError::ExpectedBitfieldId),
-                },
+                Some(Message::Bitfield(b)) => Ok(b),
+                // BEP-0003: a peer may omit the bitfield, meaning it has no pieces.
+                Some(_) | None => Ok(Vec::new()),
             }
         };
         match tokio::time::timeout(Duration::from_secs(6), func).await {
@@ -307,6 +313,49 @@ mod tests {
         assert_eq!(handshake.info_hash, INFO_HASH);
         assert_eq!(handshake.peer_id, REMOTE_PEER_ID);
         server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn complete_handshake_advertises_fast_extension() {
+        let proto = protocol().await;
+        let (mut client, mut server) = tokio::io::duplex(256);
+
+        let server_task = tokio::spawn(async move {
+            let mut client_hs = [0u8; 68];
+            server.read_exact(&mut client_hs).await.unwrap();
+            assert_eq!(client_hs[27] & crate::handshake::FAST_EXTENSION_FLAG, 0x04);
+            assert_eq!(&client_hs[20..27], &[0u8; 7]);
+            let reply = Handshake::new(INFO_HASH, REMOTE_PEER_ID).serialize();
+            server.write_all(&reply).await.unwrap();
+        });
+
+        proto.complete_handshake(&mut client).await.unwrap();
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn recv_bitfield_allows_omitted_or_non_bitfield_first() {
+        let proto = protocol().await;
+
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        writer.write_all(&[0, 0, 0, 0]).await.unwrap();
+        drop(writer);
+        let empty = proto.recv_bitfield(&mut reader).await.unwrap();
+        assert!(empty.is_empty());
+
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        let interested = message::serialize(Some(Message::Interested));
+        writer.write_all(&interested).await.unwrap();
+        drop(writer);
+        let empty = proto.recv_bitfield(&mut reader).await.unwrap();
+        assert!(empty.is_empty());
+
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        let bitfield = message::serialize(Some(Message::Bitfield(vec![0b1010_0000])));
+        writer.write_all(&bitfield).await.unwrap();
+        drop(writer);
+        let got = proto.recv_bitfield(&mut reader).await.unwrap();
+        assert_eq!(got, vec![0b1010_0000]);
     }
 
     #[tokio::test]

--- a/crates/bit_rev/src/seeding_tests.rs
+++ b/crates/bit_rev/src/seeding_tests.rs
@@ -276,6 +276,63 @@ async fn seeder_disconnects_on_out_of_bounds_request() {
 }
 
 #[tokio::test]
+async fn seeder_disconnects_on_fast_message_without_negotiation() {
+    let data = generated_payload(16_384);
+    let (session, addr, meta) = start_seeder(&data, 16_384).await;
+    let (mut stream, proto) = handshake_with(addr, meta.info_hash, *b"-LC0001-nofast000001").await;
+    drain_until_bitfield(&proto, &mut stream).await;
+
+    write_msg(&mut stream, Message::HaveAll).await;
+
+    expect_disconnect(&proto, &mut stream).await;
+    drop(session);
+}
+
+#[tokio::test]
+async fn seeder_sends_have_all_when_fast_negotiated() {
+    let data = generated_payload(16_384);
+    let (session, addr, meta) = start_seeder(&data, 16_384).await;
+    let mut stream = TcpStream::connect(addr).await.expect("connect seeder");
+    let local = Handshake::outgoing(meta.info_hash, *b"-LC0001-fastset00001");
+    stream.write_all(&local.serialize()).await.unwrap();
+    let proto = Protocol::connect(addr, meta.info_hash, *b"-LC0001-fastset00001")
+        .await
+        .unwrap();
+    let reply = Protocol::read_handshake(&mut stream).await.unwrap();
+    assert!(reply.supports_fast_extension());
+
+    let mut saw_have_all = false;
+    let mut allowed = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while tokio::time::Instant::now() < deadline {
+        let msg = tokio::time::timeout(Duration::from_millis(500), proto.read(&mut stream)).await;
+        let Ok(Ok(Some(msg))) = msg else {
+            if saw_have_all {
+                break;
+            }
+            continue;
+        };
+        match msg {
+            Message::HaveAll => saw_have_all = true,
+            Message::AllowedFast(index) => allowed.push(index),
+            Message::Bitfield(_) => panic!("expected have-all, got bitfield"),
+            Message::KeepAlive => {}
+            other if !saw_have_all => panic!("expected have-all first, got {other:?}"),
+            _ => break,
+        }
+        if saw_have_all && !allowed.is_empty() {
+            break;
+        }
+    }
+    assert!(saw_have_all, "seeder should send have-all when seeding");
+    assert!(
+        !allowed.is_empty(),
+        "seeder should advertise an allowed-fast set"
+    );
+    drop(session);
+}
+
+#[tokio::test]
 async fn incoming_unknown_info_hash_is_closed() {
     let data = generated_payload(16_384);
     let (session, addr, _meta) = start_seeder(&data, 16_384).await;

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -411,6 +411,7 @@ impl Session {
             torrent: torrent.torrent.clone(),
             choke_notify: torrent.choke_notify.clone(),
             incoming: None,
+            incoming_fast_extension: None,
             global_peers: self.global_peers.clone(),
             max_peers_per_torrent: self.options.max_peers_per_torrent,
             max_peers_global: self.options.max_peers_global,
@@ -779,6 +780,7 @@ fn choke_all_peers(peer_states: &PeerStates) {
             if let Some(tx) = &state.writer_tx {
                 let _ = tx.send(WriterRequest::Message(Message::Choke));
             }
+            state.stats.upload_notify.notify_waiters();
         }
     }
 }
@@ -806,7 +808,7 @@ async fn handle_incoming(
         debug!(%addr, "incoming peer for unknown info hash");
         return;
     };
-    let reply = Handshake::new(handshake.info_hash, peer_id);
+    let reply = Handshake::outgoing(handshake.info_hash, peer_id);
     if let Err(e) = Protocol::write_handshake(&mut stream, &reply).await {
         debug!(%addr, error = %e, "failed to write handshake reply");
         return;
@@ -816,6 +818,7 @@ async fn handle_incoming(
         peer: addr,
         info_hash: handshake.info_hash,
         peer_id,
+        incoming_fast_extension: Some(handshake.supports_fast_extension()),
         piece_tx: torrent.piece_tx.clone(),
         have_broadcast: torrent.have_broadcast.clone(),
         torrent_downloaded_state: torrent.downloaded_state.clone(),
@@ -921,6 +924,7 @@ fn apply_choke(
                 if let Some(tx) = &state.writer_tx {
                     let _ = tx.send(WriterRequest::Message(Message::Choke));
                 }
+                state.stats.upload_notify.notify_waiters();
             }
             ChokeAction::Unchoke => {
                 state.set_am_choking(false);

--- a/crates/bit_rev/src/tracker_peers.rs
+++ b/crates/bit_rev/src/tracker_peers.rs
@@ -225,6 +225,7 @@ async fn process_peers(
             torrent: runtime.torrent.clone(),
             choke_notify: runtime.choke_notify.clone(),
             incoming: None,
+            incoming_fast_extension: None,
             global_peers: runtime.global_peers.clone(),
             max_peers_per_torrent: runtime.max_peers_per_torrent,
             max_peers_global: runtime.max_peers_global,


### PR DESCRIPTION
Advertise `reserved[7] |= 0x04` on outgoing handshakes and store per-connection capability flags. Adds Suggest Piece, Have All, Have None, Reject Request, and Allowed Fast, used only when both sides negotiate the extension.

When negotiated, the first message is have-none, have-all, or a bitfield. Rejected download requests are re-queued for other peers. Upload-side requests we will not serve get an explicit reject, and choke no longer silently drops the queue. Allowed-fast sets use the canonical BEP-0006 algorithm (k=10) and pass the published reference vector. Suggest Piece is a soft preference when picking.

Peers that do not advertise the bit keep the previous post-handshake behavior, except a bitfield is no longer required as the first message.

Fixes #11