### PR TITLE
test: add integration test harness and e2e scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "serde_bencode",
  "serde_bytes",
  "sha1_smol",
+ "tempfile",
  "thiserror 2.0.16",
  "tokio",
  "tokio-util",

--- a/crates/bit_rev/Cargo.toml
+++ b/crates/bit_rev/Cargo.toml
@@ -28,3 +28,6 @@ util = { path = "../util" }
 tokio = { workspace = true, features = ["test-util"] }
 tokio-util.workspace = true
 serde_bytes.workspace = true
+serde.workspace = true
+serde_bencode.workspace = true
+tempfile = "3.10"

--- a/crates/bit_rev/src/peer_connection.rs
+++ b/crates/bit_rev/src/peer_connection.rs
@@ -123,41 +123,27 @@ impl TorrentDownloadedState {
     }
 
     pub async fn get_and_reserve_piece(&self, peer: PeerAddr) -> Option<&PieceWorkState> {
-        //loop {
-        //    if let Ok(acq) = self.semaphore.try_acquire() {
-        //        break acq.forget();
-        //    } else {
-        //        sleep(Duration::from_secs(1)).await;
-        //    }
-        //}
+        self.get_and_reserve_piece_if(peer, |_| true).await
+    }
 
+    pub async fn get_and_reserve_piece_if(
+        &self,
+        peer: PeerAddr,
+        has_piece: impl Fn(u32) -> bool,
+    ) -> Option<&PieceWorkState> {
         for pw in self.pieces.iter() {
             if pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
                 continue;
             }
-
-            //if pw
-            //    .reserverd
-            //    .swap(true, std::sync::atomic::Ordering::Relaxed)
-            //{
-            //    continue;
-            //}
+            if !has_piece(pw.piece_work.index) {
+                continue;
+            }
 
             let mut reserved = pw.reserved.lock().unwrap();
-
-            //if let Some(p) = reserved.as_ref() {
-            //    if *p == peer {
-            //        self.semaphore.add_permits(1);
-            //        return Some(pw);
-            //    }
-            //}
-
             if reserved.is_some() {
                 continue;
             }
 
-            //pw.reserverd
-            //    .store(true, std::sync::atomic::Ordering::Relaxed);
             reserved.replace(peer);
             drop(reserved);
             self.semaphore.add_permits(1);
@@ -167,6 +153,9 @@ impl TorrentDownloadedState {
 
         for pw in self.pieces.iter() {
             if pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
+                continue;
+            }
+            if !has_piece(pw.piece_work.index) {
                 continue;
             }
 
@@ -212,6 +201,7 @@ impl TorrentDownloadedState {
         }
         self.get_and_reserve_piece(peer).await
     }
+
     pub fn remove_downloaded(&self, index: u32) {
         for pw in self.pieces.iter() {
             if pw.piece_work.index == index {
@@ -222,17 +212,24 @@ impl TorrentDownloadedState {
         }
     }
 
+    pub fn release_piece(&self, index: u32) {
+        if let Some(pw) = self.pieces.get(index as usize) {
+            *pw.reserved.lock().unwrap() = None;
+            if !pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
+                pw.chuncks.lock().unwrap().clear();
+            }
+        }
+    }
+
     pub fn remove_reserved(&self, peer: PeerAddr) {
         for pw in self.pieces.iter() {
-            //if pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
-            //    continue;
-            //}
-
             let mut reserved = pw.reserved.lock().unwrap();
             if let Some(p) = reserved.as_ref() {
                 if *p == peer {
                     reserved.take();
-                    //self.semaphore.add_permits(1);
+                    if !pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
+                        pw.chuncks.lock().unwrap().clear();
+                    }
                 }
             }
         }
@@ -245,6 +242,9 @@ impl TorrentDownloadedState {
         let mut reserved = pw.reserved.lock().unwrap();
         if reserved.as_ref() == Some(&peer) {
             reserved.take();
+            if !pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
+                pw.chuncks.lock().unwrap().clear();
+            }
             true
         } else {
             false
@@ -770,11 +770,22 @@ impl PeerHandler {
                 future::pending::<()>().await;
             }
 
-            let preferred = self.preferred_piece_indices();
-            let piece = self
+            let has_piece = |index: u32| self.peer_has_piece(index);
+            let preferred: Vec<u32> = self
+                .preferred_piece_indices()
+                .into_iter()
+                .filter(|&index| has_piece(index))
+                .collect();
+            let piece = if let Some(pw) = self
                 .torrent_downloaded_state
-                .get_and_reserve_piece_preferring(self.peer, &preferred)
-                .await;
+                .reserve_first_available(self.peer, &preferred)
+            {
+                Some(pw)
+            } else {
+                self.torrent_downloaded_state
+                    .get_and_reserve_piece_if(self.peer, has_piece)
+                    .await
+            };
 
             if piece.is_none() {
                 update_interest(self, false)?;
@@ -943,8 +954,8 @@ impl PeerHandler {
                         trace!("piece index {} is corrupted", piece_chunk.index);
                         self.torrent_downloaded_state
                             .remove_downloaded(piece_chunk.index);
-                        //self.torrent_downloaded_state.remove_reserved(self.peer);
-                        //return Ok(());
+                        self.torrent_downloaded_state
+                            .release_piece(piece_chunk.index);
                     }
                 }
 
@@ -1394,6 +1405,47 @@ mod tests {
             .unwrap();
         assert_eq!(pw.piece_work.index, 2);
         assert_eq!(*pw.reserved.lock().unwrap(), Some(p1));
+    }
+
+    #[tokio::test]
+    async fn get_and_reserve_piece_if_skips_pieces_the_peer_lacks() {
+        let s = state(3, 16);
+        let p1 = peer(6881);
+        let taken = s
+            .get_and_reserve_piece_if(p1, |index| index == 2)
+            .await
+            .unwrap();
+        assert_eq!(taken.piece_work.index, 2);
+        assert_eq!(*s.pieces[2].reserved.lock().unwrap(), Some(p1));
+        assert!(s.pieces[0].reserved.lock().unwrap().is_none());
+        assert!(s.pieces[1].reserved.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn release_piece_clears_reservation_and_incomplete_chunks() {
+        let s = state(1, 16);
+        let p1 = peer(6881);
+        s.get_and_reserve_piece(p1).await.unwrap();
+        s.set_chuncks(0, 0, vec![1u8; 8]);
+
+        s.release_piece(0);
+
+        assert!(s.pieces[0].reserved.lock().unwrap().is_none());
+        assert!(s.pieces[0].chuncks.lock().unwrap().is_empty());
+        assert!(!s.pieces[0].downloaded.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn remove_reserved_clears_incomplete_chunks() {
+        let s = state(1, 16);
+        let p1 = peer(6881);
+        s.get_and_reserve_piece(p1).await.unwrap();
+        s.set_chuncks(0, 0, vec![1u8; 8]);
+
+        s.remove_reserved(p1);
+
+        assert!(s.pieces[0].reserved.lock().unwrap().is_none());
+        assert!(s.pieces[0].chuncks.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/bit_rev/tests/common/fixture.rs
+++ b/crates/bit_rev/tests/common/fixture.rs
@@ -1,0 +1,402 @@
+#![allow(dead_code)]
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use bit_rev::file::{File, Info, TorrentFile, TorrentMeta};
+use bit_rev::torrent::Torrent;
+use bit_rev::utils::{calculate_piece_size, map_piece_to_files};
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+use serde_bencode::ser;
+use serde_bytes::ByteBuf;
+use tempfile::TempDir;
+
+use super::sha1_bytes;
+
+const STREAM_CHUNK: usize = 64 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct FileSpec {
+    pub path: Vec<String>,
+    pub length: u64,
+}
+
+impl FileSpec {
+    pub fn new(path: impl IntoIterator<Item = impl Into<String>>, length: u64) -> Self {
+        Self {
+            path: path.into_iter().map(Into::into).collect(),
+            length,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WrittenFile {
+    pub path: Vec<String>,
+    pub length: u64,
+    pub disk_path: PathBuf,
+}
+
+pub struct TorrentFixture {
+    pub temp_dir: TempDir,
+    pub name: String,
+    pub piece_length: u32,
+    pub total_length: u64,
+    pub files: Vec<WrittenFile>,
+    pub piece_hashes: Vec<[u8; 20]>,
+    pub torrent_meta: TorrentMeta,
+    pub torrent_bytes: Vec<u8>,
+    pub torrent_path: PathBuf,
+    payload: Option<Vec<u8>>,
+}
+
+pub struct FixtureBuilder {
+    seed: u64,
+    name: String,
+    piece_length: u32,
+    files: Vec<FileSpec>,
+    announce: Option<String>,
+    announce_list: Option<Vec<Vec<String>>>,
+    keep_payload: bool,
+}
+
+impl FixtureBuilder {
+    pub fn new() -> Self {
+        Self {
+            seed: 0xB174_0001,
+            name: "fixture".into(),
+            piece_length: super::DEFAULT_PIECE_LENGTH,
+            files: Vec::new(),
+            announce: None,
+            announce_list: None,
+            keep_payload: true,
+        }
+    }
+
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    pub fn piece_length(mut self, piece_length: u32) -> Self {
+        self.piece_length = piece_length;
+        self
+    }
+
+    pub fn single_file(mut self, name: impl Into<String>, length: u64) -> Self {
+        let name = name.into();
+        self.name = name.clone();
+        self.files = vec![FileSpec::new([name], length)];
+        self
+    }
+
+    pub fn files(mut self, files: Vec<FileSpec>) -> Self {
+        self.files = files;
+        self
+    }
+
+    pub fn announce(mut self, url: impl Into<String>) -> Self {
+        self.announce = Some(url.into());
+        self
+    }
+
+    pub fn announce_list(mut self, list: Vec<Vec<String>>) -> Self {
+        self.announce_list = Some(list);
+        self
+    }
+
+    pub fn keep_payload(mut self, keep: bool) -> Self {
+        self.keep_payload = keep;
+        self
+    }
+
+    pub fn build(self) -> TorrentFixture {
+        assert!(self.piece_length > 0, "piece length must be positive");
+        assert!(!self.files.is_empty(), "at least one file is required");
+        TorrentFixture::generate(self)
+    }
+}
+
+impl Default for FixtureBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TorrentFixture {
+    pub fn builder() -> FixtureBuilder {
+        FixtureBuilder::new()
+    }
+
+    pub fn single(length: u64, piece_length: u32, seed: u64) -> Self {
+        Self::builder()
+            .single_file("payload.bin", length)
+            .piece_length(piece_length)
+            .seed(seed)
+            .build()
+    }
+
+    pub fn torrent(&self) -> Torrent {
+        Torrent::new(&self.torrent_meta).expect("torrent from fixture")
+    }
+
+    pub fn piece_count(&self) -> usize {
+        self.piece_hashes.len()
+    }
+
+    pub fn is_single_file(&self) -> bool {
+        self.files.len() == 1
+    }
+
+    /// Session `output_dir`: file path for single-file torrents, directory for multi-file.
+    pub fn session_output(&self, download_dir: &Path) -> PathBuf {
+        if self.is_single_file() {
+            download_dir.join(&self.name)
+        } else {
+            download_dir.to_path_buf()
+        }
+    }
+
+    pub fn payload_bytes(&self) -> Option<&[u8]> {
+        self.payload.as_deref()
+    }
+
+    pub fn set_announce(&mut self, announce: impl Into<String>) {
+        self.torrent_meta.torrent_file.announce = Some(announce.into());
+        self.rewrite_torrent();
+    }
+
+    pub fn set_announce_list(&mut self, list: Vec<Vec<String>>) {
+        if let Some(first) = list.first().and_then(|tier| tier.first()) {
+            if self.torrent_meta.torrent_file.announce.is_none() {
+                self.torrent_meta.torrent_file.announce = Some(first.clone());
+            }
+        }
+        self.torrent_meta.torrent_file.announce_list = Some(list);
+        self.rewrite_torrent();
+    }
+
+    pub fn meta_with_trackers(
+        &self,
+        announce: Option<String>,
+        announce_list: Option<Vec<Vec<String>>>,
+    ) -> TorrentMeta {
+        let mut meta = self.torrent_meta.clone();
+        if let Some(url) = announce {
+            meta.torrent_file.announce = Some(url);
+        }
+        if let Some(list) = announce_list {
+            if meta.torrent_file.announce.is_none() {
+                if let Some(first) = list.first().and_then(|tier| tier.first()) {
+                    meta.torrent_file.announce = Some(first.clone());
+                }
+            }
+            meta.torrent_file.announce_list = Some(list);
+        }
+        meta
+    }
+
+    pub fn piece_len(&self, index: u32) -> u32 {
+        calculate_piece_size(&self.torrent(), index as usize) as u32
+    }
+
+    pub fn read_block(&self, index: u32, begin: u32, length: u32) -> Vec<u8> {
+        let torrent = self.torrent();
+        let piece_len = calculate_piece_size(&torrent, index as usize);
+        let start = begin as usize;
+        let end = start
+            .checked_add(length as usize)
+            .filter(|&e| e <= piece_len)
+            .expect("block out of range");
+        if let Some(payload) = &self.payload {
+            let piece_off = index as usize * self.piece_length as usize;
+            return payload[piece_off + start..piece_off + end].to_vec();
+        }
+
+        let mappings = map_piece_to_files(&torrent, index as usize);
+        let mut out = Vec::with_capacity(end - start);
+        let mut piece_offset = 0usize;
+        for mapping in mappings {
+            let map_start = piece_offset;
+            let map_end = piece_offset + mapping.length;
+            let overlap_start = map_start.max(start);
+            let overlap_end = map_end.min(end);
+            if overlap_start < overlap_end {
+                let file_offset = mapping.file_offset + (overlap_start - map_start);
+                let read_len = overlap_end - overlap_start;
+                let disk = &self.files[mapping.file_index].disk_path;
+                let mut file = std::fs::File::open(disk).expect("open fixture file");
+                file.seek(SeekFrom::Start(file_offset as u64))
+                    .expect("seek");
+                let mut chunk = vec![0u8; read_len];
+                file.read_exact(&mut chunk).expect("read fixture block");
+                out.extend_from_slice(&chunk);
+            }
+            piece_offset = map_end;
+        }
+        out
+    }
+
+    pub fn assert_output_matches(&self, output: &Path) {
+        if self.is_single_file() {
+            let expected = self.files[0].disk_path.as_path();
+            assert_eq!(
+                super::sha1_file(output),
+                super::sha1_file(expected),
+                "single-file output hash mismatch"
+            );
+            return;
+        }
+
+        for file in &self.files {
+            let mut got = output.to_path_buf();
+            for component in &file.path {
+                got.push(component);
+            }
+            assert!(got.is_file(), "missing output file {got:?}");
+            assert_eq!(
+                std::fs::metadata(&got).expect("meta").len(),
+                file.length,
+                "length mismatch for {got:?}"
+            );
+            assert_eq!(
+                super::sha1_file(&got),
+                super::sha1_file(&file.disk_path),
+                "hash mismatch for {got:?}"
+            );
+        }
+    }
+
+    fn generate(builder: FixtureBuilder) -> Self {
+        let temp_dir = super::unique_temp_dir();
+        let payload_root = temp_dir.path().join("payload");
+        std::fs::create_dir_all(&payload_root).expect("payload root");
+
+        let total_length: u64 = builder.files.iter().map(|f| f.length).sum();
+        let piece_length = builder.piece_length;
+        let mut rng = StdRng::seed_from_u64(builder.seed);
+        let mut piece_hashes = Vec::new();
+        let mut piece_buf = Vec::with_capacity(piece_length as usize);
+        let mut payload = if builder.keep_payload {
+            Some(Vec::with_capacity(total_length as usize))
+        } else {
+            None
+        };
+
+        let mut written = Vec::with_capacity(builder.files.len());
+        for spec in &builder.files {
+            let mut disk_path = payload_root.clone();
+            for component in &spec.path {
+                disk_path.push(component);
+            }
+            if let Some(parent) = disk_path.parent() {
+                std::fs::create_dir_all(parent).expect("create parent");
+            }
+            let mut file = std::fs::File::create(&disk_path).expect("create payload file");
+            let mut remaining = spec.length;
+            let mut chunk = vec![0u8; STREAM_CHUNK];
+            while remaining > 0 {
+                let n = (remaining as usize).min(STREAM_CHUNK);
+                rng.fill_bytes(&mut chunk[..n]);
+                file.write_all(&chunk[..n]).expect("write payload");
+                if let Some(payload) = &mut payload {
+                    payload.extend_from_slice(&chunk[..n]);
+                }
+                let mut off = 0;
+                while off < n {
+                    let take = (piece_length as usize - piece_buf.len()).min(n - off);
+                    piece_buf.extend_from_slice(&chunk[off..off + take]);
+                    off += take;
+                    if piece_buf.len() == piece_length as usize {
+                        piece_hashes.push(sha1_bytes(&piece_buf));
+                        piece_buf.clear();
+                    }
+                }
+                remaining -= n as u64;
+            }
+            written.push(WrittenFile {
+                path: spec.path.clone(),
+                length: spec.length,
+                disk_path,
+            });
+        }
+        if !piece_buf.is_empty() {
+            piece_hashes.push(sha1_bytes(&piece_buf));
+        }
+
+        let mut pieces_concat = Vec::with_capacity(piece_hashes.len() * 20);
+        for hash in &piece_hashes {
+            pieces_concat.extend_from_slice(hash);
+        }
+
+        let (length, files) = if builder.files.len() == 1 {
+            (Some(builder.files[0].length as i64), None)
+        } else {
+            (
+                None,
+                Some(
+                    builder
+                        .files
+                        .iter()
+                        .map(|f| File {
+                            path: f.path.clone(),
+                            length: f.length as i64,
+                            md5sum: None,
+                        })
+                        .collect(),
+                ),
+            )
+        };
+
+        let torrent_file = TorrentFile {
+            info: Info {
+                name: builder.name.clone(),
+                pieces: ByteBuf::from(pieces_concat),
+                piece_length: i64::from(piece_length),
+                md5sum: None,
+                length,
+                files,
+                private: None,
+                path: None,
+                root_hash: None,
+            },
+            announce: builder.announce,
+            nodes: None,
+            encoding: None,
+            httpseeds: None,
+            announce_list: builder.announce_list,
+            creation_date: None,
+            comment: None,
+            created_by: None,
+        };
+        let torrent_meta = TorrentMeta::new(torrent_file).expect("fixture metainfo");
+        let torrent_bytes = ser::to_bytes(&torrent_meta.torrent_file).expect("bencode torrent");
+        let torrent_path = temp_dir.path().join(format!("{}.torrent", builder.name));
+        std::fs::write(&torrent_path, &torrent_bytes).expect("write torrent");
+
+        Self {
+            temp_dir,
+            name: builder.name,
+            piece_length,
+            total_length,
+            files: written,
+            piece_hashes,
+            torrent_meta,
+            torrent_bytes,
+            torrent_path,
+            payload,
+        }
+    }
+
+    fn rewrite_torrent(&mut self) {
+        self.torrent_bytes =
+            ser::to_bytes(&self.torrent_meta.torrent_file).expect("bencode torrent");
+        std::fs::write(&self.torrent_path, &self.torrent_bytes).expect("rewrite torrent");
+    }
+}

--- a/crates/bit_rev/tests/common/http_tracker.rs
+++ b/crates/bit_rev/tests/common/http_tracker.rs
@@ -1,0 +1,298 @@
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use serde_bencode::ser;
+use serde_bytes::ByteBuf;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+use super::compact_peers;
+
+#[derive(Clone, Debug)]
+pub struct RecordedHttpRequest {
+    pub path: String,
+    pub query: String,
+    pub headers: HashMap<String, String>,
+    pub peer_addr: SocketAddr,
+}
+
+impl RecordedHttpRequest {
+    pub fn query_param(&self, key: &str) -> Option<&str> {
+        self.query.split('&').find_map(|pair| {
+            let (k, v) = pair.split_once('=')?;
+            (k == key).then_some(v)
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum HttpAnnounceBody {
+    Peers {
+        interval: i64,
+        min_interval: Option<i64>,
+        peers: Vec<SocketAddr>,
+        warning: Option<String>,
+        tracker_id: Option<Vec<u8>>,
+    },
+    Failure(String),
+    Raw {
+        status: u16,
+        body: Vec<u8>,
+    },
+    /// Accept the request and never write a response.
+    Hang,
+}
+
+#[derive(Serialize)]
+struct BencodeAnnounce {
+    interval: i64,
+    #[serde(rename = "min interval", skip_serializing_if = "Option::is_none")]
+    min_interval: Option<i64>,
+    #[serde(rename = "tracker id", skip_serializing_if = "Option::is_none")]
+    tracker_id: Option<ByteBuf>,
+    #[serde(rename = "warning message", skip_serializing_if = "Option::is_none")]
+    warning_message: Option<String>,
+    peers: ByteBuf,
+}
+
+impl HttpAnnounceBody {
+    pub fn peers(interval: i64, peers: Vec<SocketAddr>) -> Self {
+        Self::Peers {
+            interval,
+            min_interval: None,
+            peers,
+            warning: None,
+            tracker_id: None,
+        }
+    }
+
+    fn into_http(self) -> Option<(u16, Vec<u8>)> {
+        match self {
+            Self::Hang => None,
+            Self::Raw { status, body } => Some((status, body)),
+            Self::Failure(reason) => Some((
+                200,
+                format!("d14:failure reason{}:{reason}e", reason.len()).into_bytes(),
+            )),
+            Self::Peers {
+                interval,
+                min_interval,
+                peers,
+                warning,
+                tracker_id,
+            } => {
+                let body = ser::to_bytes(&BencodeAnnounce {
+                    interval,
+                    min_interval,
+                    tracker_id: tracker_id.map(ByteBuf::from),
+                    warning_message: warning,
+                    peers: ByteBuf::from(compact_peers(&peers)),
+                })
+                .expect("bencode announce");
+                Some((200, body))
+            }
+        }
+    }
+}
+
+pub struct MockHttpTracker {
+    pub addr: SocketAddr,
+    pub url: String,
+    requests: Arc<Mutex<Vec<RecordedHttpRequest>>>,
+    request_notify: Arc<Notify>,
+    cancel: CancellationToken,
+}
+
+impl Drop for MockHttpTracker {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+impl MockHttpTracker {
+    pub async fn start(responses: Vec<HttpAnnounceBody>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock http tracker");
+        let addr = listener.local_addr().expect("local addr");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let request_notify = Arc::new(Notify::new());
+        let cancel = CancellationToken::new();
+        let idx = Arc::new(AtomicUsize::new(0));
+        let responses = Arc::new(responses);
+        let requests_task = requests.clone();
+        let notify_task = request_notify.clone();
+        let cancel_task = cancel.clone();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_task.cancelled() => break,
+                    accepted = listener.accept() => {
+                        let Ok((stream, peer_addr)) = accepted else { break };
+                        let responses = responses.clone();
+                        let idx = idx.clone();
+                        let requests = requests_task.clone();
+                        let request_notify = notify_task.clone();
+                        let cancel = cancel_task.clone();
+                        tokio::spawn(async move {
+                            let _ = handle_conn(
+                                stream,
+                                peer_addr,
+                                responses,
+                                idx,
+                                requests,
+                                request_notify,
+                                cancel,
+                            )
+                            .await;
+                        });
+                    }
+                }
+            }
+        });
+
+        Self {
+            addr,
+            url: format!("http://{addr}/announce"),
+            requests,
+            request_notify,
+            cancel,
+        }
+    }
+
+    pub fn requests(&self) -> Vec<RecordedHttpRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    pub async fn wait_requests(&self, n: usize, timeout: std::time::Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.requests().len() >= n {
+                return;
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                panic!(
+                    "http tracker saw {} requests, wanted {n} before timeout",
+                    self.requests().len()
+                );
+            }
+            tokio::select! {
+                _ = self.request_notify.notified() => {}
+                _ = tokio::time::sleep(remaining) => {
+                    panic!(
+                        "http tracker saw {} requests, wanted {n} before timeout",
+                        self.requests().len()
+                    );
+                }
+            }
+        }
+    }
+}
+
+async fn handle_conn(
+    mut stream: TcpStream,
+    peer_addr: SocketAddr,
+    responses: Arc<Vec<HttpAnnounceBody>>,
+    idx: Arc<AtomicUsize>,
+    requests: Arc<Mutex<Vec<RecordedHttpRequest>>>,
+    request_notify: Arc<Notify>,
+    cancel: CancellationToken,
+) -> std::io::Result<()> {
+    let request = tokio::select! {
+        _ = cancel.cancelled() => return Ok(()),
+        result = read_http_request(&mut stream) => result?,
+    };
+    let mut recorded = request;
+    recorded.peer_addr = peer_addr;
+    requests.lock().unwrap().push(recorded);
+    request_notify.notify_waiters();
+
+    let i = idx.fetch_add(1, Ordering::SeqCst);
+    let body = responses
+        .get(i)
+        .cloned()
+        .or_else(|| responses.last().cloned())
+        .unwrap_or_else(|| HttpAnnounceBody::peers(1800, Vec::new()));
+
+    let Some((status, body)) = body.into_http() else {
+        cancel.cancelled().await;
+        return Ok(());
+    };
+
+    let header = format!(
+        "HTTP/1.1 {status} {}\r\nContent-Length: {}\r\nConnection: close\r\nContent-Type: text/plain\r\n\r\n",
+        status_reason(status),
+        body.len()
+    );
+    stream.write_all(header.as_bytes()).await?;
+    stream.write_all(&body).await?;
+    stream.shutdown().await
+}
+
+fn status_reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        403 => "Forbidden",
+        500 => "Internal Server Error",
+        _ => "Error",
+    }
+}
+
+async fn read_http_request(stream: &mut TcpStream) -> std::io::Result<RecordedHttpRequest> {
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 1024];
+    loop {
+        let n = stream.read(&mut tmp).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "client closed before request completed",
+            ));
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if buf.len() > 64 * 1024 {
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidData,
+                "request too large",
+            ));
+        }
+    }
+
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines = text.split("\r\n");
+    let request_line = lines.next().unwrap_or_default();
+    let mut parts = request_line.split_whitespace();
+    let _method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    let (path, query) = target.split_once('?').unwrap_or((target, ""));
+
+    let mut headers = HashMap::new();
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+
+    Ok(RecordedHttpRequest {
+        path: path.to_string(),
+        query: query.to_string(),
+        headers,
+        peer_addr: "127.0.0.1:0".parse().unwrap(),
+    })
+}

--- a/crates/bit_rev/tests/common/mod.rs
+++ b/crates/bit_rev/tests/common/mod.rs
@@ -1,0 +1,128 @@
+//! Shared integration-test harness. Binds only to 127.0.0.1.
+//!
+//! The types here are a reusable fixture API. Individual scenarios only
+//! touch a subset, so unused items are expected.
+#![allow(dead_code)]
+
+pub mod fixture;
+pub mod http_tracker;
+pub mod seeder;
+pub mod udp_tracker;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use bit_rev::file::TorrentMeta;
+use bit_rev::session::{AddTorrentOptions, AddTorrentResult, PieceResult, Session, SessionOptions};
+use bit_rev::torrent::Torrent;
+use tempfile::TempDir;
+
+pub use fixture::{FileSpec, TorrentFixture};
+#[allow(unused_imports)]
+pub use http_tracker::{HttpAnnounceBody, MockHttpTracker, RecordedHttpRequest};
+pub use seeder::{SeederConfig, SeederPeer};
+#[allow(unused_imports)]
+pub use udp_tracker::{MockUdpTracker, RecordedUdpAnnounce, UdpAnnounceBody};
+
+pub const DEFAULT_PIECE_LENGTH: u32 = 32 * 1024;
+pub const BLOCK_SIZE: u32 = 16 * 1024;
+pub const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(45);
+pub const LISTEN_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub fn unique_temp_dir() -> TempDir {
+    tempfile::Builder::new()
+        .prefix("bitrev-it-")
+        .tempdir()
+        .expect("temp dir")
+}
+
+pub async fn test_session(state_dir: Option<PathBuf>) -> Session {
+    let session = Session::with_options(SessionOptions {
+        listen_port: 0,
+        state_dir,
+        ..SessionOptions::default()
+    });
+    tokio::time::timeout(LISTEN_TIMEOUT, session.wait_listening())
+        .await
+        .expect("session listen timeout");
+    session
+}
+
+pub async fn add_download(
+    session: &Session,
+    meta: TorrentMeta,
+    output: impl Into<PathBuf>,
+) -> AddTorrentResult {
+    session
+        .add_torrent(AddTorrentOptions::from(meta).output_dir(output))
+        .await
+        .expect("add torrent")
+}
+
+pub async fn wait_for_completion(
+    pr_rx: &flume::Receiver<PieceResult>,
+    torrent: &Torrent,
+    already_have: usize,
+    timeout: Duration,
+) {
+    let needed = torrent.piece_hashes.len().saturating_sub(already_have);
+    let deadline = tokio::time::Instant::now() + timeout;
+    for i in 0..needed {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        tokio::time::timeout(remaining, pr_rx.recv_async())
+            .await
+            .unwrap_or_else(|_| panic!("piece {} / {needed} timed out", i + 1))
+            .expect("piece channel closed");
+    }
+}
+
+pub fn sha1_bytes(data: &[u8]) -> [u8; 20] {
+    let mut hasher = sha1_smol::Sha1::new();
+    hasher.update(data);
+    hasher.digest().bytes()
+}
+
+pub fn sha1_file(path: &Path) -> [u8; 20] {
+    let mut hasher = sha1_smol::Sha1::new();
+    let mut file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {path:?}: {e}"));
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = std::io::Read::read(&mut file, &mut buf).expect("read");
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    hasher.digest().bytes()
+}
+
+/// Best-effort peak RSS. `None` when the platform helper is unavailable.
+pub fn peak_rss_bytes() -> Option<u64> {
+    let pid = std::process::id();
+    let output = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let kb: u64 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .ok()?;
+    Some(kb.saturating_mul(1024))
+}
+
+pub fn compact_peers(addrs: &[std::net::SocketAddr]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(addrs.len() * 6);
+    for addr in addrs {
+        match addr {
+            std::net::SocketAddr::V4(v4) => {
+                buf.extend_from_slice(&v4.ip().octets());
+                buf.extend_from_slice(&v4.port().to_be_bytes());
+            }
+            std::net::SocketAddr::V6(_) => panic!("compact v4 helper got IPv6 {addr}"),
+        }
+    }
+    buf
+}

--- a/crates/bit_rev/tests/common/seeder.rs
+++ b/crates/bit_rev/tests/common/seeder.rs
@@ -1,0 +1,290 @@
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bit_rev::bitfield::Bitfield;
+use bit_rev::handshake::Handshake;
+use bit_rev::message::{self, BlockRequest, Message};
+use bit_rev::protocol::Protocol;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+use super::fixture::TorrentFixture;
+
+#[derive(Clone, Debug)]
+pub struct SeederConfig {
+    pub pieces: Option<HashSet<u32>>,
+    pub read_latency: Duration,
+    pub write_latency: Duration,
+    pub corrupt_pieces: HashSet<u32>,
+    pub disconnect_after_blocks: Option<u64>,
+    pub never_unchoke: bool,
+    pub peer_id: [u8; 20],
+}
+
+impl Default for SeederConfig {
+    fn default() -> Self {
+        Self {
+            pieces: None,
+            read_latency: Duration::ZERO,
+            write_latency: Duration::ZERO,
+            corrupt_pieces: HashSet::new(),
+            disconnect_after_blocks: None,
+            never_unchoke: false,
+            peer_id: *b"-SD0001-0123456789ab",
+        }
+    }
+}
+
+impl SeederConfig {
+    pub fn all_pieces() -> Self {
+        Self::default()
+    }
+
+    pub fn with_pieces(pieces: impl IntoIterator<Item = u32>) -> Self {
+        Self {
+            pieces: Some(pieces.into_iter().collect()),
+            ..Self::default()
+        }
+    }
+
+    pub fn peer_id(mut self, peer_id: [u8; 20]) -> Self {
+        self.peer_id = peer_id;
+        self
+    }
+
+    pub fn latency(mut self, latency: Duration) -> Self {
+        self.read_latency = latency;
+        self.write_latency = latency;
+        self
+    }
+
+    pub fn corrupt(mut self, piece: u32) -> Self {
+        self.corrupt_pieces.insert(piece);
+        self
+    }
+
+    pub fn disconnect_after_blocks(mut self, n: u64) -> Self {
+        self.disconnect_after_blocks = Some(n);
+        self
+    }
+
+    pub fn never_unchoke(mut self) -> Self {
+        self.never_unchoke = true;
+        self
+    }
+}
+
+pub struct SeederPeer {
+    pub addr: std::net::SocketAddr,
+    pub blocks_sent: Arc<AtomicU64>,
+    block_notify: Arc<Notify>,
+    cancel: CancellationToken,
+}
+
+impl Drop for SeederPeer {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+impl SeederPeer {
+    pub async fn start(fixture: Arc<TorrentFixture>, config: SeederConfig) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind seeder");
+        let addr = listener.local_addr().expect("seeder addr");
+        let blocks_sent = Arc::new(AtomicU64::new(0));
+        let block_notify = Arc::new(Notify::new());
+        let cancel = CancellationToken::new();
+        let blocks_task = blocks_sent.clone();
+        let notify_task = block_notify.clone();
+        let cancel_task = cancel.clone();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_task.cancelled() => break,
+                    accepted = listener.accept() => {
+                        let Ok((stream, _)) = accepted else { break };
+                        let fixture = fixture.clone();
+                        let config = config.clone();
+                        let blocks_sent = blocks_task.clone();
+                        let block_notify = notify_task.clone();
+                        let cancel = cancel_task.clone();
+                        tokio::spawn(async move {
+                            let _ = serve_peer(
+                                stream,
+                                fixture,
+                                config,
+                                blocks_sent,
+                                block_notify,
+                                cancel,
+                            )
+                            .await;
+                        });
+                    }
+                }
+            }
+        });
+
+        Self {
+            addr,
+            blocks_sent,
+            block_notify,
+            cancel,
+        }
+    }
+
+    pub fn blocks_sent(&self) -> u64 {
+        self.blocks_sent.load(Ordering::Relaxed)
+    }
+
+    pub async fn wait_blocks_sent(&self, n: u64, timeout: Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.blocks_sent() >= n {
+                return;
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                panic!(
+                    "seeder sent {} blocks, wanted {n} before timeout",
+                    self.blocks_sent()
+                );
+            }
+            tokio::select! {
+                _ = self.block_notify.notified() => {}
+                _ = tokio::time::sleep(remaining) => {
+                    panic!(
+                        "seeder sent {} blocks, wanted {n} before timeout",
+                        self.blocks_sent()
+                    );
+                }
+            }
+        }
+    }
+}
+
+async fn write_msg(stream: &mut TcpStream, msg: Message) -> std::io::Result<()> {
+    stream.write_all(&message::serialize(Some(msg))).await
+}
+
+fn advertised_bitfield(piece_count: usize, pieces: &Option<HashSet<u32>>) -> Bitfield {
+    let mut bf = Bitfield::with_piece_count(piece_count);
+    for i in 0..piece_count {
+        let have = pieces
+            .as_ref()
+            .map(|set| set.contains(&(i as u32)))
+            .unwrap_or(true);
+        if have {
+            bf.set_piece(i);
+        }
+    }
+    bf
+}
+
+fn has_piece(config: &SeederConfig, index: u32) -> bool {
+    config
+        .pieces
+        .as_ref()
+        .map(|set| set.contains(&index))
+        .unwrap_or(true)
+}
+
+async fn serve_peer(
+    mut stream: TcpStream,
+    fixture: Arc<TorrentFixture>,
+    config: SeederConfig,
+    blocks_sent: Arc<AtomicU64>,
+    block_notify: Arc<Notify>,
+    cancel: CancellationToken,
+) -> anyhow::Result<()> {
+    let _hs = Protocol::read_handshake(&mut stream).await?;
+    let reply = Handshake::new(fixture.torrent_meta.info_hash, config.peer_id);
+    Protocol::write_handshake(&mut stream, &reply).await?;
+
+    let bf = advertised_bitfield(fixture.piece_count(), &config.pieces);
+    write_msg(&mut stream, Message::Bitfield(bf.as_bytes().to_vec())).await?;
+    if !config.never_unchoke {
+        write_msg(&mut stream, Message::Unchoke).await?;
+    }
+
+    let proto = Protocol::connect(
+        stream.peer_addr()?,
+        fixture.torrent_meta.info_hash,
+        config.peer_id,
+    )
+    .await?;
+
+    loop {
+        if cancel.is_cancelled() {
+            break;
+        }
+        if config.read_latency > Duration::ZERO {
+            tokio::time::sleep(config.read_latency).await;
+        }
+        let msg = tokio::select! {
+            _ = cancel.cancelled() => break,
+            msg = proto.read(&mut stream) => msg,
+        };
+        let msg = match msg {
+            Ok(Some(msg)) => msg,
+            Ok(None) => continue,
+            Err(_) => break,
+        };
+        match msg {
+            Message::Interested => {
+                if !config.never_unchoke {
+                    write_msg(&mut stream, Message::Unchoke).await?;
+                }
+            }
+            Message::Request(payload) => {
+                let Some(req) = BlockRequest::from_payload(&payload) else {
+                    continue;
+                };
+                if !has_piece(&config, req.index) {
+                    continue;
+                }
+                if config.write_latency > Duration::ZERO {
+                    tokio::time::sleep(config.write_latency).await;
+                }
+                let mut data = fixture.read_block(req.index, req.begin, req.length);
+                if config.corrupt_pieces.contains(&req.index) {
+                    if let Some(byte) = data.first_mut() {
+                        *byte ^= 0xFF;
+                    }
+                }
+                write_msg(
+                    &mut stream,
+                    message::format_piece(req.index, req.begin, data),
+                )
+                .await?;
+                let sent = blocks_sent.fetch_add(1, Ordering::Relaxed) + 1;
+                block_notify.notify_waiters();
+                if let Some(limit) = config.disconnect_after_blocks {
+                    if sent >= limit {
+                        break;
+                    }
+                }
+            }
+            Message::NotInterested
+            | Message::Bitfield(_)
+            | Message::Have(_)
+            | Message::KeepAlive
+            | Message::Choke
+            | Message::Unchoke
+            | Message::Cancel(_)
+            | Message::SuggestPiece(_)
+            | Message::HaveAll
+            | Message::HaveNone
+            | Message::RejectRequest { .. }
+            | Message::AllowedFast(_) => {}
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/crates/bit_rev/tests/common/udp_tracker.rs
+++ b/crates/bit_rev/tests/common/udp_tracker.rs
@@ -1,0 +1,253 @@
+#![allow(dead_code)]
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::net::UdpSocket;
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+const PROTOCOL_ID: u64 = 0x0417_2710_1980;
+const ACTION_CONNECT: u32 = 0;
+const ACTION_ANNOUNCE: u32 = 1;
+const ACTION_ERROR: u32 = 3;
+
+#[derive(Clone, Debug)]
+pub struct RecordedUdpAnnounce {
+    pub from: SocketAddr,
+    pub connection_id: u64,
+    pub transaction_id: u32,
+    pub info_hash: [u8; 20],
+    pub peer_id: [u8; 20],
+    pub downloaded: u64,
+    pub left: u64,
+    pub uploaded: u64,
+    pub event: u32,
+    pub key: u32,
+    pub num_want: i32,
+    pub port: u16,
+}
+
+#[derive(Clone, Debug)]
+pub enum UdpAnnounceBody {
+    Peers {
+        interval: u32,
+        leechers: u32,
+        seeders: u32,
+        peers: Vec<SocketAddr>,
+    },
+    Error(String),
+    /// Receive the announce and send nothing back.
+    Hang,
+}
+
+impl UdpAnnounceBody {
+    pub fn peers(interval: u32, peers: Vec<SocketAddr>) -> Self {
+        Self::Peers {
+            interval,
+            leechers: 0,
+            seeders: peers.len() as u32,
+            peers,
+        }
+    }
+}
+
+pub struct MockUdpTracker {
+    pub addr: SocketAddr,
+    pub url: String,
+    announces: Arc<Mutex<Vec<RecordedUdpAnnounce>>>,
+    announce_notify: Arc<Notify>,
+    cancel: CancellationToken,
+}
+
+impl Drop for MockUdpTracker {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+impl MockUdpTracker {
+    pub async fn start(responses: Vec<UdpAnnounceBody>) -> Self {
+        let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .expect("bind mock udp tracker");
+        let addr = socket.local_addr().expect("udp local addr");
+        let announces = Arc::new(Mutex::new(Vec::new()));
+        let announce_notify = Arc::new(Notify::new());
+        let cancel = CancellationToken::new();
+        let idx = Arc::new(AtomicUsize::new(0));
+        let responses = Arc::new(responses);
+        let announces_task = announces.clone();
+        let notify_task = announce_notify.clone();
+        let cancel_task = cancel.clone();
+
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 512];
+            let mut next_connection = 1u64;
+            loop {
+                tokio::select! {
+                    _ = cancel_task.cancelled() => break,
+                    recv = socket.recv_from(&mut buf) => {
+                        let Ok((len, from)) = recv else { break };
+                        let packet = &buf[..len];
+                        if packet.len() == 16 {
+                            if read_u64(packet, 0) != Some(PROTOCOL_ID)
+                                || read_u32(packet, 8) != Some(ACTION_CONNECT)
+                            {
+                                continue;
+                            }
+                            let Some(tid) = read_u32(packet, 12) else { continue };
+                            next_connection += 1;
+                            let _ = socket
+                                .send_to(&connect_response(tid, next_connection), from)
+                                .await;
+                            continue;
+                        }
+                        if packet.len() != 98 {
+                            continue;
+                        }
+                        let Some(announce) = parse_announce(packet, from) else { continue };
+                        announces_task.lock().unwrap().push(announce.clone());
+                        notify_task.notify_waiters();
+                        let i = idx.fetch_add(1, Ordering::SeqCst);
+                        let reply = responses
+                            .get(i)
+                            .cloned()
+                            .or_else(|| responses.last().cloned())
+                            .unwrap_or_else(|| UdpAnnounceBody::peers(1800, Vec::new()));
+                        match reply {
+                            UdpAnnounceBody::Hang => {}
+                            UdpAnnounceBody::Error(message) => {
+                                let _ = socket
+                                    .send_to(&error_response(announce.transaction_id, &message), from)
+                                    .await;
+                            }
+                            UdpAnnounceBody::Peers {
+                                interval,
+                                leechers,
+                                seeders,
+                                peers,
+                            } => {
+                                let _ = socket
+                                    .send_to(
+                                        &announce_response(
+                                            announce.transaction_id,
+                                            interval,
+                                            leechers,
+                                            seeders,
+                                            &peers,
+                                        ),
+                                        from,
+                                    )
+                                    .await;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Self {
+            addr,
+            url: format!("udp://{addr}/announce"),
+            announces,
+            announce_notify,
+            cancel,
+        }
+    }
+
+    pub fn announces(&self) -> Vec<RecordedUdpAnnounce> {
+        self.announces.lock().unwrap().clone()
+    }
+
+    pub async fn wait_announces(&self, n: usize, timeout: std::time::Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.announces().len() >= n {
+                return;
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                panic!(
+                    "udp tracker saw {} announces, wanted {n} before timeout",
+                    self.announces().len()
+                );
+            }
+            tokio::select! {
+                _ = self.announce_notify.notified() => {}
+                _ = tokio::time::sleep(remaining) => {
+                    panic!(
+                        "udp tracker saw {} announces, wanted {n} before timeout",
+                        self.announces().len()
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
+    data.get(offset..offset + 4)
+        .and_then(|b| b.try_into().ok())
+        .map(u32::from_be_bytes)
+}
+
+fn read_u64(data: &[u8], offset: usize) -> Option<u64> {
+    data.get(offset..offset + 8)
+        .and_then(|b| b.try_into().ok())
+        .map(u64::from_be_bytes)
+}
+
+fn connect_response(transaction_id: u32, connection_id: u64) -> [u8; 16] {
+    let mut data = [0u8; 16];
+    data[0..4].copy_from_slice(&ACTION_CONNECT.to_be_bytes());
+    data[4..8].copy_from_slice(&transaction_id.to_be_bytes());
+    data[8..16].copy_from_slice(&connection_id.to_be_bytes());
+    data
+}
+
+fn error_response(transaction_id: u32, message: &str) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(&ACTION_ERROR.to_be_bytes());
+    data.extend_from_slice(&transaction_id.to_be_bytes());
+    data.extend_from_slice(message.as_bytes());
+    data
+}
+
+fn announce_response(
+    transaction_id: u32,
+    interval: u32,
+    leechers: u32,
+    seeders: u32,
+    peers: &[SocketAddr],
+) -> Vec<u8> {
+    let mut data = Vec::with_capacity(20 + peers.len() * 6);
+    data.extend_from_slice(&ACTION_ANNOUNCE.to_be_bytes());
+    data.extend_from_slice(&transaction_id.to_be_bytes());
+    data.extend_from_slice(&interval.to_be_bytes());
+    data.extend_from_slice(&leechers.to_be_bytes());
+    data.extend_from_slice(&seeders.to_be_bytes());
+    data.extend_from_slice(&super::compact_peers(peers));
+    data
+}
+
+fn parse_announce(data: &[u8], from: SocketAddr) -> Option<RecordedUdpAnnounce> {
+    if read_u32(data, 8)? != ACTION_ANNOUNCE {
+        return None;
+    }
+    Some(RecordedUdpAnnounce {
+        from,
+        connection_id: read_u64(data, 0)?,
+        transaction_id: read_u32(data, 12)?,
+        info_hash: data[16..36].try_into().ok()?,
+        peer_id: data[36..56].try_into().ok()?,
+        downloaded: read_u64(data, 56)?,
+        left: read_u64(data, 64)?,
+        uploaded: read_u64(data, 72)?,
+        event: read_u32(data, 80)?,
+        key: read_u32(data, 88)?,
+        num_want: i32::from_be_bytes(data[92..96].try_into().ok()?),
+        port: u16::from_be_bytes(data[96..98].try_into().ok()?),
+    })
+}

--- a/crates/bit_rev/tests/e2e.rs
+++ b/crates/bit_rev/tests/e2e.rs
@@ -1,0 +1,394 @@
+mod common;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use common::{
+    add_download, test_session, unique_temp_dir, wait_for_completion, FileSpec, HttpAnnounceBody,
+    MockHttpTracker, MockUdpTracker, SeederConfig, SeederPeer, TorrentFixture, UdpAnnounceBody,
+    BLOCK_SIZE, DEFAULT_PIECE_LENGTH, DOWNLOAD_TIMEOUT,
+};
+
+const FOUR_MIB: u64 = 4 * 1024 * 1024;
+
+#[test]
+fn fixture_is_deterministic() {
+    let a = TorrentFixture::single(64 * 1024, DEFAULT_PIECE_LENGTH, 42);
+    let b = TorrentFixture::single(64 * 1024, DEFAULT_PIECE_LENGTH, 42);
+    assert_eq!(a.torrent_meta.info_hash, b.torrent_meta.info_hash);
+    assert_eq!(a.piece_hashes, b.piece_hashes);
+    assert_eq!(a.payload_bytes(), b.payload_bytes());
+}
+
+fn partition_pieces(piece_count: u32, buckets: usize) -> Vec<Vec<u32>> {
+    let mut out = vec![Vec::new(); buckets];
+    for index in 0..piece_count {
+        out[index as usize % buckets].push(index);
+    }
+    out
+}
+
+fn unique_peer_id(tag: u8) -> [u8; 20] {
+    let mut id = *b"-SDIT01-............";
+    id[19] = tag;
+    id
+}
+
+async fn start_seeders(
+    fixture: &Arc<TorrentFixture>,
+    configs: Vec<SeederConfig>,
+) -> Vec<SeederPeer> {
+    let mut seeders = Vec::with_capacity(configs.len());
+    for config in configs {
+        seeders.push(SeederPeer::start(fixture.clone(), config).await);
+    }
+    seeders
+}
+
+async fn download_via_http(
+    fixture: &TorrentFixture,
+    seeders: &[SeederPeer],
+    output_parent: &std::path::Path,
+) {
+    let peers: Vec<_> = seeders.iter().map(|s| s.addr).collect();
+    let tracker = MockHttpTracker::start(vec![HttpAnnounceBody::peers(1800, peers)]).await;
+    let meta = fixture.meta_with_trackers(Some(tracker.url.clone()), None);
+
+    let session = test_session(None).await;
+    let output = fixture.session_output(output_parent);
+    let added = add_download(&session, meta, output.clone()).await;
+    wait_for_completion(
+        &added.pr_rx,
+        &added.torrent,
+        added.already_have.len(),
+        DOWNLOAD_TIMEOUT,
+    )
+    .await;
+    tracker.wait_requests(1, Duration::from_secs(10)).await;
+    session.shutdown();
+    fixture.assert_output_matches(&output);
+    let requests = tracker.requests();
+    assert!(
+        !requests.is_empty(),
+        "leecher never announced to the mock tracker"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.query_param("info_hash").is_some()),
+        "announce is missing info_hash"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn e2e_single_file_three_seeders() {
+    let fixture = Arc::new(TorrentFixture::single(
+        FOUR_MIB,
+        DEFAULT_PIECE_LENGTH,
+        0x5104_E2E1,
+    ));
+    let seeders = start_seeders(
+        &fixture,
+        vec![
+            SeederConfig::all_pieces().peer_id(unique_peer_id(1)),
+            SeederConfig::all_pieces().peer_id(unique_peer_id(2)),
+            SeederConfig::all_pieces().peer_id(unique_peer_id(3)),
+        ],
+    )
+    .await;
+
+    let download_dir = unique_temp_dir();
+    download_via_http(&fixture, &seeders, download_dir.path()).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn e2e_multi_file_layout_and_bytes() {
+    let fixture = Arc::new(
+        TorrentFixture::builder()
+            .name("bundle")
+            .seed(0x4D_F1_1E_01)
+            .piece_length(DEFAULT_PIECE_LENGTH)
+            .files(vec![
+                FileSpec::new(["tiny.txt"], 1_000),
+                FileSpec::new(["a.bin"], 15_000),
+                FileSpec::new(["b.bin"], 16_768),
+                FileSpec::new(["nested", "rest.bin"], 40_000),
+            ])
+            .build(),
+    );
+    assert!(
+        fixture.files[0].length < u64::from(fixture.piece_length),
+        "first file must be smaller than a piece"
+    );
+    let torrent = fixture.torrent();
+    let piece0 = bit_rev::utils::map_piece_to_files(&torrent, 0);
+    assert_eq!(
+        piece0.len(),
+        3,
+        "piece 0 should span the first three files, got {piece0:?}"
+    );
+
+    let seeders = start_seeders(
+        &fixture,
+        vec![
+            SeederConfig::all_pieces().peer_id(unique_peer_id(1)),
+            SeederConfig::all_pieces().peer_id(unique_peer_id(2)),
+            SeederConfig::all_pieces().peer_id(unique_peer_id(3)),
+        ],
+    )
+    .await;
+
+    let download_dir = unique_temp_dir();
+    download_via_http(&fixture, &seeders, download_dir.path()).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multi_peer_disjoint_pieces() {
+    let fixture = Arc::new(TorrentFixture::single(
+        FOUR_MIB,
+        DEFAULT_PIECE_LENGTH,
+        0xC00D_D100,
+    ));
+    let parts = partition_pieces(fixture.piece_count() as u32, 3);
+    assert!(parts.iter().all(|p| !p.is_empty()));
+
+    let seeders = start_seeders(
+        &fixture,
+        vec![
+            SeederConfig::with_pieces(parts[0].clone()).peer_id(unique_peer_id(1)),
+            SeederConfig::with_pieces(parts[1].clone()).peer_id(unique_peer_id(2)),
+            SeederConfig::with_pieces(parts[2].clone()).peer_id(unique_peer_id(3)),
+        ],
+    )
+    .await;
+
+    let download_dir = unique_temp_dir();
+    download_via_http(&fixture, &seeders, download_dir.path()).await;
+
+    for (i, seeder) in seeders.iter().enumerate() {
+        assert!(
+            seeder.blocks_sent() > 0,
+            "seeder {i} served zero blocks (partition {:?})",
+            parts[i]
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn corrupt_piece_is_refetched() {
+    let fixture = Arc::new(TorrentFixture::single(
+        512 * 1024,
+        DEFAULT_PIECE_LENGTH,
+        0xC044_0700,
+    ));
+    let piece0_blocks = u64::from(fixture.piece_len(0).div_ceil(BLOCK_SIZE));
+    let corrupt = SeederPeer::start(
+        fixture.clone(),
+        SeederConfig::with_pieces([0])
+            .peer_id(unique_peer_id(1))
+            .corrupt(0)
+            .disconnect_after_blocks(piece0_blocks),
+    )
+    .await;
+    let honest = SeederPeer::start(
+        fixture.clone(),
+        SeederConfig::all_pieces().peer_id(unique_peer_id(2)),
+    )
+    .await;
+
+    let tracker =
+        MockHttpTracker::start(vec![HttpAnnounceBody::peers(1800, vec![corrupt.addr])]).await;
+    let meta = fixture.meta_with_trackers(Some(tracker.url.clone()), None);
+    let download_dir = unique_temp_dir();
+    let session = test_session(None).await;
+    let output = fixture.session_output(download_dir.path());
+    let added = add_download(&session, meta, output.clone()).await;
+
+    corrupt
+        .wait_blocks_sent(piece0_blocks, Duration::from_secs(10))
+        .await;
+    assert!(
+        session.connect_peer(&fixture.torrent_meta.info_hash, honest.addr),
+        "failed to connect honest seeder"
+    );
+    wait_for_completion(
+        &added.pr_rx,
+        &added.torrent,
+        added.already_have.len(),
+        DOWNLOAD_TIMEOUT,
+    )
+    .await;
+    session.shutdown();
+    fixture.assert_output_matches(&output);
+    assert!(corrupt.blocks_sent() > 0);
+    assert!(honest.blocks_sent() > 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn disconnect_mid_piece_is_retried() {
+    let fixture = Arc::new(TorrentFixture::single(
+        512 * 1024,
+        DEFAULT_PIECE_LENGTH,
+        0xD15C_0001,
+    ));
+    assert!(
+        fixture.piece_len(0) > BLOCK_SIZE,
+        "need a multi-block piece to drop mid-piece"
+    );
+    let flaky = SeederPeer::start(
+        fixture.clone(),
+        SeederConfig::with_pieces([0])
+            .peer_id(unique_peer_id(1))
+            .disconnect_after_blocks(1),
+    )
+    .await;
+    let honest = SeederPeer::start(
+        fixture.clone(),
+        SeederConfig::all_pieces().peer_id(unique_peer_id(2)),
+    )
+    .await;
+
+    let tracker =
+        MockHttpTracker::start(vec![HttpAnnounceBody::peers(1800, vec![flaky.addr])]).await;
+    let meta = fixture.meta_with_trackers(Some(tracker.url.clone()), None);
+    let download_dir = unique_temp_dir();
+    let session = test_session(None).await;
+    let output = fixture.session_output(download_dir.path());
+    let added = add_download(&session, meta, output.clone()).await;
+
+    flaky.wait_blocks_sent(1, Duration::from_secs(10)).await;
+    assert!(
+        session.connect_peer(&fixture.torrent_meta.info_hash, honest.addr),
+        "failed to connect honest seeder"
+    );
+    wait_for_completion(
+        &added.pr_rx,
+        &added.torrent,
+        added.already_have.len(),
+        DOWNLOAD_TIMEOUT,
+    )
+    .await;
+    session.shutdown();
+    fixture.assert_output_matches(&output);
+    assert_eq!(flaky.blocks_sent(), 1);
+    assert!(honest.blocks_sent() > 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tracker_failure_then_second_tracker_succeeds() {
+    let fixture = Arc::new(TorrentFixture::single(
+        256 * 1024,
+        DEFAULT_PIECE_LENGTH,
+        0xFA11_0002,
+    ));
+    let seeders = start_seeders(
+        &fixture,
+        vec![SeederConfig::all_pieces().peer_id(unique_peer_id(1))],
+    )
+    .await;
+
+    let failing = MockHttpTracker::start(vec![HttpAnnounceBody::Failure(
+        "unregistered torrent".into(),
+    )])
+    .await;
+    let udp =
+        MockUdpTracker::start(vec![UdpAnnounceBody::peers(1800, vec![seeders[0].addr])]).await;
+
+    let meta = fixture.meta_with_trackers(
+        Some(failing.url.clone()),
+        Some(vec![vec![failing.url.clone()], vec![udp.url.clone()]]),
+    );
+
+    let download_dir = unique_temp_dir();
+    let session = test_session(None).await;
+    let output = fixture.session_output(download_dir.path());
+    let added = add_download(&session, meta, output.clone()).await;
+    wait_for_completion(
+        &added.pr_rx,
+        &added.torrent,
+        added.already_have.len(),
+        DOWNLOAD_TIMEOUT,
+    )
+    .await;
+    failing.wait_requests(1, Duration::from_secs(10)).await;
+    udp.wait_announces(1, Duration::from_secs(10)).await;
+    session.shutdown();
+    fixture.assert_output_matches(&output);
+    assert_eq!(
+        udp.announces()[0].info_hash,
+        fixture.torrent_meta.info_hash,
+        "UDP announce info_hash mismatch"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn slow_peer_does_not_block_download() {
+    let fixture = Arc::new(TorrentFixture::single(
+        1024 * 1024,
+        DEFAULT_PIECE_LENGTH,
+        0x5100_0001,
+    ));
+    let seeders = start_seeders(
+        &fixture,
+        vec![
+            SeederConfig::all_pieces()
+                .peer_id(unique_peer_id(1))
+                .latency(Duration::from_millis(200)),
+            SeederConfig::all_pieces().peer_id(unique_peer_id(2)),
+            SeederConfig::all_pieces().peer_id(unique_peer_id(3)),
+        ],
+    )
+    .await;
+
+    let download_dir = unique_temp_dir();
+    let started = Instant::now();
+    download_via_http(&fixture, &seeders, download_dir.path()).await;
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "download took {elapsed:?}, possible head-of-line blocking on the slow seeder"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "512 MiB fixture; run with --ignored"]
+async fn large_file_stays_memory_bounded() {
+    const LARGE: u64 = 512 * 1024 * 1024;
+    const RSS_BOUND: u64 = 400 * 1024 * 1024;
+
+    let fixture = Arc::new(
+        TorrentFixture::builder()
+            .single_file("large.bin", LARGE)
+            .piece_length(256 * 1024)
+            .seed(0x1A4E_0001)
+            .keep_payload(false)
+            .build(),
+    );
+    let seeders = start_seeders(
+        &fixture,
+        vec![SeederConfig::all_pieces().peer_id(unique_peer_id(1))],
+    )
+    .await;
+
+    let download_dir = unique_temp_dir();
+    let tracker =
+        MockHttpTracker::start(vec![HttpAnnounceBody::peers(1800, vec![seeders[0].addr])]).await;
+    let meta = fixture.meta_with_trackers(Some(tracker.url.clone()), None);
+
+    let session = test_session(None).await;
+    let output = fixture.session_output(download_dir.path());
+    let added = add_download(&session, meta, output.clone()).await;
+    wait_for_completion(
+        &added.pr_rx,
+        &added.torrent,
+        added.already_have.len(),
+        Duration::from_secs(180),
+    )
+    .await;
+    session.shutdown();
+    fixture.assert_output_matches(&output);
+
+    if let Some(rss) = common::peak_rss_bytes() {
+        assert!(rss < RSS_BOUND, "peak RSS {rss} exceeded bound {RSS_BOUND}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #24: in-process integration tests for download, multi-peer assembly, and recovery. No external network.

- Harness in `crates/bit_rev/tests/common/`: deterministic `TorrentFixture`, `MockHttpTracker`, `MockUdpTracker`, and a configurable `SeederPeer` (piece set, latency, corrupt piece, disconnect after N blocks, never-unchoke).
- Scenarios in `crates/bit_rev/tests/e2e.rs`: single-file and multi-file e2e, disjoint seeders, corrupt-piece refetch, mid-piece disconnect, HTTP failure then UDP success, slow-peer completion, and a 512 MiB `#[ignore]` RSS check.
- CI already runs `cargo test`. The test job now has a 10 minute timeout.

Small engine fixes so the recovery cases can finish: reserve only pieces the peer advertised, and clear leftover chunks when a piece fails hash or a peer dies.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-features --workspace` (189 passed, 1 ignored)
- [x] `cargo test --test e2e` run 3 times (no flakes)

Closes #24