### PR TITLE
feat: add CLI configuration system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +232,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
  "util",
 ]
@@ -204,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -236,18 +287,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "bit_rev",
+ "clap",
  "console-subscriber",
  "flume",
  "indicatif",
+ "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
+ "util",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
@@ -555,7 +656,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -626,6 +727,12 @@ dependencies = [
  "nom",
  "num-traits",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -930,6 +1037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,9 +1081,9 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags",
  "libc",
@@ -1124,16 +1237,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.73"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1157,9 +1275,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1346,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -1437,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustix"
@@ -1589,6 +1707,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1803,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1884,6 +2017,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.11.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "util"
 version = "0.1.0"
 dependencies = [
@@ -2126,11 +2306,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -2253,12 +2433,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -2269,7 +2455,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2278,7 +2464,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2305,7 +2491,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2326,19 +2512,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2349,9 +2535,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2361,9 +2547,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2373,9 +2559,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2385,9 +2571,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2397,9 +2583,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2409,9 +2595,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2421,9 +2607,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2433,15 +2619,27 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.45.0"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 thiserror = "2.0.9"
 indicatif = "0.17.7"
+clap = { version = "4.5", features = ["derive"] }
+toml = "0.8"
 flume = { version = "0.11.0", default-features = false, features = ["async", "select"] }
 reqwest = { version = "0.12", features = ["json", "gzip"] }
 byteorder = "1.4.3"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This Project it's a rewrite of [tornado](https://github.com/fraidev/tornado) in 
 Exemple of how to download a debian iso:
 
 ```bash
-cargo run --release -- samples/debian-12.10.0-amd64-netinst.iso.torrent
+cargo run --release --bin bitrev -- samples/debian-13.0.0-amd64-netinst.iso.torrent
 ```
 
 Tests:

--- a/crates/bit_rev/Cargo.toml
+++ b/crates/bit_rev/Cargo.toml
@@ -31,3 +31,4 @@ serde_bytes.workspace = true
 serde.workspace = true
 serde_bencode.workspace = true
 tempfile = "3.10"
+toml.workspace = true

--- a/crates/bit_rev/src/config.default.toml
+++ b/crates/bit_rev/src/config.default.toml
@@ -1,0 +1,86 @@
+# BitRev default configuration.
+# Unknown keys are rejected. Keys for features that are not implemented yet
+# still parse so this file stays valid across releases.
+
+# Directory where torrent data is written.
+download_dir = "."
+
+# TCP listen port announced to trackers.
+port = 6881
+
+# Maximum peers for one torrent.
+max_peers_per_torrent = 55
+
+# Maximum peers across all torrents.
+max_connections = 200
+
+# Peers requested from each tracker announce.
+numwant = 50
+
+# Resume data, cached torrents, and DHT state. `~` is the home directory.
+state_dir = "~/.bitrev"
+
+# MSE policy: disabled | prefer_plaintext | prefer_encrypted | require_encrypted
+encryption = "prefer_encrypted"
+
+# Bytes per second. 0 is unlimited.
+upload_limit = 0
+download_limit = 0
+
+# Peer exchange (BEP-0011).
+pex = true
+
+# Local peer discovery (BEP-0014).
+lpd = true
+
+# UPnP / NAT-PMP port mapping.
+nat = true
+
+# HTTP/FTP web seeds (BEP-0017 / BEP-0019).
+webseed = true
+
+# Dual-stack IPv6 (BEP-0007).
+ipv6 = true
+
+# Move data here when a torrent finishes. Empty disables the feature.
+completed_dir = ""
+
+# Watch this directory for new .torrent / .magnet files. Empty disables it.
+watch_dir = ""
+
+[seed]
+# Serve pieces after the download finishes.
+enabled = true
+# Stop seeding at this upload/download ratio. 0 is unlimited.
+ratio_limit = 0.0
+# Stop seeding this many minutes after completion. 0 is unlimited.
+time_limit = 0
+
+[dht]
+# Distributed hash table (BEP-0005).
+enabled = true
+port = 6881
+
+[utp]
+# Micro Transport Protocol (BEP-0029).
+enabled = true
+
+[queue]
+max_active_downloads = 5
+max_active_uploads = 8
+# 0 is unlimited.
+max_active = 0
+dont_count_slow = true
+
+[ip_filter]
+# Path to an eMule / CIDR blocklist. Empty disables filtering.
+path = ""
+
+[server]
+# Used by `bitrev serve`. Binding loopback is intentional.
+host = "127.0.0.1"
+port = 8080
+username = "admin"
+# Empty password is generated on first `bitrev serve`.
+password = ""
+qbittorrent_compat = true

--- a/crates/bit_rev/src/config.rs
+++ b/crates/bit_rev/src/config.rs
@@ -1,0 +1,297 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::file::AnnounceParams;
+use crate::session::{
+    SessionOptions, DEFAULT_LISTEN_PORT, DEFAULT_MAX_PEERS_GLOBAL, DEFAULT_MAX_PEERS_PER_TORRENT,
+};
+
+/// Session and engine settings loaded from TOML, env, and CLI flags.
+///
+/// Unknown keys are rejected (`deny_unknown_fields`) so a typo fails with the
+/// offending key name in the error. Keys for features that are not implemented
+/// yet still parse so config files stay stable across releases.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Config {
+    pub download_dir: PathBuf,
+    pub port: u16,
+    pub max_peers_per_torrent: usize,
+    pub max_connections: usize,
+    pub numwant: u32,
+    pub state_dir: PathBuf,
+    pub seed: SeedConfig,
+    pub dht: DhtConfig,
+    pub encryption: EncryptionMode,
+    pub utp: UtpConfig,
+    pub upload_limit: u64,
+    pub download_limit: u64,
+    pub pex: bool,
+    pub lpd: bool,
+    pub nat: bool,
+    pub webseed: bool,
+    pub ipv6: bool,
+    pub queue: QueueConfig,
+    pub completed_dir: PathBuf,
+    pub watch_dir: PathBuf,
+    pub ip_filter: IpFilterConfig,
+    pub server: ServerConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SeedConfig {
+    pub enabled: bool,
+    pub ratio_limit: f64,
+    /// Minutes after completion. 0 is unlimited.
+    pub time_limit: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DhtConfig {
+    pub enabled: bool,
+    pub port: u16,
+}
+
+/// MSE handshake policy (spec 10). Stored for config stability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EncryptionMode {
+    Disabled,
+    PreferPlaintext,
+    #[default]
+    PreferEncrypted,
+    RequireEncrypted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UtpConfig {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct QueueConfig {
+    pub max_active_downloads: usize,
+    pub max_active_uploads: usize,
+    pub max_active: usize,
+    pub dont_count_slow: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct IpFilterConfig {
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub qbittorrent_compat: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            download_dir: PathBuf::from("."),
+            port: DEFAULT_LISTEN_PORT,
+            max_peers_per_torrent: DEFAULT_MAX_PEERS_PER_TORRENT,
+            max_connections: DEFAULT_MAX_PEERS_GLOBAL,
+            numwant: AnnounceParams::DEFAULT_NUMWANT,
+            state_dir: PathBuf::from("~/.bitrev"),
+            seed: SeedConfig::default(),
+            dht: DhtConfig::default(),
+            encryption: EncryptionMode::default(),
+            utp: UtpConfig::default(),
+            upload_limit: 0,
+            download_limit: 0,
+            pex: true,
+            lpd: true,
+            nat: true,
+            webseed: true,
+            ipv6: true,
+            queue: QueueConfig::default(),
+            completed_dir: PathBuf::new(),
+            watch_dir: PathBuf::new(),
+            ip_filter: IpFilterConfig::default(),
+            server: ServerConfig::default(),
+        }
+    }
+}
+
+impl Default for SeedConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            ratio_limit: 0.0,
+            time_limit: 0,
+        }
+    }
+}
+
+impl Default for DhtConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            port: DEFAULT_LISTEN_PORT,
+        }
+    }
+}
+
+impl Default for UtpConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+impl Default for QueueConfig {
+    fn default() -> Self {
+        Self {
+            max_active_downloads: 5,
+            max_active_uploads: 8,
+            max_active: 0,
+            dont_count_slow: true,
+        }
+    }
+}
+
+impl Default for IpFilterConfig {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::new(),
+        }
+    }
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+            username: "admin".to_string(),
+            password: String::new(),
+            qbittorrent_compat: true,
+        }
+    }
+}
+
+impl Config {
+    /// Commented default file written by `bitrev config init`.
+    pub fn documented_default_toml() -> &'static str {
+        include_str!("config.default.toml")
+    }
+
+    /// Single mapping from file/env/flag config onto engine session knobs.
+    /// Later issues extend both sides of this function.
+    pub fn session_options(&self) -> SessionOptions {
+        let state_dir = util::paths::expand_tilde(&self.state_dir);
+        SessionOptions {
+            listen_port: self.port,
+            max_peers_per_torrent: self.max_peers_per_torrent,
+            max_peers_global: self.max_connections,
+            state_dir: if state_dir.as_os_str().is_empty() {
+                None
+            } else {
+                Some(state_dir)
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn documented_default_toml_parses_to_default() {
+        let parsed: Config = toml::from_str(Config::documented_default_toml()).unwrap();
+        assert_eq!(parsed, Config::default());
+    }
+
+    #[test]
+    fn unknown_key_is_rejected_by_name() {
+        let err = toml::from_str::<Config>("not_a_real_key = 1\n").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not_a_real_key"),
+            "error should name the unknown key: {msg}"
+        );
+    }
+
+    #[test]
+    fn unknown_nested_key_is_rejected_by_name() {
+        let err = toml::from_str::<Config>("[dht]\nnot_a_dht_key = true\n").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not_a_dht_key"),
+            "error should name the unknown key: {msg}"
+        );
+    }
+
+    #[test]
+    fn session_options_maps_engine_keys() {
+        let config = Config {
+            port: 6999,
+            max_peers_per_torrent: 10,
+            max_connections: 20,
+            state_dir: PathBuf::from("~/.bitrev"),
+            ..Config::default()
+        };
+
+        let options = config.session_options();
+        assert_eq!(options.listen_port, 6999);
+        assert_eq!(options.max_peers_per_torrent, 10);
+        assert_eq!(options.max_peers_global, 20);
+        assert_eq!(
+            options.state_dir.as_deref(),
+            Some(util::paths::state_dir().as_path())
+        );
+    }
+
+    #[test]
+    fn default_session_options_match_engine_defaults() {
+        let options = Config::default().session_options();
+        let expected = SessionOptions::default();
+        assert_eq!(options.listen_port, expected.listen_port);
+        assert_eq!(
+            options.max_peers_per_torrent,
+            expected.max_peers_per_torrent
+        );
+        assert_eq!(options.max_peers_global, expected.max_peers_global);
+        assert_eq!(options.state_dir, expected.state_dir);
+    }
+
+    #[test]
+    fn empty_state_dir_disables_persistence() {
+        let config = Config {
+            state_dir: PathBuf::new(),
+            ..Config::default()
+        };
+        assert_eq!(config.session_options().state_dir, None);
+    }
+
+    #[test]
+    fn encryption_modes_round_trip() {
+        for mode in [
+            EncryptionMode::Disabled,
+            EncryptionMode::PreferPlaintext,
+            EncryptionMode::PreferEncrypted,
+            EncryptionMode::RequireEncrypted,
+        ] {
+            let config = Config {
+                encryption: mode,
+                ..Config::default()
+            };
+            let text = toml::to_string(&config).unwrap();
+            let parsed: Config = toml::from_str(&text).unwrap();
+            assert_eq!(parsed.encryption, mode);
+        }
+    }
+}

--- a/crates/bit_rev/src/lib.rs
+++ b/crates/bit_rev/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod allowed_fast;
 pub mod bitfield;
 pub mod choke;
+pub mod config;
 pub mod discovery;
 pub mod extension;
 pub mod file;

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -125,9 +125,13 @@ impl AddTorrentOptions {
         }
     }
 
-    fn from_path(path: &str) -> Self {
-        let torrent_meta = file::from_filename(path).unwrap();
-        Self::from_meta(torrent_meta)
+    pub fn from_path(path: &str) -> anyhow::Result<Self> {
+        let torrent_meta = file::from_filename(path)?;
+        Ok(Self::from_meta(torrent_meta))
+    }
+
+    pub fn name(&self) -> &str {
+        &self.torrent_meta.torrent_file.info.name
     }
 
     pub fn output_dir(mut self, dir: impl Into<PathBuf>) -> Self {
@@ -152,8 +156,10 @@ impl From<TorrentMeta> for AddTorrentOptions {
     }
 }
 
-impl From<&str> for AddTorrentOptions {
-    fn from(path: &str) -> Self {
+impl TryFrom<&str> for AddTorrentOptions {
+    type Error = anyhow::Error;
+
+    fn try_from(path: &str) -> Result<Self, Self::Error> {
         Self::from_path(path)
     }
 }
@@ -989,5 +995,19 @@ impl Drop for Session {
 impl Default for Session {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod add_options_tests {
+    use super::AddTorrentOptions;
+
+    #[test]
+    fn from_path_is_fallible() {
+        let err = match AddTorrentOptions::from_path("/does/not/exist.torrent") {
+            Ok(_) => panic!("expected a parse error"),
+            Err(err) => err,
+        };
+        assert!(!err.to_string().is_empty());
     }
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,8 +3,12 @@ name = "cli"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "bitrev_cli"
+path = "src/lib.rs"
+
 [[bin]]
-name = "cli"
+name = "bitrev"
 path = "src/main.rs"
 
 [features]
@@ -18,5 +22,11 @@ bit_rev.workspace = true
 indicatif.workspace = true
 console-subscriber = { workspace = true, optional = true }
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 flume.workspace = true
+clap.workspace = true
+toml.workspace = true
+util = { path = "../util" }
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1,0 +1,198 @@
+use std::path::PathBuf;
+
+use clap::{ArgAction, Parser, Subcommand};
+
+/// A BitTorrent client.
+#[derive(Debug, Parser)]
+#[command(
+    name = "bitrev",
+    version = bit_rev::identity::CLIENT_VERSION,
+    about = "A BitTorrent client",
+    arg_required_else_help = true
+)]
+pub struct Cli {
+    /// Torrent files or magnet links
+    #[arg(value_name = "TORRENT|MAGNET")]
+    pub inputs: Vec<String>,
+
+    /// Download directory
+    #[arg(short, long, value_name = "DIR")]
+    pub output: Option<PathBuf>,
+
+    /// TCP listen port
+    #[arg(short, long, value_name = "PORT")]
+    pub port: Option<u16>,
+
+    /// Stay running and seed after downloads complete
+    #[arg(long, overrides_with = "no_seed")]
+    pub seed: bool,
+
+    /// Exit after downloads complete
+    #[arg(long = "no-seed")]
+    pub no_seed: bool,
+
+    /// Force a full re-hash instead of trusting resume data
+    #[arg(long)]
+    pub verify: bool,
+
+    /// Path to the TOML config file
+    #[arg(long, value_name = "PATH", global = true)]
+    pub config: Option<PathBuf>,
+
+    /// Decrease log verbosity
+    #[arg(short, long, action = ArgAction::Count, global = true)]
+    pub quiet: u8,
+
+    /// Increase log verbosity
+    #[arg(short, long, action = ArgAction::Count, global = true)]
+    pub verbose: u8,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Inspect or write configuration
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigCommand {
+    /// Write a default commented config file
+    Init {
+        /// Overwrite an existing file
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+impl Cli {
+    /// `--seed` keeps the process alive. `--no-seed` and the default exit after completion.
+    pub fn stay_alive(&self) -> bool {
+        self.seed && !self.no_seed
+    }
+}
+
+pub fn init_tracing(verbose: u8, quiet: u8) {
+    #[cfg(feature = "tokio-console")]
+    {
+        let _ = (verbose, quiet);
+        console_subscriber::init();
+    }
+
+    #[cfg(not(feature = "tokio-console"))]
+    {
+        use tracing_subscriber::EnvFilter;
+
+        let default_level = match (verbose as i16).saturating_sub(quiet as i16) {
+            ..=-3 => "off",
+            -2 => "error",
+            -1 => "warn",
+            0 => "info",
+            1 => "debug",
+            _ => "trace",
+        };
+        let filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{CommandFactory, Parser};
+
+    use super::Cli;
+
+    #[test]
+    fn version_matches_identity() {
+        let cmd = Cli::command();
+        assert_eq!(cmd.get_version(), Some(bit_rev::identity::CLIENT_VERSION));
+        assert_eq!(env!("CARGO_PKG_VERSION"), bit_rev::identity::CLIENT_VERSION);
+    }
+
+    #[test]
+    fn help_lists_every_flag() {
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        cmd.write_long_help(&mut buf).unwrap();
+        let help = String::from_utf8(buf).unwrap();
+
+        for needle in [
+            "--output",
+            "-o",
+            "--port",
+            "-p",
+            "--seed",
+            "--no-seed",
+            "--verify",
+            "--config",
+            "--quiet",
+            "-q",
+            "--verbose",
+            "-v",
+            "--help",
+            "--version",
+            "config",
+        ] {
+            assert!(help.contains(needle), "help is missing {needle}:\n{help}");
+        }
+
+        let mut config_cmd = Cli::command();
+        let init = config_cmd.find_subcommand_mut("config").unwrap();
+        let mut init_help = Vec::new();
+        init.write_long_help(&mut init_help).unwrap();
+        let init_help = String::from_utf8(init_help).unwrap();
+        assert!(
+            init_help.contains("init"),
+            "config help is missing init:\n{init_help}"
+        );
+
+        let mut init_cmd = Cli::command();
+        let init = init_cmd
+            .find_subcommand_mut("config")
+            .unwrap()
+            .find_subcommand_mut("init")
+            .unwrap();
+        let mut force_help = Vec::new();
+        init.write_long_help(&mut force_help).unwrap();
+        let force_help = String::from_utf8(force_help).unwrap();
+        assert!(
+            force_help.contains("--force"),
+            "config init help is missing --force:\n{force_help}"
+        );
+    }
+
+    #[test]
+    fn parses_repeatable_inputs_and_flags() {
+        let cli = Cli::parse_from([
+            "bitrev",
+            "-o",
+            "/tmp/dl",
+            "-p",
+            "6999",
+            "--seed",
+            "--verify",
+            "--config",
+            "/tmp/cfg.toml",
+            "one.torrent",
+            "two.torrent",
+        ]);
+        assert_eq!(cli.inputs, ["one.torrent", "two.torrent"]);
+        assert_eq!(cli.output.as_deref().unwrap().as_os_str(), "/tmp/dl");
+        assert_eq!(cli.port, Some(6999));
+        assert!(cli.seed);
+        assert!(cli.verify);
+        assert!(cli.stay_alive());
+    }
+
+    #[test]
+    fn no_seed_overrides_seed() {
+        let cli = Cli::parse_from(["bitrev", "--seed", "--no-seed", "t.torrent"]);
+        assert!(!cli.stay_alive());
+    }
+}

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1,0 +1,379 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use anyhow::{anyhow, Context};
+use bit_rev::config::{Config, EncryptionMode};
+
+use crate::args::Cli;
+
+#[derive(Debug, Default, Clone)]
+pub struct FlagOverrides {
+    pub port: Option<u16>,
+    pub download_dir: Option<PathBuf>,
+}
+
+impl From<&Cli> for FlagOverrides {
+    fn from(cli: &Cli) -> Self {
+        Self {
+            port: cli.port,
+            download_dir: cli.output.clone(),
+        }
+    }
+}
+
+pub fn default_config_path() -> PathBuf {
+    util::paths::state_dir().join("config.toml")
+}
+
+/// Load config with precedence: defaults < TOML file < `BITREV_*` env < flags.
+///
+/// A missing file is not an error. A malformed file names the path and key.
+pub fn load_config(
+    config_path: Option<&Path>,
+    env: impl Fn(&str) -> Option<String>,
+    flags: &FlagOverrides,
+) -> anyhow::Result<Config> {
+    let path = config_path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(default_config_path);
+
+    let mut config = if path.exists() {
+        let contents = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read config file {}", path.display()))?;
+        parse_config_file(&path, &contents)?
+    } else {
+        Config::default()
+    };
+
+    apply_env(&mut config, &env)?;
+    apply_flags(&mut config, flags);
+    Ok(config)
+}
+
+pub fn parse_config_file(path: &Path, contents: &str) -> anyhow::Result<Config> {
+    toml::from_str(contents).map_err(|err| anyhow!("invalid config file {}: {err}", path.display()))
+}
+
+pub fn write_default_config(path: &Path, force: bool) -> anyhow::Result<()> {
+    if path.exists() && !force {
+        anyhow::bail!(
+            "config already exists at {}, use --force to overwrite",
+            path.display()
+        );
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+    std::fs::write(path, Config::documented_default_toml())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn apply_flags(config: &mut Config, flags: &FlagOverrides) {
+    if let Some(port) = flags.port {
+        config.port = port;
+    }
+    if let Some(dir) = &flags.download_dir {
+        config.download_dir = dir.clone();
+    }
+}
+
+fn apply_env(config: &mut Config, env: &impl Fn(&str) -> Option<String>) -> anyhow::Result<()> {
+    if let Some(v) = env_parse(env, "BITREV_PORT")? {
+        config.port = v;
+    }
+    if let Some(v) = env("BITREV_DOWNLOAD_DIR") {
+        config.download_dir = PathBuf::from(v);
+    }
+    if let Some(v) = env_parse(env, "BITREV_MAX_PEERS_PER_TORRENT")? {
+        config.max_peers_per_torrent = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_MAX_CONNECTIONS")? {
+        config.max_connections = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_NUMWANT")? {
+        config.numwant = v;
+    }
+    if let Some(v) = env("BITREV_STATE_DIR") {
+        config.state_dir = PathBuf::from(v);
+    }
+    if let Some(v) = env_bool(env, "BITREV_SEED_ENABLED")? {
+        config.seed.enabled = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_SEED_RATIO_LIMIT")? {
+        config.seed.ratio_limit = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_SEED_TIME_LIMIT")? {
+        config.seed.time_limit = v;
+    }
+    if let Some(v) = env_bool(env, "BITREV_DHT_ENABLED")? {
+        config.dht.enabled = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_DHT_PORT")? {
+        config.dht.port = v;
+    }
+    if let Some(v) = env("BITREV_ENCRYPTION") {
+        config.encryption = parse_encryption(&v)?;
+    }
+    if let Some(v) = env_bool(env, "BITREV_UTP_ENABLED")? {
+        config.utp.enabled = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_UPLOAD_LIMIT")? {
+        config.upload_limit = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_DOWNLOAD_LIMIT")? {
+        config.download_limit = v;
+    }
+    if let Some(v) = env_bool(env, "BITREV_PEX")? {
+        config.pex = v;
+    }
+    if let Some(v) = env_bool(env, "BITREV_LPD")? {
+        config.lpd = v;
+    }
+    if let Some(v) = env_bool(env, "BITREV_NAT")? {
+        config.nat = v;
+    }
+    if let Some(v) = env_bool(env, "BITREV_WEBSEED")? {
+        config.webseed = v;
+    }
+    if let Some(v) = env_bool(env, "BITREV_IPV6")? {
+        config.ipv6 = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_QUEUE_MAX_ACTIVE_DOWNLOADS")? {
+        config.queue.max_active_downloads = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_QUEUE_MAX_ACTIVE_UPLOADS")? {
+        config.queue.max_active_uploads = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_QUEUE_MAX_ACTIVE")? {
+        config.queue.max_active = v;
+    }
+    if let Some(v) = env_bool(env, "BITREV_QUEUE_DONT_COUNT_SLOW")? {
+        config.queue.dont_count_slow = v;
+    }
+    if let Some(v) = env("BITREV_COMPLETED_DIR") {
+        config.completed_dir = PathBuf::from(v);
+    }
+    if let Some(v) = env("BITREV_WATCH_DIR") {
+        config.watch_dir = PathBuf::from(v);
+    }
+    if let Some(v) = env("BITREV_IP_FILTER_PATH") {
+        config.ip_filter.path = PathBuf::from(v);
+    }
+    if let Some(v) = env("BITREV_SERVER_HOST") {
+        config.server.host = v;
+    }
+    if let Some(v) = env_parse(env, "BITREV_SERVER_PORT")? {
+        config.server.port = v;
+    }
+    if let Some(v) = env("BITREV_SERVER_USERNAME") {
+        config.server.username = v;
+    }
+    if let Some(v) = env("BITREV_SERVER_PASSWORD") {
+        config.server.password = v;
+    }
+    if let Some(v) = env_bool(env, "BITREV_SERVER_QBITTORRENT_COMPAT")? {
+        config.server.qbittorrent_compat = v;
+    }
+    Ok(())
+}
+
+fn env_parse<T: FromStr>(
+    env: &impl Fn(&str) -> Option<String>,
+    key: &str,
+) -> anyhow::Result<Option<T>>
+where
+    T::Err: std::fmt::Display,
+{
+    match env(key) {
+        Some(value) => value
+            .parse()
+            .map(Some)
+            .map_err(|err| anyhow!("invalid {key}: {err}")),
+        None => Ok(None),
+    }
+}
+
+fn env_bool(env: &impl Fn(&str) -> Option<String>, key: &str) -> anyhow::Result<Option<bool>> {
+    match env(key) {
+        Some(value) => parse_bool(key, &value).map(Some),
+        None => Ok(None),
+    }
+}
+
+fn parse_bool(key: &str, value: &str) -> anyhow::Result<bool> {
+    match value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => anyhow::bail!("invalid boolean for {key}: {value}"),
+    }
+}
+
+fn parse_encryption(value: &str) -> anyhow::Result<EncryptionMode> {
+    match value {
+        "disabled" => Ok(EncryptionMode::Disabled),
+        "prefer_plaintext" => Ok(EncryptionMode::PreferPlaintext),
+        "prefer_encrypted" => Ok(EncryptionMode::PreferEncrypted),
+        "require_encrypted" => Ok(EncryptionMode::RequireEncrypted),
+        _ => anyhow::bail!("invalid BITREV_ENCRYPTION: {value}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use super::{load_config, write_default_config, FlagOverrides};
+
+    fn env_map(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key| map.get(key).cloned()
+    }
+
+    #[test]
+    fn flag_overrides_env_and_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "port = 6882\ndownload_dir = \"/from-file\"\n").unwrap();
+
+        let config = load_config(
+            Some(&path),
+            env_map(&[
+                ("BITREV_PORT", "6883"),
+                ("BITREV_DOWNLOAD_DIR", "/from-env"),
+            ]),
+            &FlagOverrides {
+                port: Some(6884),
+                download_dir: Some(PathBuf::from("/from-flag")),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(config.port, 6884);
+        assert_eq!(config.download_dir, PathBuf::from("/from-flag"));
+    }
+
+    #[test]
+    fn env_overrides_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "port = 6882\ndownload_dir = \"/from-file\"\n").unwrap();
+
+        let config = load_config(
+            Some(&path),
+            env_map(&[
+                ("BITREV_PORT", "6883"),
+                ("BITREV_DOWNLOAD_DIR", "/from-env"),
+            ]),
+            &FlagOverrides::default(),
+        )
+        .unwrap();
+
+        assert_eq!(config.port, 6883);
+        assert_eq!(config.download_dir, PathBuf::from("/from-env"));
+    }
+
+    #[test]
+    fn env_overrides_without_config_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.toml");
+
+        let config = load_config(
+            Some(&missing),
+            env_map(&[
+                ("BITREV_PORT", "6999"),
+                ("BITREV_DOWNLOAD_DIR", "/from-env"),
+            ]),
+            &FlagOverrides::default(),
+        )
+        .unwrap();
+
+        assert_eq!(config.port, 6999);
+        assert_eq!(config.download_dir, PathBuf::from("/from-env"));
+    }
+
+    #[test]
+    fn file_used_when_no_env_or_flags() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "port = 6882\ndownload_dir = \"/from-file\"\n").unwrap();
+
+        let config = load_config(Some(&path), |_| None, &FlagOverrides::default()).unwrap();
+        assert_eq!(config.port, 6882);
+        assert_eq!(config.download_dir, PathBuf::from("/from-file"));
+    }
+
+    #[test]
+    fn nested_env_overrides_dht_and_server_port() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.toml");
+        let config = load_config(
+            Some(&missing),
+            env_map(&[("BITREV_DHT_PORT", "7001"), ("BITREV_SERVER_PORT", "9090")]),
+            &FlagOverrides::default(),
+        )
+        .unwrap();
+        assert_eq!(config.dht.port, 7001);
+        assert_eq!(config.server.port, 9090);
+    }
+
+    #[test]
+    fn malformed_toml_names_file_and_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "port = \"not-a-port\"\n").unwrap();
+
+        let err = load_config(Some(&path), |_| None, &FlagOverrides::default()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bad.toml") || msg.contains(&path.display().to_string()),
+            "error should name the file: {msg}"
+        );
+        assert!(msg.contains("port"), "error should name the key: {msg}");
+    }
+
+    #[test]
+    fn unknown_key_is_rejected_with_file_and_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "not_a_real_key = 1\n").unwrap();
+
+        let err = load_config(Some(&path), |_| None, &FlagOverrides::default()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bad.toml") || msg.contains(&path.display().to_string()),
+            "error should name the file: {msg}"
+        );
+        assert!(
+            msg.contains("not_a_real_key"),
+            "error should name the key: {msg}"
+        );
+    }
+
+    #[test]
+    fn config_init_output_reparses_to_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write_default_config(&path, false).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let parsed: bit_rev::config::Config = toml::from_str(&text).unwrap();
+        assert_eq!(parsed, bit_rev::config::Config::default());
+    }
+
+    #[test]
+    fn config_init_refuses_overwrite_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write_default_config(&path, false).unwrap();
+        let err = write_default_config(&path, false).unwrap_err();
+        assert!(err.to_string().contains("--force"));
+        write_default_config(&path, true).unwrap();
+    }
+}

--- a/crates/cli/src/download.rs
+++ b/crates/cli/src/download.rs
@@ -1,0 +1,138 @@
+use std::collections::HashSet;
+use std::fmt::Write;
+use std::path::Path;
+
+use anyhow::Context;
+use bit_rev::config::Config;
+use bit_rev::session::{AddTorrentOptions, AddTorrentResult, Session};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle};
+
+use crate::args::Cli;
+
+pub async fn run(cli: Cli, config: Config) -> anyhow::Result<()> {
+    let mut pending = Vec::with_capacity(cli.inputs.len());
+    for input in &cli.inputs {
+        pending.push((
+            input.clone(),
+            add_options(input, &config.download_dir, cli.verify)?,
+        ));
+    }
+
+    let session = Session::with_options(config.session_options());
+    let mp = MultiProgress::with_draw_target(ProgressDrawTarget::stderr());
+    let style = progress_style();
+
+    let mut join = tokio::task::JoinSet::new();
+    for (input, opts) in pending {
+        let result = session
+            .add_torrent(opts)
+            .await
+            .with_context(|| format!("failed to add {input}"))?;
+        let name = result.torrent.name.clone();
+        let pb = mp.add(ProgressBar::new(result.torrent.length as u64));
+        pb.set_style(style.clone());
+        pb.set_message(name);
+        join.spawn(drive_progress(result, pb));
+    }
+
+    let downloads = async {
+        while let Some(res) = join.join_next().await {
+            res.map_err(|err| anyhow::anyhow!("download task failed: {err}"))??;
+        }
+        anyhow::Ok(())
+    };
+
+    tokio::select! {
+        result = downloads => {
+            result?;
+            if cli.stay_alive() {
+                eprintln!("Seeding. Press Ctrl-C to stop.");
+                shutdown_signal().await;
+            }
+            shutdown_session(&session).await;
+        }
+        _ = shutdown_signal() => {
+            shutdown_session(&session).await;
+        }
+    }
+
+    Ok(())
+}
+
+fn add_options(
+    input: &str,
+    download_dir: &Path,
+    verify: bool,
+) -> anyhow::Result<AddTorrentOptions> {
+    if input.starts_with("magnet:") {
+        anyhow::bail!("magnet links are not supported yet");
+    }
+    let opts = AddTorrentOptions::from_path(input)
+        .with_context(|| format!("failed to open torrent {input}"))?;
+    let output = util::paths::expand_tilde(download_dir).join(opts.name());
+    Ok(opts.verify(verify).output_dir(output))
+}
+
+fn progress_style() -> ProgressStyle {
+    ProgressStyle::with_template(
+        "{spinner:.green} [{elapsed_precise}][{msg}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec},{eta})",
+    )
+    .unwrap()
+    .with_key(
+        "eta",
+        |state: &ProgressState, w: &mut dyn Write| {
+            write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
+        },
+    )
+    .progress_chars("#>-")
+}
+
+async fn drive_progress(result: AddTorrentResult, pb: ProgressBar) -> anyhow::Result<()> {
+    let torrent = result.torrent;
+    let mut have = HashSet::new();
+    let mut downloaded = 0u64;
+    for piece in &result.already_have {
+        have.insert(piece.index);
+        downloaded += u64::from(piece.length);
+    }
+    pb.set_position(downloaded);
+
+    while have.len() < torrent.piece_hashes.len() {
+        let piece = result.pr_rx.recv_async().await?;
+        if have.insert(piece.index) {
+            downloaded += u64::from(piece.length);
+            pb.set_position(downloaded);
+        }
+    }
+    pb.finish_with_message(format!("{} complete", torrent.name));
+    Ok(())
+}
+
+async fn shutdown_session(session: &Session) {
+    eprintln!("Shutting down...");
+    session.shutdown_graceful().await;
+    tokio::select! {
+        _ = shutdown_signal() => {
+            eprintln!("Forced exit");
+            std::process::exit(130);
+        }
+        _ = tokio::time::sleep(std::time::Duration::from_secs(8)) => {}
+    }
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+    #[cfg(unix)]
+    {
+        let mut term = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("install SIGTERM handler");
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = ctrl_c.await;
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod args;
+pub mod config;
+pub mod download;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,122 +1,38 @@
-use indicatif::{ProgressBar, ProgressState, ProgressStyle};
-use std::{
-    fmt::Write,
-    sync::{atomic::AtomicU64, Arc},
-};
+use bitrev_cli::args::{init_tracing, Cli, Command, ConfigCommand};
+use bitrev_cli::config::{default_config_path, load_config, write_default_config, FlagOverrides};
+use bitrev_cli::download;
+use clap::Parser;
 
-use bit_rev::session::{AddTorrentOptions, Session};
+fn main() {
+    let cli = Cli::parse();
+    if let Err(err) = run(cli) {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
 
 #[tokio::main]
-async fn main() {
-    #[cfg(not(feature = "tokio-console"))]
-    tracing_subscriber::fmt::init();
-
-    #[cfg(feature = "tokio-console")]
-    console_subscriber::init();
-
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let verify = args.iter().any(|arg| arg == "--verify");
-    let positional: Vec<&str> = args
-        .iter()
-        .filter(|arg| !arg.starts_with('-'))
-        .map(String::as_str)
-        .collect();
-    let filename = positional.first().copied().expect("No torrent path given");
-    let output = positional.get(1).map(|s| (*s).to_string());
-
-    if let Err(err) = download_file(filename, output, verify).await {
-        eprintln!("Error: {:?}", err);
-    }
-}
-
-async fn shutdown_signal() {
-    let ctrl_c = tokio::signal::ctrl_c();
-    #[cfg(unix)]
-    {
-        let mut term = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("install SIGTERM handler");
-        tokio::select! {
-            _ = ctrl_c => {}
-            _ = term.recv() => {}
+async fn run(cli: Cli) -> anyhow::Result<()> {
+    match cli.command {
+        Some(Command::Config {
+            command: ConfigCommand::Init { force },
+        }) => {
+            let path = cli.config.clone().unwrap_or_else(default_config_path);
+            write_default_config(&path, force)?;
+            eprintln!("Wrote {}", path.display());
+            Ok(())
         }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = ctrl_c.await;
-    }
-}
-
-pub async fn download_file(
-    filename: &str,
-    out_file: Option<String>,
-    verify: bool,
-) -> anyhow::Result<()> {
-    let session = Session::new();
-
-    let mut add_opts = AddTorrentOptions::from(filename).verify(verify);
-    if let Some(output) = out_file {
-        add_opts = add_opts.output_dir(output);
-    }
-
-    let add_torrent_result = session.add_torrent(add_opts).await?;
-    let torrent = add_torrent_result.torrent.clone();
-
-    let total_size = torrent.length as u64;
-    let pb = ProgressBar::new(total_size);
-
-    pb.set_style(
-        ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise}][{msg}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec},{eta})"
-            ).unwrap().with_key(
-            "eta",
-            | state: &ProgressState, w: &mut dyn Write | write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
-        ).progress_chars("#>-")
-    );
-
-    let total_downloaded = Arc::new(AtomicU64::new(0));
-    let total_downloaded_clone = total_downloaded.clone();
-
-    tokio::spawn(async move {
-        loop {
-            let new = total_downloaded_clone.load(std::sync::atomic::Ordering::Relaxed);
-            pb.set_position(new);
-            pb.set_message("Downloading");
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
-    });
-
-    let mut hashset = std::collections::HashSet::new();
-    for pr in &add_torrent_result.already_have {
-        hashset.insert(pr.index);
-        total_downloaded.fetch_add(pr.length as u64, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    let download = async {
-        while hashset.len() < torrent.piece_hashes.len() {
-            let pr = add_torrent_result.pr_rx.recv_async().await?;
-            hashset.insert(pr.index);
-            total_downloaded.fetch_add(pr.length as u64, std::sync::atomic::Ordering::Relaxed);
-        }
-        anyhow::Ok(())
-    };
-
-    tokio::select! {
-        result = download => {
-            result?;
-            session.shutdown_graceful().await;
-        }
-        _ = shutdown_signal() => {
-            eprintln!("Shutting down...");
-            session.shutdown_graceful().await;
-            tokio::select! {
-                _ = shutdown_signal() => {
-                    eprintln!("Forced exit");
-                    std::process::exit(130);
-                }
-                _ = tokio::time::sleep(std::time::Duration::from_secs(8)) => {}
+        None => {
+            if cli.inputs.is_empty() {
+                anyhow::bail!("no torrent or magnet given");
             }
+            init_tracing(cli.verbose, cli.quiet);
+            let config = load_config(
+                cli.config.as_deref(),
+                |key| std::env::var(key).ok(),
+                &FlagOverrides::from(&cli),
+            )?;
+            download::run(cli, config).await
         }
     }
-
-    Ok(())
 }

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1,0 +1,88 @@
+use std::process::Command;
+
+use bit_rev::identity::CLIENT_VERSION;
+
+fn bitrev() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_bitrev"))
+}
+
+#[test]
+fn help_lists_every_flag() {
+    let output = bitrev().arg("--help").output().expect("run bitrev --help");
+    assert!(output.status.success());
+    let help = String::from_utf8_lossy(&output.stdout);
+    for needle in [
+        "--output",
+        "-o",
+        "--port",
+        "-p",
+        "--seed",
+        "--no-seed",
+        "--verify",
+        "--config",
+        "--quiet",
+        "-q",
+        "--verbose",
+        "-v",
+        "--version",
+        "config",
+    ] {
+        assert!(
+            help.contains(needle),
+            "bitrev --help is missing {needle}:\n{help}"
+        );
+    }
+
+    let config_help = bitrev()
+        .args(["config", "init", "--help"])
+        .output()
+        .expect("run bitrev config init --help");
+    assert!(config_help.status.success());
+    let config_help = String::from_utf8_lossy(&config_help.stdout);
+    assert!(
+        config_help.contains("--force"),
+        "config init help is missing --force:\n{config_help}"
+    );
+}
+
+#[test]
+fn version_equals_identity_constant() {
+    let output = bitrev()
+        .arg("--version")
+        .output()
+        .expect("run bitrev --version");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(CLIENT_VERSION),
+        "--version {stdout:?} should contain {CLIENT_VERSION}"
+    );
+}
+
+#[test]
+fn config_init_writes_default_and_refuses_overwrite() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+
+    let first = bitrev()
+        .args(["--config", path.to_str().unwrap(), "config", "init"])
+        .output()
+        .expect("config init");
+    assert!(
+        first.status.success(),
+        "config init failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let text = std::fs::read_to_string(&path).unwrap();
+    let parsed: bit_rev::config::Config = toml::from_str(&text).unwrap();
+    assert_eq!(parsed, bit_rev::config::Config::default());
+
+    let second = bitrev()
+        .args(["--config", path.to_str().unwrap(), "config", "init"])
+        .output()
+        .expect("config init overwrite");
+    assert!(!second.status.success());
+    let err = String::from_utf8_lossy(&second.stderr);
+    assert!(err.contains("--force"), "{err}");
+}

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 lazy_static::lazy_static! {
     pub static ref HOME: PathBuf = dirs::home_dir().expect("failed to determine home directory");
-    /// Client state directory. Hardcoded until the config system (issue #21) lands.
+    /// Default client state directory (`~/.bitrev`).
     pub static ref STATE_DIR: PathBuf = HOME.join(".bitrev");
     pub static ref CONFIG_DIR: PathBuf = HOME.join(".config").join("bit_rev");
     pub static ref CONVERSATIONS_DIR: PathBuf = CONFIG_DIR.join("conversations");
@@ -45,6 +45,17 @@ lazy_static::lazy_static! {
 /// Default client state directory (`~/.bitrev`).
 pub fn state_dir() -> PathBuf {
     STATE_DIR.clone()
+}
+
+/// Expand a leading `~` component to the user's home directory.
+pub fn expand_tilde(path: &Path) -> PathBuf {
+    if path == Path::new("~") {
+        return HOME.clone();
+    }
+    match path.strip_prefix("~") {
+        Ok(rest) => HOME.join(rest),
+        Err(_) => path.to_path_buf(),
+    }
 }
 
 /// Resume files: `<state_dir>/resume/<info_hash_hex>.resume`.
@@ -408,6 +419,20 @@ mod tests {
         assert_eq!(
             torrents_dir(&state_dir()),
             HOME.join(".bitrev").join("torrents")
+        );
+    }
+
+    #[test]
+    fn expand_tilde_resolves_home_prefix() {
+        assert_eq!(expand_tilde(Path::new("~")), *HOME);
+        assert_eq!(expand_tilde(Path::new("~/.bitrev")), state_dir());
+        assert_eq!(
+            expand_tilde(Path::new("/abs/path")),
+            PathBuf::from("/abs/path")
+        );
+        assert_eq!(
+            expand_tilde(Path::new("rel/path")),
+            PathBuf::from("rel/path")
         );
     }
 


### PR DESCRIPTION
Add `bit_rev::config::Config` with serde for the spec 13 table (including keys for features that are not implemented yet) and reject unknown keys by name. `Config::session_options()` is the mapping onto engine knobs.

The CLI layers defaults, then `~/.bitrev/config.toml` or `--config`, then `BITREV_*` env (nested as `BITREV_DHT_PORT` / `BITREV_SERVER_PORT`), then clap flags. The binary is renamed to `bitrev`. `bitrev config init` writes a commented default file and refuses to overwrite without `--force`.

`--seed` stays alive after completion. `--verify` maps to `AddTorrentOptions::verify`. Multiple positional inputs each get a progress bar on stderr. `AddTorrentOptions::from_path` is now fallible.

Fixes #21