### PR TITLE
feat: harden peer wire protocol

### DIFF
--- a/crates/bit_rev/src/extension/handshake.rs
+++ b/crates/bit_rev/src/extension/handshake.rs
@@ -6,6 +6,8 @@ use crate::identity;
 
 pub const DEFAULT_REQQ: i64 = 250;
 pub const UT_METADATA: &str = "ut_metadata";
+pub const MAX_METADATA_SIZE: i64 = 2 * 1024 * 1024;
+pub const MAX_EXTENSION_PAYLOAD: usize = 2 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ExtensionHandshake {
@@ -72,6 +74,9 @@ impl ExtensionHandshake {
     }
 
     pub fn decode(bytes: &[u8]) -> Self {
+        if bytes.len() > MAX_EXTENSION_PAYLOAD {
+            return Self::default();
+        }
         let Ok(Value::Dict(dict)) = serde_bencode::from_bytes::<Value>(bytes) else {
             return Self::default();
         };
@@ -97,7 +102,9 @@ impl ExtensionHandshake {
             handshake.reqq = Some(*reqq);
         }
         if let Some(Value::Int(size)) = dict.get(&b"metadata_size"[..]) {
-            handshake.metadata_size = Some(*size);
+            if (0..=MAX_METADATA_SIZE).contains(size) {
+                handshake.metadata_size = Some(*size);
+            }
         }
         handshake
     }
@@ -233,6 +240,19 @@ mod tests {
         assert_eq!(decoded.reqq, Some(250));
         assert_eq!(decoded.metadata_size, Some(32768));
         assert_eq!(decoded.v.as_deref(), Some("\u{00b5}Torrent 1.2"));
+    }
+
+    #[test]
+    fn decode_rejects_oversized_payload_and_metadata_size() {
+        let huge = vec![0u8; MAX_EXTENSION_PAYLOAD + 1];
+        assert_eq!(
+            ExtensionHandshake::decode(&huge),
+            ExtensionHandshake::default()
+        );
+
+        let oversized = b"d13:metadata_sizei999999999ee";
+        let decoded = ExtensionHandshake::decode(oversized);
+        assert!(decoded.metadata_size.is_none());
     }
 
     #[test]

--- a/crates/bit_rev/src/extension/mod.rs
+++ b/crates/bit_rev/src/extension/mod.rs
@@ -1,5 +1,8 @@
 pub mod handshake;
 pub mod registry;
 
-pub use handshake::{ExtensionHandshake, PeerExtensionInfo, DEFAULT_REQQ, UT_METADATA};
+pub use handshake::{
+    ExtensionHandshake, PeerExtensionInfo, DEFAULT_REQQ, MAX_EXTENSION_PAYLOAD, MAX_METADATA_SIZE,
+    UT_METADATA,
+};
 pub use registry::{Extension, ExtensionRegistry, ExtensionSession};

--- a/crates/bit_rev/src/handshake.rs
+++ b/crates/bit_rev/src/handshake.rs
@@ -19,10 +19,15 @@ pub struct HandshakeCapabilities {
     pub extension_protocol: bool,
 }
 
+/// Standard BitTorrent `pstrlen`. Larger values are rejected before allocation.
+pub const MAX_PSTR_LEN: usize = 19;
+
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum HandshakeError {
     #[error("Protocol length can't be zero")]
     ProtocolLengthCantBeZero,
+    #[error("Protocol length is invalid")]
+    InvalidProtocolLength,
     #[error("Handshake buffer is too short")]
     BufferTooShort,
 }

--- a/crates/bit_rev/src/message.rs
+++ b/crates/bit_rev/src/message.rs
@@ -25,8 +25,7 @@ pub enum MessageId {
 #[derive(Debug)]
 pub enum WriterRequest {
     Message(Message),
-    //ReadChunkRequest(ChunkInfo),
-    //Disconnect(anyhow::Result<()>),
+    Disconnect,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -141,8 +140,53 @@ pub enum MessageError {
     InvalidPayload(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecodeError {
+    Truncated,
+    UnknownId(u8),
+    InvalidLengthPrefix,
+}
+
 pub const MAX_INCOMING_REQUEST_LENGTH: u32 = 128 * 1024;
 pub const MAX_UPLOAD_QUEUE: usize = 8;
+pub const MAX_CHOKED_REQUESTS: u32 = 8;
+pub const MAX_QUEUE_OVERFLOWS: u32 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestStormError {
+    Choked,
+    Queue,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RequestStorm {
+    pub choked_requests: u32,
+    pub queue_overflows: u32,
+}
+
+impl RequestStorm {
+    pub fn on_choked_request(&mut self) -> Result<(), RequestStormError> {
+        self.choked_requests = self.choked_requests.saturating_add(1);
+        if self.choked_requests > MAX_CHOKED_REQUESTS {
+            Err(RequestStormError::Choked)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn on_queue_overflow(&mut self) -> Result<(), RequestStormError> {
+        self.queue_overflows = self.queue_overflows.saturating_add(1);
+        if self.queue_overflows > MAX_QUEUE_OVERFLOWS {
+            Err(RequestStormError::Queue)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn reset_choked(&mut self) {
+        self.choked_requests = 0;
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BlockRequest {
@@ -391,15 +435,17 @@ pub fn serialize(msg: Option<Message>) -> Vec<u8> {
     }
 }
 
-pub fn read(length_buf: &[u8], message_buf: &[u8]) -> Option<Message> {
-    let length_buf: [u8; 4] = length_buf.try_into().ok()?;
+pub fn read(length_buf: &[u8], message_buf: &[u8]) -> Result<Message, DecodeError> {
+    let length_buf: [u8; 4] = length_buf
+        .try_into()
+        .map_err(|_| DecodeError::InvalidLengthPrefix)?;
     let length = u32::from_be_bytes(length_buf);
     if length == 0 {
-        return None;
+        return Ok(Message::KeepAlive);
     }
     let length = length as usize;
     if message_buf.is_empty() || message_buf.len() < length {
-        return None;
+        return Err(DecodeError::Truncated);
     }
 
     let id = message_buf[0];
@@ -424,32 +470,30 @@ pub fn read(length_buf: &[u8], message_buf: &[u8]) -> Option<Message> {
         21 => MessageId::MsgHashRequest,
         22 => MessageId::MsgHashes,
         23 => MessageId::MsgHashReject,
-        _ => return None,
+        _ => return Err(DecodeError::UnknownId(id)),
     };
 
     match message_id {
         MessageId::MsgHave | MessageId::MsgSuggestPiece | MessageId::MsgAllowedFast
             if payload.len() < 4 =>
         {
-            return None
+            return Err(DecodeError::Truncated)
         }
         MessageId::MsgRequest | MessageId::MsgCancel | MessageId::MsgRejectRequest
             if payload.len() < 12 =>
         {
-            return None
+            return Err(DecodeError::Truncated)
         }
-        MessageId::MsgPiece if payload.len() < 8 => return None,
-        MessageId::MsgExtended if payload.is_empty() => return None,
+        MessageId::MsgPiece if payload.len() < 8 => return Err(DecodeError::Truncated),
+        MessageId::MsgExtended if payload.is_empty() => return Err(DecodeError::Truncated),
         _ => {}
     }
 
-    Some(
-        (MessageInner {
-            id: message_id,
-            payload,
-        })
-        .into(),
-    )
+    Ok((MessageInner {
+        id: message_id,
+        payload,
+    })
+    .into())
 }
 
 #[cfg(test)]
@@ -616,10 +660,10 @@ mod tests {
         let expected = Message::Have(4);
 
         let result = read(&length_buf, &message_buf);
-        assert_eq!(result, Some(expected));
+        assert_eq!(result, Ok(expected));
     }
 
-    fn round_trip(msg: Message) -> Option<Message> {
+    fn round_trip(msg: Message) -> Result<Message, DecodeError> {
         let bytes = serialize(Some(msg));
         read(&bytes[0..4], &bytes[4..])
     }
@@ -669,12 +713,11 @@ mod tests {
 
         for msg in cases {
             let expected = msg.clone();
-            assert_eq!(round_trip(msg), Some(expected));
+            assert_eq!(round_trip(msg), Ok(expected));
         }
 
-        // Keep-alive serializes to a zero length prefix. read maps length 0 to None.
         assert_eq!(serialize(Some(Message::KeepAlive)), vec![0, 0, 0, 0]);
-        assert_eq!(round_trip(Message::KeepAlive), None);
+        assert_eq!(round_trip(Message::KeepAlive), Ok(Message::KeepAlive));
     }
 
     #[test]
@@ -711,20 +754,20 @@ mod tests {
         let mut expected = vec![0x00, 0x00, 0x00, 0x0f, 20, 0];
         expected.extend_from_slice(b"d1:md1:ai1eee");
         assert_eq!(serialize(Some(handshake.clone())), expected);
-        assert_eq!(round_trip(handshake.clone()), Some(handshake));
+        assert_eq!(round_trip(handshake.clone()), Ok(handshake));
 
         let data = format_extended(3, vec![0xaa, 0xbb]);
         assert_eq!(
             serialize(Some(data.clone())),
             vec![0x00, 0x00, 0x00, 0x04, 20, 3, 0xaa, 0xbb]
         );
-        assert_eq!(round_trip(data.clone()), Some(data));
+        assert_eq!(round_trip(data.clone()), Ok(data));
         assert!(format_extended(1, vec![]).is_extended());
     }
 
     #[test]
     fn read_keep_alive_length_zero() {
-        assert_eq!(read(&[0, 0, 0, 0], &[]), None);
+        assert_eq!(read(&[0, 0, 0, 0], &[]), Ok(Message::KeepAlive));
     }
 
     #[test]
@@ -754,27 +797,47 @@ mod tests {
         ];
 
         for (length_buf, message_buf) in cases {
-            assert_eq!(read(length_buf, message_buf), None);
+            assert_eq!(read(length_buf, message_buf), Err(DecodeError::Truncated));
         }
     }
 
     #[test]
     fn read_unknown_id() {
-        let cases: &[(&[u8], &[u8])] = &[
-            (&[0, 0, 0, 1], &[99]),
-            (&[0, 0, 0, 3], &[9, 0, 1]),
-            (&[0, 0, 0, 1], &[255]),
+        let cases: &[(&[u8], &[u8], u8)] = &[
+            (&[0, 0, 0, 1], &[99], 99),
+            (&[0, 0, 0, 3], &[9, 0, 1], 9),
+            (&[0, 0, 0, 1], &[255], 255),
         ];
 
-        for (length_buf, message_buf) in cases {
-            assert_eq!(read(length_buf, message_buf), None);
+        for (length_buf, message_buf, id) in cases {
+            assert_eq!(
+                read(length_buf, message_buf),
+                Err(DecodeError::UnknownId(*id))
+            );
         }
     }
 
     #[test]
     fn read_empty_buffer() {
-        assert_eq!(read(&[], &[]), None);
-        assert_eq!(read(&[0, 0, 0, 1], &[]), None);
+        assert_eq!(read(&[], &[]), Err(DecodeError::InvalidLengthPrefix));
+        assert_eq!(read(&[0, 0, 0, 1], &[]), Err(DecodeError::Truncated));
+    }
+
+    #[test]
+    fn request_storm_disconnects_after_threshold() {
+        let mut storm = RequestStorm::default();
+        for _ in 0..MAX_CHOKED_REQUESTS {
+            assert_eq!(storm.on_choked_request(), Ok(()));
+        }
+        assert_eq!(storm.on_choked_request(), Err(RequestStormError::Choked));
+        storm.reset_choked();
+        assert_eq!(storm.on_choked_request(), Ok(()));
+
+        let mut storm = RequestStorm::default();
+        for _ in 0..MAX_QUEUE_OVERFLOWS {
+            assert_eq!(storm.on_queue_overflow(), Ok(()));
+        }
+        assert_eq!(storm.on_queue_overflow(), Err(RequestStormError::Queue));
     }
 
     #[test]

--- a/crates/bit_rev/src/peer_connection.rs
+++ b/crates/bit_rev/src/peer_connection.rs
@@ -22,11 +22,11 @@ use crate::{
     extension::{ExtensionRegistry, ExtensionSession},
     message::{
         self, format_reject_request, validate_request, BlockRequest, Message, RequestError,
-        WriterRequest, MAX_UPLOAD_QUEUE,
+        RequestStorm, WriterRequest, MAX_UPLOAD_QUEUE,
     },
     peer::PeerAddr,
     peer_state::PeerStates,
-    protocol::{Protocol, ProtocolError},
+    protocol::{Frame, PeerTimeouts, Protocol, ProtocolError},
     session::{DownloadState, PieceWork},
     storage::Storage,
     torrent::Torrent,
@@ -252,40 +252,60 @@ impl TorrentDownloadedState {
         }
     }
 
-    pub fn set_chuncks(&self, index: u32, start: u32, buf: Vec<u8>) {
-        //let mut chuncks = self.pieces[index as usize].chuncks.lock().unwrap();
-        let mut chuncks = self
-            .pieces
-            .iter()
-            .find(|pw| pw.piece_work.index == index)
-            .unwrap()
-            .chuncks
-            .lock()
-            .unwrap();
+    pub fn set_chuncks(&self, index: u32, start: u32, buf: Vec<u8>, peer: PeerAddr) -> bool {
+        let Some(pw) = self.pieces.iter().find(|pw| pw.piece_work.index == index) else {
+            return false;
+        };
+        let mut chuncks = pw.chuncks.lock().unwrap();
+        if chuncks.iter().any(|c| c.start == start) {
+            return false;
+        }
         chuncks.push(Chunk {
             index,
             start,
             length: buf.len() as u32,
             buf,
+            peer,
         });
+        true
+    }
+
+    pub fn piece_contributors(&self, index: u32) -> Vec<PeerAddr> {
+        let Some(pw) = self.pieces.get(index as usize) else {
+            return Vec::new();
+        };
+        let mut peers = Vec::new();
+        for chunk in pw.chuncks.lock().unwrap().iter() {
+            if !peers.contains(&chunk.peer) {
+                peers.push(chunk.peer);
+            }
+        }
+        peers
     }
 
     pub fn set_downloaded_if_all_chunks(&self, index: u32) -> Option<&PieceWorkState> {
-        // check if all chuncks are downloaded
-        if self.pieces[index as usize]
+        let pw = self.pieces.get(index as usize)?;
+        if pw.downloaded.load(std::sync::atomic::Ordering::Relaxed) {
+            return None;
+        }
+        let complete = pw
             .chuncks
             .lock()
             .unwrap()
             .iter()
             .fold(0, |acc, c| acc + c.length as usize)
-            == self.pieces[index as usize].piece_work.length as usize
-        {
-            self.pieces[index as usize]
-                .downloaded
-                .store(true, std::sync::atomic::Ordering::Relaxed);
-            return Some(&self.pieces[index as usize]);
+            == pw.piece_work.length as usize;
+        if !complete {
+            return None;
         }
-        None
+        let already = pw
+            .downloaded
+            .swap(true, std::sync::atomic::Ordering::Relaxed);
+        if already {
+            None
+        } else {
+            Some(pw)
+        }
     }
 }
 
@@ -314,6 +334,7 @@ pub struct Chunk {
     pub start: u32,
     pub length: u32,
     pub buf: Vec<u8>,
+    pub peer: PeerAddr,
 }
 
 pub struct FullPiece {
@@ -369,6 +390,7 @@ pub struct PeerHandler {
     our_allowed_fast: Mutex<HashSet<u32>>,
     suggested_pieces: Mutex<Vec<u32>>,
     outstanding_requests: Mutex<HashSet<BlockRequest>>,
+    request_storm: Mutex<RequestStorm>,
     extension_protocol: AtomicBool,
     extensions: Mutex<ExtensionSession>,
     listen_port: u16,
@@ -399,6 +421,7 @@ impl PeerHandler {
             our_allowed_fast: Mutex::new(HashSet::new()),
             suggested_pieces: Mutex::new(Vec::new()),
             outstanding_requests: Mutex::new(HashSet::new()),
+            request_storm: Mutex::new(RequestStorm::default()),
             extension_protocol: AtomicBool::new(false),
             extensions: Mutex::new(config.extensions.bind()),
             listen_port: config.listen_port,
@@ -572,13 +595,25 @@ impl PeerHandler {
         {
             debug!("ignoring request while choking {:?}", req);
             self.send_reject(req);
+            self.request_storm
+                .lock()
+                .unwrap()
+                .on_choked_request()
+                .map_err(|_| anyhow::anyhow!("request storm while choked"))?;
             return Ok(());
         }
+        self.request_storm.lock().unwrap().reset_choked();
 
         let mut queue = self.upload_queue.lock().unwrap();
         if queue.len() >= MAX_UPLOAD_QUEUE {
             debug!("upload queue full, dropping request {:?}", req);
             self.send_reject(req);
+            drop(queue);
+            self.request_storm
+                .lock()
+                .unwrap()
+                .on_queue_overflow()
+                .map_err(|_| anyhow::anyhow!("upload queue exceeded repeatedly"))?;
             return Ok(());
         }
         queue.push_back(req);
@@ -957,6 +992,7 @@ impl PeerHandler {
                     piece_chunk.index,
                     piece_chunk.start,
                     piece_chunk.data,
+                    self.peer,
                 );
                 if let Some(full_piece) = self
                     .torrent_downloaded_state
@@ -972,13 +1008,29 @@ impl PeerHandler {
                             buf,
                         };
 
-                        self.piece_tx.send(full_piece).unwrap();
+                        if self.piece_tx.send(full_piece).is_err() {
+                            return Ok(());
+                        }
                     } else {
                         trace!("piece index {} is corrupted", piece_chunk.index);
+                        let contributors = self
+                            .torrent_downloaded_state
+                            .piece_contributors(piece_chunk.index);
+                        let sole = contributors.len() == 1;
+                        let mut banned_self = false;
+                        for peer in contributors {
+                            if self.peers_state.record_hash_failure(peer, sole) && peer == self.peer
+                            {
+                                banned_self = true;
+                            }
+                        }
                         self.torrent_downloaded_state
                             .remove_downloaded(piece_chunk.index);
                         self.torrent_downloaded_state
                             .release_piece(piece_chunk.index);
+                        if banned_self {
+                            return Err(anyhow::anyhow!("banned after hash failure"));
+                        }
                     }
                 }
 
@@ -1062,13 +1114,18 @@ impl PeerConnection {
                 .await
                 .map_err(ProtocolError::Io)
         };
-        let mut stream = match tokio::time::timeout(Duration::from_secs(6), connect).await {
+        let mut stream = match tokio::time::timeout(PeerTimeouts::default().connect, connect).await
+        {
             Ok(Ok(b)) => Ok(b),
             Ok(Err(e)) => Err(e),
             Err(e) => Err(ProtocolError::Timeout(e)),
         }?;
 
-        let protocol = Arc::new(Protocol::connect(self.peer, self.info_hash, self.peer_id).await?);
+        let protocol = Arc::new(
+            Protocol::connect(self.peer, self.info_hash, self.peer_id)
+                .await?
+                .with_piece_count(self.handler.torrent_downloaded_state.piece_count()),
+        );
         let handshake = protocol.complete_handshake(&mut stream).await?;
         self.handler
             .set_fast_extension(handshake.supports_fast_extension());
@@ -1088,7 +1145,11 @@ impl PeerConnection {
         peer_writer_rx: flume::Receiver<WriterRequest>,
         have_broadcast: tokio::sync::broadcast::Receiver<u32>,
     ) -> anyhow::Result<()> {
-        let protocol = Arc::new(Protocol::connect(self.peer, self.info_hash, self.peer_id).await?);
+        let protocol = Arc::new(
+            Protocol::connect(self.peer, self.info_hash, self.peer_id)
+                .await?
+                .with_piece_count(self.handler.torrent_downloaded_state.piece_count()),
+        );
         self.send_extension_handshake(&protocol, &mut stream)
             .await?;
         self.send_initial_bitfield(&protocol, &mut stream).await?;
@@ -1175,6 +1236,7 @@ impl PeerConnection {
         mut have_broadcast: tokio::sync::broadcast::Receiver<u32>,
     ) -> anyhow::Result<()> {
         let (mut read, mut write) = stream.split();
+        let timeouts = protocol.timeouts;
 
         let writer = {
             async move {
@@ -1197,7 +1259,7 @@ impl PeerConnection {
                                 },
                                 _ => continue
                             },
-                            r = timeout(Duration::from_secs(120), peer_writer_rx.recv_async()) => match r {
+                            r = timeout(timeouts.keep_alive, peer_writer_rx.recv_async()) => match r {
                                 Ok(Ok(msg)) =>{
                                     msg
                                 },
@@ -1214,6 +1276,10 @@ impl PeerConnection {
                     };
 
                     let buf = match req {
+                        WriterRequest::Disconnect => {
+                            debug!("writer received disconnect");
+                            break;
+                        }
                         WriterRequest::Message(msg)
                             if msg.is_extended() && !self.handler.extension_protocol() =>
                         {
@@ -1222,7 +1288,7 @@ impl PeerConnection {
                         WriterRequest::Message(msg) => message::serialize(Some(msg)),
                     };
 
-                    match timeout(Duration::from_secs(10), write.write_all(&buf)).await {
+                    match timeout(timeouts.read_step, write.write_all(&buf)).await {
                         Ok(Ok(_)) => {
                             //debug!("sent message");
                         }
@@ -1241,29 +1307,41 @@ impl PeerConnection {
         };
 
         let reader = async move {
+            let handshake_at = tokio::time::Instant::now();
+            let mut last_inbound = handshake_at;
+            let mut seen_first = false;
             loop {
-                let message =
-                    tokio::time::timeout(Duration::from_secs(10), protocol.read(&mut read)).await;
-
-                match message {
-                    Ok(Ok(None)) => {
+                let frame = match protocol
+                    .read_with_idle(&mut read, last_inbound, seen_first, handshake_at)
+                    .await
+                {
+                    Ok(frame) => frame,
+                    Err(e) => {
+                        debug!("reader stop: {:?}", e);
+                        break;
+                    }
+                };
+                match frame {
+                    Frame::Eof => {
                         debug!("peer disconnected");
                         break;
                     }
-                    Ok(Ok(Some(msg))) => match self.handler.on_received_message(msg) {
-                        Ok(_) => {}
-                        Err(e) => {
+                    Frame::KeepAlive => {
+                        last_inbound = tokio::time::Instant::now();
+                        seen_first = true;
+                    }
+                    Frame::Unknown { id } => {
+                        debug!("skipping unknown message id {id}");
+                        last_inbound = tokio::time::Instant::now();
+                        seen_first = true;
+                    }
+                    Frame::Message(msg) => {
+                        last_inbound = tokio::time::Instant::now();
+                        seen_first = true;
+                        if let Err(e) = self.handler.on_received_message(msg) {
                             debug!("error processing message: {:?}", e);
                             break;
                         }
-                    },
-                    Ok(Err(e)) => {
-                        debug!("error reading from peer: {:?}", e);
-                        break;
-                    }
-                    Err(e) => {
-                        debug!("timeout reading from peer: {:?}", e);
-                        break;
                     }
                 }
             }
@@ -1308,6 +1386,21 @@ pub struct SpawnPeerParams {
     pub max_peers_global: usize,
 }
 
+struct PeerSlotGuard {
+    global_peers: Arc<std::sync::atomic::AtomicUsize>,
+    peer_states: Arc<PeerStates>,
+    downloaded_state: Arc<TorrentDownloadedState>,
+    peer: PeerAddr,
+}
+
+impl Drop for PeerSlotGuard {
+    fn drop(&mut self) {
+        self.peer_states.states.remove(&self.peer);
+        self.downloaded_state.remove_reserved(self.peer);
+        self.global_peers.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 pub fn try_spawn_peer(params: SpawnPeerParams) -> bool {
     let global = params.global_peers.load(Ordering::Relaxed);
     if global >= params.max_peers_global {
@@ -1316,6 +1409,10 @@ pub fn try_spawn_peer(params: SpawnPeerParams) -> bool {
     }
     if params.peer_states.len() >= params.max_peers_per_torrent {
         debug!(peer = %params.peer, "per-torrent connection cap reached");
+        return false;
+    }
+    if params.peer_states.is_banned(params.peer) {
+        debug!(peer = %params.peer, "refusing banned peer");
         return false;
     }
 
@@ -1327,8 +1424,15 @@ pub fn try_spawn_peer(params: SpawnPeerParams) -> bool {
         return false;
     }
     params.global_peers.fetch_add(1, Ordering::Relaxed);
+    let slot = PeerSlotGuard {
+        global_peers: params.global_peers.clone(),
+        peer_states: params.peer_states.clone(),
+        downloaded_state: params.torrent_downloaded_state.clone(),
+        peer: params.peer,
+    };
 
     tokio::spawn(async move {
+        let _slot = slot;
         let handler = Arc::new(PeerHandler::from_config(PeerHandlerConfig {
             peer: params.peer,
             piece_tx: params.piece_tx,
@@ -1378,8 +1482,6 @@ pub fn try_spawn_peer(params: SpawnPeerParams) -> bool {
         if let Err(e) = result {
             debug!("error managing peer: {:#}", e);
         }
-        handler.on_peer_died();
-        params.global_peers.fetch_sub(1, Ordering::Relaxed);
     });
     true
 }
@@ -1509,7 +1611,7 @@ mod tests {
         let s = state(1, 16);
         let p1 = peer(6881);
         s.get_and_reserve_piece(p1).await.unwrap();
-        s.set_chuncks(0, 0, vec![1u8; 8]);
+        s.set_chuncks(0, 0, vec![1u8; 8], p1);
 
         s.release_piece(0);
 
@@ -1523,7 +1625,7 @@ mod tests {
         let s = state(1, 16);
         let p1 = peer(6881);
         s.get_and_reserve_piece(p1).await.unwrap();
-        s.set_chuncks(0, 0, vec![1u8; 8]);
+        s.set_chuncks(0, 0, vec![1u8; 8], p1);
 
         s.remove_reserved(p1);
 
@@ -1535,20 +1637,21 @@ mod tests {
     fn set_chuncks_then_downloaded_when_lengths_sum() {
         let s = state(2, 16);
 
-        s.set_chuncks(0, 0, vec![0u8; 8]);
+        s.set_chuncks(0, 0, vec![0u8; 8], peer(1));
         assert!(s.set_downloaded_if_all_chunks(0).is_none());
         assert!(!s.pieces[0].downloaded.load(Ordering::Relaxed));
         assert!(!s.is_complete());
 
-        s.set_chuncks(0, 8, vec![1u8; 8]);
+        s.set_chuncks(0, 8, vec![1u8; 8], peer(1));
         let done = s.set_downloaded_if_all_chunks(0);
         assert!(done.is_some());
         assert_eq!(done.unwrap().piece_work.index, 0);
         assert!(s.pieces[0].downloaded.load(Ordering::Relaxed));
         assert!(!s.is_complete());
 
-        s.set_chuncks(1, 0, vec![2u8; 16]);
+        s.set_chuncks(1, 0, vec![2u8; 16], peer(2));
         assert!(s.set_downloaded_if_all_chunks(1).is_some());
+        assert!(s.set_downloaded_if_all_chunks(1).is_none());
         assert!(s.pieces[1].downloaded.load(Ordering::Relaxed));
         assert!(s.is_complete());
     }
@@ -1572,7 +1675,7 @@ mod tests {
     #[test]
     fn remove_downloaded_clears_chunks_and_flag() {
         let s = state(1, 16);
-        s.set_chuncks(0, 0, vec![7u8; 16]);
+        s.set_chuncks(0, 0, vec![7u8; 16], peer(1));
         assert!(s.set_downloaded_if_all_chunks(0).is_some());
         assert!(s.pieces[0].downloaded.load(Ordering::Relaxed));
         assert_eq!(s.pieces[0].chuncks.lock().unwrap().len(), 1);
@@ -1601,7 +1704,7 @@ mod tests {
                     let reserved_by_me = pw.reserved.lock().unwrap().as_ref() == Some(&peer);
                     if reserved_by_me {
                         let index = pw.piece_work.index;
-                        s.set_chuncks(index, 0, vec![0u8; PIECE_LEN as usize]);
+                        s.set_chuncks(index, 0, vec![0u8; PIECE_LEN as usize], peer);
                         s.set_downloaded_if_all_chunks(index);
                         completed += 1;
                     } else {
@@ -1624,5 +1727,18 @@ mod tests {
             let reserved = pw.reserved.lock().unwrap();
             assert!(reserved.is_some());
         }
+    }
+
+    #[test]
+    fn set_chuncks_first_write_wins_attribution() {
+        let s = state(1, 16);
+        let p1 = peer(6881);
+        let p2 = peer(6882);
+        assert!(s.set_chuncks(0, 0, vec![1u8; 8], p1));
+        assert!(!s.set_chuncks(0, 0, vec![2u8; 8], p2));
+        assert!(s.set_chuncks(0, 8, vec![3u8; 8], p2));
+        let contributors = s.piece_contributors(0);
+        assert_eq!(contributors, vec![p1, p2]);
+        assert_eq!(s.pieces[0].chuncks.lock().unwrap()[0].buf[0], 1);
     }
 }

--- a/crates/bit_rev/src/peer_state.rs
+++ b/crates/bit_rev/src/peer_state.rs
@@ -1,20 +1,28 @@
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use tokio::sync::Notify;
 
 use crate::{bitfield::Bitfield, message::WriterRequest, peer::PeerAddr};
 
+pub const BAN_TTL: Duration = Duration::from_secs(60 * 60);
+pub const HASH_FAILURE_BAN_THRESHOLD: u32 = 3;
+
 #[derive(Debug, Default)]
 pub struct PeerStates {
     pub states: DashMap<PeerAddr, PeerState>,
+    hash_failures: DashMap<PeerAddr, u32>,
+    banned: DashMap<PeerAddr, Instant>,
 }
 
 impl PeerStates {
     pub fn add_if_not_seen(&self, peer: PeerAddr) -> bool {
+        if self.is_banned(peer) {
+            return false;
+        }
         use dashmap::mapref::entry::Entry;
         match self.states.entry(peer) {
             Entry::Occupied(_) => false,
@@ -26,6 +34,9 @@ impl PeerStates {
     }
 
     pub fn insert_live(&self, peer: PeerAddr, writer_tx: flume::Sender<WriterRequest>) -> bool {
+        if self.is_banned(peer) {
+            return false;
+        }
         use dashmap::mapref::entry::Entry;
         match self.states.entry(peer) {
             Entry::Occupied(_) => false,
@@ -42,6 +53,62 @@ impl PeerStates {
 
     pub fn is_empty(&self) -> bool {
         self.states.is_empty()
+    }
+
+    pub fn purge_expired_bans(&self) {
+        let now = Instant::now();
+        self.banned.retain(|_, until| *until > now);
+    }
+
+    pub fn is_banned(&self, peer: PeerAddr) -> bool {
+        self.purge_expired_bans();
+        self.banned.contains_key(&peer)
+    }
+
+    pub fn ban(&self, peer: PeerAddr) {
+        self.banned.insert(peer, Instant::now() + BAN_TTL);
+        if let Some(state) = self.states.get(&peer) {
+            if let Some(tx) = &state.writer_tx {
+                let _ = tx.send(WriterRequest::Disconnect);
+            }
+        }
+    }
+
+    pub fn banned_count(&self) -> usize {
+        self.purge_expired_bans();
+        self.banned.len()
+    }
+
+    pub fn hash_failures(&self, peer: PeerAddr) -> u32 {
+        self.hash_failures.get(&peer).map(|n| *n).unwrap_or(0)
+    }
+
+    pub fn increment_failures(&self, peer: PeerAddr) -> u32 {
+        let count = {
+            let mut entry = self.hash_failures.entry(peer).or_insert(0);
+            *entry = entry.saturating_add(1);
+            *entry
+        };
+        if let Some(mut state) = self.states.get_mut(&peer) {
+            state.hash_failures = count;
+        }
+        count
+    }
+
+    /// Returns true if the peer is now banned.
+    pub fn record_hash_failure(&self, peer: PeerAddr, sole_contributor: bool) -> bool {
+        if sole_contributor {
+            self.increment_failures(peer);
+            self.ban(peer);
+            return true;
+        }
+        let count = self.increment_failures(peer);
+        if count >= HASH_FAILURE_BAN_THRESHOLD {
+            self.ban(peer);
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -60,6 +127,7 @@ pub struct PeerState {
     pub peer_allowed_fast: HashSet<u32>,
     pub our_allowed_fast: HashSet<u32>,
     pub suggested_pieces: Vec<u32>,
+    pub hash_failures: u32,
     pub stats: Arc<PeerLiveStats>,
     pub writer_tx: Option<flume::Sender<WriterRequest>>,
 }
@@ -111,6 +179,7 @@ impl PeerState {
             peer_allowed_fast: HashSet::new(),
             our_allowed_fast: HashSet::new(),
             suggested_pieces: Vec::new(),
+            hash_failures: 0,
             stats: Arc::new(PeerLiveStats::default()),
             writer_tx: None,
         }
@@ -158,5 +227,43 @@ mod tests {
         assert!(states.add_if_not_seen(peer));
         assert!(!states.add_if_not_seen(peer));
         assert_eq!(states.states.len(), 1);
+    }
+
+    #[test]
+    fn sole_contributor_is_banned_immediately() {
+        let states = PeerStates::default();
+        let peer = "127.0.0.1:6881".parse().unwrap();
+        assert!(states.record_hash_failure(peer, true));
+        assert!(states.is_banned(peer));
+        assert_eq!(states.banned_count(), 1);
+        assert!(!states.add_if_not_seen(peer));
+        let other_port: PeerAddr = "127.0.0.1:9999".parse().unwrap();
+        assert!(!states.is_banned(other_port));
+        assert!(states.add_if_not_seen(other_port));
+    }
+
+    #[test]
+    fn shared_contributors_banned_after_three_failures() {
+        let states = PeerStates::default();
+        let peer = "10.0.0.2:6881".parse().unwrap();
+        assert!(!states.record_hash_failure(peer, false));
+        assert!(!states.record_hash_failure(peer, false));
+        assert!(!states.is_banned(peer));
+        assert_eq!(states.hash_failures(peer), 2);
+        assert!(states.record_hash_failure(peer, false));
+        assert!(states.is_banned(peer));
+        assert_eq!(states.hash_failures(peer), 3);
+    }
+
+    #[test]
+    fn expired_bans_are_purged() {
+        let states = PeerStates::default();
+        let peer = "192.168.1.8:6881".parse().unwrap();
+        states
+            .banned
+            .insert(peer, Instant::now() - Duration::from_secs(1));
+        assert!(!states.is_banned(peer));
+        assert_eq!(states.banned_count(), 0);
+        assert!(states.add_if_not_seen(peer));
     }
 }

--- a/crates/bit_rev/src/protocol.rs
+++ b/crates/bit_rev/src/protocol.rs
@@ -1,14 +1,48 @@
-use crate::handshake::{Handshake, HandshakeError};
+use crate::handshake::{Handshake, HandshakeError, MAX_PSTR_LEN};
 use crate::message;
-use crate::message::Message;
+use crate::message::{Message, WriterRequest};
 use crate::peer::PeerAddr;
 use byteorder::{BigEndian, ByteOrder};
+use std::io::ErrorKind;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::error::Elapsed;
 
-const HANDSHAKE_TIMEOUT: u64 = 3;
+/// Upper bound on a peer-supplied length prefix. Covers a 16 KiB block and a
+/// bitfield for very large torrents. Never allocate before this check.
+pub const MAX_MESSAGE_LEN: u32 = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerTimeouts {
+    pub connect: Duration,
+    pub handshake: Duration,
+    pub read_step: Duration,
+    pub idle: Duration,
+    pub handshake_to_first: Duration,
+    pub keep_alive: Duration,
+}
+
+impl Default for PeerTimeouts {
+    fn default() -> Self {
+        Self {
+            connect: Duration::from_secs(6),
+            handshake: Duration::from_secs(3),
+            read_step: Duration::from_secs(10),
+            idle: Duration::from_secs(180),
+            handshake_to_first: Duration::from_secs(20),
+            keep_alive: Duration::from_secs(120),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Frame {
+    KeepAlive,
+    Message(Message),
+    Unknown { id: u8 },
+    Eof,
+}
 
 #[derive(Error, Debug)]
 pub enum ProtocolError {
@@ -20,6 +54,14 @@ pub enum ProtocolError {
     Io(std::io::Error),
     #[error("Info hash is not equal")]
     InfoHashIsNotEqual,
+    #[error("message too large: {length} bytes")]
+    MessageTooLarge { length: u32 },
+    #[error("truncated message")]
+    Truncated,
+    #[error("peer idle timeout")]
+    Idle,
+    #[error("no message after handshake")]
+    HandshakeIdle,
 }
 
 #[derive(Debug, Clone)]
@@ -27,6 +69,8 @@ pub struct Protocol {
     pub peer: PeerAddr,
     pub info_hash: [u8; 20],
     pub peer_id: [u8; 20],
+    pub piece_count: Option<usize>,
+    pub timeouts: PeerTimeouts,
 }
 
 impl Protocol {
@@ -39,38 +83,135 @@ impl Protocol {
             peer,
             info_hash,
             peer_id,
+            piece_count: None,
+            timeouts: PeerTimeouts::default(),
         })
+    }
+
+    pub fn with_piece_count(mut self, count: usize) -> Self {
+        self.piece_count = Some(count);
+        self
+    }
+
+    pub fn with_timeouts(mut self, timeouts: PeerTimeouts) -> Self {
+        self.timeouts = timeouts;
+        self
     }
 
     pub async fn read(
         &self,
         mut stream: impl AsyncReadExt + Unpin,
-    ) -> Result<Option<Message>, ProtocolError> {
-        // Read exactly 4 bytes for the length
+    ) -> Result<Frame, ProtocolError> {
         let mut length_buf = [0u8; 4];
-        stream
-            .read_exact(&mut length_buf)
-            .await
-            .map_err(ProtocolError::Io)?;
-
-        let length = BigEndian::read_u32(&length_buf) as usize;
-
-        // Check if length is zero (keep-alive in BT),
-        // or is otherwise "invalid" (too large, etc.)
-        if length == 0 {
-            // Possibly treat as keep-alive or return Ok(None):
-            return Ok(None);
+        match stream.read_exact(&mut length_buf).await {
+            Ok(_) => {}
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(Frame::Eof),
+            Err(e) => return Err(ProtocolError::Io(e)),
         }
 
-        // Read exactly `length` bytes for the payload
-        let mut msg_bytes = vec![0u8; length];
-        stream
-            .read_exact(&mut msg_bytes)
-            .await
-            .map_err(ProtocolError::Io)?;
+        let length = BigEndian::read_u32(&length_buf);
+        if length == 0 {
+            return Ok(Frame::KeepAlive);
+        }
+        if length > MAX_MESSAGE_LEN {
+            return Err(ProtocolError::MessageTooLarge { length });
+        }
 
-        // Delegate to your parser
-        Ok(message::read(&length_buf, &msg_bytes))
+        let mut id_buf = [0u8; 1];
+        match tokio::time::timeout(self.timeouts.read_step, stream.read_exact(&mut id_buf)).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) if e.kind() == ErrorKind::UnexpectedEof => {
+                return Err(ProtocolError::Truncated);
+            }
+            Ok(Err(e)) => return Err(ProtocolError::Io(e)),
+            Err(e) => return Err(ProtocolError::Timeout(e)),
+        }
+
+        let remaining = (length as usize) - 1;
+        if id_buf[0] == message::MessageId::MsgBitfield as u8 {
+            if let Some(count) = self.piece_count {
+                if remaining > count.div_ceil(8) {
+                    return Err(ProtocolError::MessageTooLarge { length });
+                }
+            }
+        }
+
+        let mut msg_bytes = vec![0u8; length as usize];
+        msg_bytes[0] = id_buf[0];
+        if remaining > 0 {
+            match tokio::time::timeout(
+                self.timeouts.read_step,
+                stream.read_exact(&mut msg_bytes[1..]),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) if e.kind() == ErrorKind::UnexpectedEof => {
+                    return Err(ProtocolError::Truncated);
+                }
+                Ok(Err(e)) => return Err(ProtocolError::Io(e)),
+                Err(e) => return Err(ProtocolError::Timeout(e)),
+            }
+        }
+
+        match message::read(&length_buf, &msg_bytes) {
+            Ok(Message::KeepAlive) => Ok(Frame::KeepAlive),
+            Ok(msg) => Ok(Frame::Message(msg)),
+            Err(message::DecodeError::UnknownId(id)) => Ok(Frame::Unknown { id }),
+            Err(message::DecodeError::Truncated | message::DecodeError::InvalidLengthPrefix) => {
+                Err(ProtocolError::Truncated)
+            }
+        }
+    }
+
+    pub async fn read_with_idle(
+        &self,
+        stream: &mut (impl AsyncReadExt + Unpin),
+        last_inbound: tokio::time::Instant,
+        seen_first: bool,
+        handshake_at: tokio::time::Instant,
+    ) -> Result<Frame, ProtocolError> {
+        let idle_at = last_inbound + self.timeouts.idle;
+        let first_at = handshake_at + self.timeouts.handshake_to_first;
+        let deadline = if seen_first {
+            idle_at
+        } else {
+            first_at.min(idle_at)
+        };
+        tokio::select! {
+            _ = tokio::time::sleep_until(deadline) => {
+                if !seen_first && tokio::time::Instant::now() >= first_at {
+                    Err(ProtocolError::HandshakeIdle)
+                } else {
+                    Err(ProtocolError::Idle)
+                }
+            }
+            result = self.read(stream) => result,
+        }
+    }
+
+    pub async fn write_with_keepalives(
+        write: &mut (impl AsyncWriteExt + Unpin),
+        rx: flume::Receiver<WriterRequest>,
+        timeouts: &PeerTimeouts,
+    ) -> Result<(), ProtocolError> {
+        loop {
+            let req = match tokio::time::timeout(timeouts.keep_alive, rx.recv_async()).await {
+                Ok(Ok(req)) => req,
+                Ok(Err(_)) => break,
+                Err(_) => WriterRequest::Message(Message::KeepAlive),
+            };
+            let buf = match req {
+                WriterRequest::Disconnect => break,
+                WriterRequest::Message(msg) => message::serialize(Some(msg)),
+            };
+            match tokio::time::timeout(timeouts.read_step, write.write_all(&buf)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(ProtocolError::Io(e)),
+                Err(e) => return Err(ProtocolError::Timeout(e)),
+            }
+        }
+        Ok(())
     }
 
     pub async fn send_request(
@@ -149,24 +290,40 @@ impl Protocol {
             .map_err(ProtocolError::Io)
     }
 
+    async fn read_handshake_body(
+        stream: &mut (impl AsyncReadExt + Unpin),
+    ) -> Result<Handshake, ProtocolError> {
+        let protocol_str_len_buf = &mut [0u8; 1];
+        stream
+            .read_exact(protocol_str_len_buf)
+            .await
+            .map_err(ProtocolError::Io)?;
+        let protocol_str_len = protocol_str_len_buf[0] as usize;
+        if protocol_str_len == 0 {
+            return Err(ProtocolError::Handshake(
+                HandshakeError::ProtocolLengthCantBeZero,
+            ));
+        }
+        if protocol_str_len > MAX_PSTR_LEN {
+            return Err(ProtocolError::Handshake(
+                HandshakeError::InvalidProtocolLength,
+            ));
+        }
+        let mut handshake_bytes = vec![0u8; protocol_str_len + 48];
+        stream
+            .read_exact(&mut handshake_bytes)
+            .await
+            .map_err(ProtocolError::Io)?;
+        Handshake::read(protocol_str_len, handshake_bytes).map_err(ProtocolError::Handshake)
+    }
+
     pub async fn read_handshake(
         stream: &mut (impl AsyncReadExt + Unpin),
     ) -> Result<Handshake, ProtocolError> {
-        let timeout = tokio::time::timeout(Duration::from_secs(HANDSHAKE_TIMEOUT), async {
-            let protocol_str_len_buf = &mut [0u8; 1];
-            stream
-                .read_exact(protocol_str_len_buf)
-                .await
-                .map_err(ProtocolError::Io)?;
-            let protocol_str_len = protocol_str_len_buf[0] as usize;
-            let handshake_bytes = &mut vec![0u8; protocol_str_len + 48];
-            stream
-                .read_exact(handshake_bytes)
-                .await
-                .map_err(ProtocolError::Io)?;
-            Handshake::read(protocol_str_len, handshake_bytes.to_vec())
-                .map_err(ProtocolError::Handshake)
-        })
+        let timeout = tokio::time::timeout(
+            PeerTimeouts::default().handshake,
+            Self::read_handshake_body(stream),
+        )
         .await;
 
         match timeout {
@@ -203,28 +360,14 @@ impl Protocol {
         &self,
         stream: &mut (impl AsyncReadExt + AsyncWriteExt + Unpin),
     ) -> Result<Handshake, ProtocolError> {
-        let timeout = tokio::time::timeout(Duration::from_secs(HANDSHAKE_TIMEOUT), async {
+        let timeout = tokio::time::timeout(self.timeouts.handshake, async {
             let handshake = Handshake::outgoing(self.info_hash, self.peer_id);
             let handshake_bytes = handshake.serialize();
             stream
                 .write_all(&handshake_bytes)
                 .await
                 .map_err(ProtocolError::Io)?;
-
-            let protocol_str_len_buf = &mut [0u8; 1];
-            stream
-                .read_exact(protocol_str_len_buf)
-                .await
-                .map_err(ProtocolError::Io)?;
-            let protocol_str_len = protocol_str_len_buf[0] as usize;
-            let handshake_bytes = &mut vec![0u8; protocol_str_len + 48];
-            stream
-                .read_exact(handshake_bytes)
-                .await
-                .map_err(ProtocolError::Io)?;
-
-            Handshake::read(protocol_str_len, handshake_bytes.to_vec())
-                .map_err(ProtocolError::Handshake)
+            Self::read_handshake_body(stream).await
         })
         .await;
 
@@ -258,9 +401,9 @@ impl Protocol {
     ) -> Result<Vec<u8>, ProtocolError> {
         let func = async {
             match self.read(stream).await? {
-                Some(Message::Bitfield(b)) => Ok(b),
+                Frame::Message(Message::Bitfield(b)) => Ok(b),
                 // BEP-0003: a peer may omit the bitfield, meaning it has no pieces.
-                Some(_) | None => Ok(Vec::new()),
+                _ => Ok(Vec::new()),
             }
         };
         match tokio::time::timeout(Duration::from_secs(6), func).await {
@@ -429,12 +572,181 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_keep_alive_returns_none() {
+    async fn read_keep_alive_returns_keep_alive() {
         let proto = protocol().await;
         let (mut writer, reader) = tokio::io::duplex(64);
 
         writer.write_all(&[0, 0, 0, 0]).await.unwrap();
         let result = proto.read(reader).await.unwrap();
-        assert_eq!(result, None);
+        assert_eq!(result, Frame::KeepAlive);
+    }
+
+    #[tokio::test]
+    async fn read_rejects_length_bomb_without_allocating() {
+        let proto = protocol().await;
+        let (mut writer, reader) = tokio::io::duplex(16);
+        writer.write_all(&[0xFF, 0xFF, 0xFF, 0xFF]).await.unwrap();
+        let err = proto.read(reader).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::MessageTooLarge { length: u32::MAX }
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_truncated_payload_is_error() {
+        let proto = protocol().await;
+        let (mut writer, reader) = tokio::io::duplex(16);
+        writer.write_all(&[0, 0, 0, 5, 4]).await.unwrap();
+        drop(writer);
+        let err = proto.read(reader).await.unwrap_err();
+        assert!(matches!(err, ProtocolError::Truncated));
+    }
+
+    #[tokio::test]
+    async fn read_unknown_id_is_skipped_then_message() {
+        let proto = protocol().await;
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        writer.write_all(&[0, 0, 0, 1, 99]).await.unwrap();
+        writer
+            .write_all(&message::serialize(Some(Message::Have(4))))
+            .await
+            .unwrap();
+        assert_eq!(
+            proto.read(&mut reader).await.unwrap(),
+            Frame::Unknown { id: 99 }
+        );
+        assert_eq!(
+            proto.read(&mut reader).await.unwrap(),
+            Frame::Message(Message::Have(4))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_eof_on_closed_stream() {
+        let proto = protocol().await;
+        let (writer, reader) = tokio::io::duplex(16);
+        drop(writer);
+        assert_eq!(proto.read(reader).await.unwrap(), Frame::Eof);
+    }
+
+    #[tokio::test]
+    async fn bitfield_length_is_tightened_when_piece_count_known() {
+        let proto = protocol().await.with_piece_count(8);
+        let (mut writer, reader) = tokio::io::duplex(32);
+        // id=5 bitfield, claims 4 payload bytes; 8 pieces need only 1.
+        writer
+            .write_all(&[0, 0, 0, 5, 5, 0xFF, 0xFF, 0xFF, 0xFF])
+            .await
+            .unwrap();
+        let err = proto.read(reader).await.unwrap_err();
+        assert!(matches!(err, ProtocolError::MessageTooLarge { length: 5 }));
+    }
+
+    #[tokio::test]
+    async fn idle_peer_dropped_at_three_minutes() {
+        tokio::time::pause();
+        tokio::spawn(std::future::pending::<()>());
+        let proto = protocol().await;
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        writer.write_all(&[0, 0, 0, 0]).await.unwrap();
+        let handshake_at = tokio::time::Instant::now();
+        let frame = proto
+            .read_with_idle(&mut reader, handshake_at, false, handshake_at)
+            .await
+            .unwrap();
+        assert_eq!(frame, Frame::KeepAlive);
+        let last = tokio::time::Instant::now();
+
+        let proto_idle = proto.clone();
+        let handle = tokio::spawn(async move {
+            proto_idle
+                .read_with_idle(&mut reader, last, true, handshake_at)
+                .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(180)).await;
+        let result = handle.await.unwrap();
+        assert!(matches!(result, Err(ProtocolError::Idle)));
+    }
+
+    #[tokio::test]
+    async fn keep_alive_sending_peer_is_kept() {
+        tokio::time::pause();
+        tokio::spawn(std::future::pending::<()>());
+        let proto = protocol().await;
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        let handshake_at = tokio::time::Instant::now();
+        writer.write_all(&[0, 0, 0, 0]).await.unwrap();
+        assert_eq!(
+            proto
+                .read_with_idle(&mut reader, handshake_at, false, handshake_at)
+                .await
+                .unwrap(),
+            Frame::KeepAlive
+        );
+
+        let mut last = tokio::time::Instant::now();
+        for _ in 0..3 {
+            tokio::time::advance(Duration::from_secs(120)).await;
+            writer.write_all(&[0, 0, 0, 0]).await.unwrap();
+            let frame = proto
+                .read_with_idle(&mut reader, last, true, handshake_at)
+                .await
+                .expect("keep-alive should keep the connection");
+            assert_eq!(frame, Frame::KeepAlive);
+            last = tokio::time::Instant::now();
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_sends_keep_alive_at_two_minutes() {
+        tokio::time::pause();
+        tokio::spawn(std::future::pending::<()>());
+        let (mut client, mut server) = tokio::io::duplex(64);
+        let (_tx, rx) = flume::unbounded::<WriterRequest>();
+        let timeouts = PeerTimeouts::default();
+        let writer = tokio::spawn(async move {
+            Protocol::write_with_keepalives(&mut client, rx, &timeouts).await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(120)).await;
+
+        let mut buf = [0u8; 4];
+        tokio::time::timeout(Duration::from_secs(1), server.read_exact(&mut buf))
+            .await
+            .expect("keep-alive should arrive")
+            .unwrap();
+        assert_eq!(buf, [0, 0, 0, 0]);
+        writer.abort();
+    }
+
+    #[tokio::test]
+    async fn no_first_message_dropped_at_twenty_seconds() {
+        tokio::time::pause();
+        tokio::spawn(std::future::pending::<()>());
+        let proto = protocol().await;
+        let (_writer, mut reader) = tokio::io::duplex(16);
+        let handshake_at = tokio::time::Instant::now();
+        let handle = tokio::spawn(async move {
+            proto
+                .read_with_idle(&mut reader, handshake_at, false, handshake_at)
+                .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(20)).await;
+        let result = handle.await.unwrap();
+        assert!(matches!(result, Err(ProtocolError::HandshakeIdle)));
+    }
+
+    #[tokio::test]
+    async fn read_handshake_rejects_oversized_pstrlen() {
+        let (mut writer, mut reader) = tokio::io::duplex(32);
+        writer.write_all(&[255]).await.unwrap();
+        let err = Protocol::read_handshake(&mut reader).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::Handshake(HandshakeError::InvalidProtocolLength)
+        ));
     }
 }

--- a/crates/bit_rev/src/protocol_udp.rs
+++ b/crates/bit_rev/src/protocol_udp.rs
@@ -721,6 +721,26 @@ mod tests {
         (buf[..len].to_vec(), from)
     }
 
+    async fn recv_announce(
+        socket: &UdpSocket,
+        connection_id: u64,
+        params: &AnnounceParams,
+    ) -> (u32, SocketAddr) {
+        loop {
+            let (data, from) = recv_from_mock(socket).await;
+            if data.len() == CONNECT_REQUEST_LEN {
+                let tid = assert_connect_request(&data);
+                socket
+                    .send_to(&connect_response_bytes(tid, connection_id), from)
+                    .await
+                    .unwrap();
+                continue;
+            }
+            let tid = assert_announce_request(&data, connection_id, params);
+            return (tid, from);
+        }
+    }
+
     #[test]
     fn test_build_connect_request() {
         let request = build_connect_request(0x0102_0304);
@@ -927,12 +947,12 @@ mod tests {
         .await
         .unwrap();
 
-        let (announce, from) = recv_from_mock(&mock).await;
-        let announce_tid = assert_announce_request(
-            &announce,
+        let (announce_tid, from) = recv_announce(
+            &mock,
             FIXED_CONNECTION_ID,
             &sample_params(Some(AnnounceEvent::Started)),
-        );
+        )
+        .await;
         let response = announce_response_v4(
             announce_tid,
             1800,
@@ -980,8 +1000,7 @@ mod tests {
         .await
         .unwrap();
 
-        let (announce, from) = recv_from_mock(&mock).await;
-        let announce_tid = assert_announce_request(&announce, FIXED_CONNECTION_ID, &params);
+        let (announce_tid, from) = recv_announce(&mock, FIXED_CONNECTION_ID, &params).await;
         mock.send_to(
             &announce_response_v4(announce_tid.wrapping_add(1), 60, 0, 0, &[]),
             from,
@@ -1032,8 +1051,7 @@ mod tests {
         .await
         .unwrap();
 
-        let (announce, from) = recv_from_mock(&mock).await;
-        let announce_tid = assert_announce_request(&announce, FIXED_CONNECTION_ID, &params);
+        let (announce_tid, from) = recv_announce(&mock, FIXED_CONNECTION_ID, &params).await;
         mock.send_to(
             &error_response_bytes(announce_tid, "banned by tracker"),
             from,
@@ -1076,8 +1094,7 @@ mod tests {
         mock.send_to(&connect_response_bytes(connect_tid, 1), from)
             .await
             .unwrap();
-        let (announce, from) = recv_from_mock(&mock).await;
-        let announce_tid = assert_announce_request(&announce, 1, &params);
+        let (announce_tid, from) = recv_announce(&mock, 1, &params).await;
         mock.send_to(&announce_response_v4(announce_tid, 1800, 0, 0, &[]), from)
             .await
             .unwrap();
@@ -1103,13 +1120,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (stale, from) = recv_from_mock(&mock).await;
-        let stale_cid = read_u64_at(&stale, 0);
-        assert_eq!(
-            stale_cid, 2,
-            "client must announce with the fresh connection id"
-        );
-        let announce_tid = assert_announce_request(&stale, 2, &params);
+        let (announce_tid, from) = recv_announce(&mock, 2, &params).await;
         mock.send_to(&announce_response_v4(announce_tid, 60, 0, 0, &[]), from)
             .await
             .unwrap();
@@ -1143,8 +1154,7 @@ mod tests {
         mock.send_to(&connect_response_bytes(connect_tid, 11), from)
             .await
             .unwrap();
-        let (announce, from) = recv_from_mock(&mock).await;
-        let announce_tid = assert_announce_request(&announce, 11, &params);
+        let (announce_tid, from) = recv_announce(&mock, 11, &params).await;
         mock.send_to(&announce_response_v4(announce_tid, 1800, 0, 0, &[]), from)
             .await
             .unwrap();
@@ -1169,13 +1179,7 @@ mod tests {
         mock.send_to(&connect_response_bytes(connect_tid, 22), from)
             .await
             .unwrap();
-        let (announce, from) = recv_from_mock(&mock).await;
-        assert_ne!(
-            read_u64_at(&announce, 0),
-            11,
-            "server would reject the expired connection id"
-        );
-        let announce_tid = assert_announce_request(&announce, 22, &params);
+        let (announce_tid, from) = recv_announce(&mock, 22, &params).await;
         mock.send_to(&announce_response_v4(announce_tid, 90, 1, 1, &[]), from)
             .await
             .unwrap();
@@ -1215,8 +1219,7 @@ mod tests {
         .await
         .unwrap();
 
-        let (announce, from) = recv_from_mock(&mock).await;
-        let announce_tid = assert_announce_request(&announce, FIXED_CONNECTION_ID, &params);
+        let (announce_tid, from) = recv_announce(&mock, FIXED_CONNECTION_ID, &params).await;
         let peer = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
         mock.send_to(
             &announce_response_v6(announce_tid, 120, 4, 5, &[(peer, 6881)]),
@@ -1258,13 +1261,11 @@ mod tests {
         .await
         .unwrap();
 
-        let (first, _from) = recv_from_mock(&mock).await;
-        let first_tid = assert_announce_request(&first, FIXED_CONNECTION_ID, &params);
+        let (first_tid, _from) = recv_announce(&mock, FIXED_CONNECTION_ID, &params).await;
 
         tokio::time::advance(Duration::from_secs(15)).await;
 
-        let (second, from) = recv_from_mock(&mock).await;
-        let second_tid = assert_announce_request(&second, FIXED_CONNECTION_ID, &params);
+        let (second_tid, from) = recv_announce(&mock, FIXED_CONNECTION_ID, &params).await;
         assert_ne!(
             first_tid, second_tid,
             "each request uses a fresh transaction id"

--- a/crates/bit_rev/src/seeding_tests.rs
+++ b/crates/bit_rev/src/seeding_tests.rs
@@ -7,8 +7,10 @@ use tokio::net::TcpStream;
 
 use crate::file::{Info, TorrentFile, TorrentMeta};
 use crate::handshake::Handshake;
-use crate::message::{self, BlockRequest, Message, MAX_INCOMING_REQUEST_LENGTH};
-use crate::protocol::Protocol;
+use crate::message::{
+    self, BlockRequest, Message, MAX_CHOKED_REQUESTS, MAX_INCOMING_REQUEST_LENGTH,
+};
+use crate::protocol::{Frame, Protocol};
 use crate::session::{AddTorrentOptions, Session, SessionOptions};
 use crate::utils;
 
@@ -122,9 +124,10 @@ async fn drain_until_bitfield(proto: &Protocol, stream: &mut TcpStream) {
             .expect("bitfield timeout")
             .expect("bitfield read");
         match msg {
-            Some(Message::Bitfield(_)) => return,
-            Some(Message::KeepAlive) | None => continue,
-            Some(other) => panic!("expected bitfield first, got {other:?}"),
+            Frame::Message(Message::Bitfield(_)) => return,
+            Frame::KeepAlive | Frame::Unknown { .. } => continue,
+            Frame::Eof => panic!("expected bitfield, got eof"),
+            Frame::Message(other) => panic!("expected bitfield first, got {other:?}"),
         }
     }
 }
@@ -132,8 +135,8 @@ async fn drain_until_bitfield(proto: &Protocol, stream: &mut TcpStream) {
 async fn expect_disconnect(proto: &Protocol, stream: &mut TcpStream) {
     let result = tokio::time::timeout(Duration::from_secs(2), proto.read(&mut *stream)).await;
     match result {
-        Ok(Ok(None)) | Ok(Err(_)) | Err(_) => {}
-        Ok(Ok(Some(msg))) => panic!("expected disconnect, got {msg:?}"),
+        Ok(Ok(Frame::Eof)) | Ok(Err(_)) | Err(_) => {}
+        Ok(Ok(other)) => panic!("expected disconnect, got {other:?}"),
     }
 }
 
@@ -162,7 +165,7 @@ async fn seeder_serves_full_torrent_to_in_process_leecher() {
             .await
             .expect("read timeout")
             .expect("read error");
-        let Some(msg) = msg else {
+        let Frame::Message(msg) = msg else {
             continue;
         };
         match msg {
@@ -306,7 +309,7 @@ async fn seeder_sends_have_all_when_fast_negotiated() {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
     while tokio::time::Instant::now() < deadline {
         let msg = tokio::time::timeout(Duration::from_millis(500), proto.read(&mut stream)).await;
-        let Ok(Ok(Some(msg))) = msg else {
+        let Ok(Ok(Frame::Message(msg))) = msg else {
             if saw_have_all {
                 break;
             }
@@ -343,7 +346,7 @@ async fn seeder_sends_no_extended_without_negotiation() {
     let mut saw_bitfield = false;
     while tokio::time::Instant::now() < deadline {
         let msg = tokio::time::timeout(Duration::from_millis(400), proto.read(&mut stream)).await;
-        let Ok(Ok(Some(msg))) = msg else {
+        let Ok(Ok(Frame::Message(msg))) = msg else {
             if saw_bitfield {
                 break;
             }
@@ -380,7 +383,7 @@ async fn seeder_sends_extension_handshake_immediately_when_negotiated() {
     let mut handshake = None;
     while tokio::time::Instant::now() < deadline {
         let msg = tokio::time::timeout(Duration::from_millis(400), proto.read(&mut stream)).await;
-        let Ok(Ok(Some(msg))) = msg else {
+        let Ok(Ok(Frame::Message(msg))) = msg else {
             continue;
         };
         match msg {
@@ -418,5 +421,54 @@ async fn incoming_unknown_info_hash_is_closed() {
         matches!(result, Ok(Err(_)) | Err(_) | Ok(Ok(0))),
         "unknown hash should close, got {result:?}"
     );
+    drop(session);
+}
+
+#[tokio::test]
+async fn seeder_disconnects_on_choked_request_storm() {
+    let data = generated_payload(16_384);
+    let (session, addr, meta) = start_seeder(&data, 16_384).await;
+    let (mut stream, proto) = handshake_with(addr, meta.info_hash, *b"-LC0001-storm0000001").await;
+    drain_until_bitfield(&proto, &mut stream).await;
+
+    for _ in 0..(MAX_CHOKED_REQUESTS + 1) {
+        write_msg(&mut stream, message::format_request(0, 0, 16_384)).await;
+    }
+
+    expect_disconnect(&proto, &mut stream).await;
+    drop(session);
+}
+
+#[tokio::test]
+async fn incoming_connections_are_accounted() {
+    let data = generated_payload(16_384);
+    let (session, addr, meta) = start_seeder(&data, 16_384).await;
+    assert_eq!(session.global_peer_count(), 0);
+
+    let mut streams = Vec::new();
+    for i in 0u8..50 {
+        let mut peer_id = *b"-LC0001-account00000";
+        peer_id[19] = i;
+        let (stream, proto) = handshake_with(addr, meta.info_hash, peer_id).await;
+        streams.push((stream, proto));
+    }
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while session.global_peer_count() < 50 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("incoming peers should be counted");
+
+    drop(streams);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while session.global_peer_count() != 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("peer counter should return to 0");
     drop(session);
 }

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -192,6 +192,10 @@ impl Session {
         session
     }
 
+    pub fn global_peer_count(&self) -> usize {
+        self.global_peers.load(Ordering::Relaxed)
+    }
+
     pub fn listen_port(&self) -> u16 {
         self.listen_addr
             .lock()
@@ -851,6 +855,10 @@ async fn handle_incoming(
         debug!(%addr, "incoming peer for unknown info hash");
         return;
     };
+    if torrent.peer_states.is_banned(addr) {
+        debug!(%addr, "refusing banned incoming peer");
+        return;
+    }
     let reply = Handshake::outgoing(handshake.info_hash, ctx.peer_id);
     if let Err(e) = Protocol::write_handshake(&mut stream, &reply).await {
         debug!(%addr, error = %e, "failed to write handshake reply");

--- a/crates/bit_rev/tests/common/seeder.rs
+++ b/crates/bit_rev/tests/common/seeder.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use bit_rev::bitfield::Bitfield;
 use bit_rev::handshake::Handshake;
 use bit_rev::message::{self, BlockRequest, Message};
-use bit_rev::protocol::Protocol;
+use bit_rev::protocol::{Frame, Protocol};
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Notify;
@@ -232,9 +232,9 @@ async fn serve_peer(
             msg = proto.read(&mut stream) => msg,
         };
         let msg = match msg {
-            Ok(Some(msg)) => msg,
-            Ok(None) => continue,
-            Err(_) => break,
+            Ok(Frame::Message(msg)) => msg,
+            Ok(Frame::KeepAlive) | Ok(Frame::Unknown { .. }) => continue,
+            Ok(Frame::Eof) | Err(_) => break,
         };
         match msg {
             Message::Interested => {

--- a/crates/bit_rev/tests/e2e.rs
+++ b/crates/bit_rev/tests/e2e.rs
@@ -225,6 +225,74 @@ async fn corrupt_piece_is_refetched() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn corrupt_seeder_is_banned_and_download_completes() {
+    let fixture = Arc::new(TorrentFixture::single(
+        256 * 1024,
+        DEFAULT_PIECE_LENGTH,
+        0xBA11_0001,
+    ));
+    let corrupt = SeederPeer::start(
+        fixture.clone(),
+        SeederConfig::with_pieces([0])
+            .peer_id(unique_peer_id(1))
+            .corrupt(0),
+    )
+    .await;
+    let honest = SeederPeer::start(
+        fixture.clone(),
+        SeederConfig::all_pieces().peer_id(unique_peer_id(2)),
+    )
+    .await;
+
+    let tracker =
+        MockHttpTracker::start(vec![HttpAnnounceBody::peers(1800, vec![corrupt.addr])]).await;
+    let meta = fixture.meta_with_trackers(Some(tracker.url.clone()), None);
+    let download_dir = unique_temp_dir();
+    let session = test_session(None).await;
+    let output = fixture.session_output(download_dir.path());
+    let added = add_download(&session, meta, output.clone()).await;
+
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            if let Some(torrent) = session.torrent_session(&fixture.torrent_meta.info_hash) {
+                if torrent.peer_states.is_banned(corrupt.addr) {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("corrupt seeder should be banned after hash failure");
+
+    assert!(
+        session.connect_peer(&fixture.torrent_meta.info_hash, honest.addr),
+        "failed to connect honest seeder"
+    );
+    wait_for_completion(
+        &added.pr_rx,
+        &added.torrent,
+        added.already_have.len(),
+        DOWNLOAD_TIMEOUT,
+    )
+    .await;
+
+    let torrent = session
+        .torrent_session(&fixture.torrent_meta.info_hash)
+        .expect("torrent session");
+    assert!(
+        torrent.peer_states.is_banned(corrupt.addr),
+        "corrupt seeder should stay banned"
+    );
+    assert!(torrent.peer_states.banned_count() >= 1);
+    assert!(!torrent.peer_states.is_banned(honest.addr));
+
+    session.shutdown();
+    fixture.assert_output_matches(&output);
+    assert!(honest.blocks_sent() > 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn disconnect_mid_piece_is_retried() {
     let fixture = Arc::new(TorrentFixture::single(
         512 * 1024,

--- a/crates/bit_rev/tests/resume.rs
+++ b/crates/bit_rev/tests/resume.rs
@@ -13,7 +13,7 @@ use bit_rev::bitfield::Bitfield;
 use bit_rev::file::{Info, TorrentFile, TorrentMeta};
 use bit_rev::handshake::Handshake;
 use bit_rev::message::{self, BlockRequest, Message};
-use bit_rev::protocol::Protocol;
+use bit_rev::protocol::{Frame, Protocol};
 use bit_rev::resume::{self, ResumeData, ResumeStatus};
 use bit_rev::session::{AddTorrentOptions, Session, SessionOptions};
 use bit_rev::torrent::Torrent;
@@ -184,9 +184,9 @@ async fn serve_recording_peer(
             _ = cancel.cancelled() => break,
             msg = proto.read(&mut stream) => {
                 let msg = match msg {
-                    Ok(Some(msg)) => msg,
-                    Ok(None) => continue,
-                    Err(_) => break,
+                    Ok(Frame::Message(msg)) => msg,
+                    Ok(Frame::KeepAlive) | Ok(Frame::Unknown { .. }) => continue,
+                    Ok(Frame::Eof) | Err(_) => break,
                 };
                 match msg {
                     Message::Interested => {

--- a/crates/bit_rev/tests/tracker_udp.rs
+++ b/crates/bit_rev/tests/tracker_udp.rs
@@ -288,6 +288,7 @@ async fn announce_loop_round_trips_started_and_interval() {
 async fn announce_loop_respects_interval_and_sends_stopped() {
     let _lock = lock_tests();
     tokio::time::pause();
+    tokio::spawn(std::future::pending::<()>());
     let (url, mut rx, handle) = spawn_udp_mock(vec![AnnounceReply::Peers { interval: 1800 }]).await;
     let shutdown = CancellationToken::new();
     let loop_shutdown = shutdown.clone();
@@ -300,24 +301,37 @@ async fn announce_loop_respects_interval_and_sends_stopped() {
     let first = rx.recv().await.expect("started announce");
     assert_eq!(first.event, 2);
     settle().await;
+    while rx.try_recv().is_ok() {}
 
     tokio::time::advance(Duration::from_secs(1799)).await;
     settle().await;
     assert!(rx.try_recv().is_err(), "re-announce sent before interval");
 
     tokio::time::advance(Duration::from_secs(2)).await;
-    let second = rx.recv().await.expect("interval re-announce");
-    assert_eq!(second.event, 0);
+    let second = loop {
+        let msg = rx.recv().await.expect("interval re-announce");
+        if msg.event == 0 {
+            break msg;
+        }
+        assert_eq!(
+            msg.event, 2,
+            "only started retranmits are expected before a none event"
+        );
+    };
     assert_eq!(second.key, ANNOUNCE_KEY);
 
     shutdown.cancel();
     settle().await;
-    let stopped = rx.recv().await.expect("stopped announce");
-    assert_eq!(stopped.event, 3);
+    let stopped = loop {
+        let msg = rx.recv().await.expect("stopped announce");
+        if msg.event == 3 {
+            break msg;
+        }
+    };
     assert_eq!(stopped.num_want, 0);
     assert_eq!(stopped.key, ANNOUNCE_KEY);
 
-    let _ = tokio::time::timeout(Duration::from_secs(2), loop_task).await;
+    loop_task.abort();
     handle.abort();
 }
 
@@ -326,6 +340,7 @@ async fn announce_loop_respects_interval_and_sends_stopped() {
 async fn announce_loop_retries_error_packet_with_backoff() {
     let _lock = lock_tests();
     tokio::time::pause();
+    tokio::spawn(std::future::pending::<()>());
     let (url, mut rx, handle) = spawn_udp_mock(vec![
         AnnounceReply::Error,
         AnnounceReply::Peers { interval: 1800 },
@@ -342,18 +357,25 @@ async fn announce_loop_retries_error_packet_with_backoff() {
     let first = rx.recv().await.expect("failed started announce");
     assert_eq!(first.event, 2);
     settle().await;
+    while rx.try_recv().is_ok() {}
 
     tokio::time::advance(Duration::from_secs(14)).await;
     settle().await;
     assert!(rx.try_recv().is_err(), "retried before backoff elapsed");
 
     tokio::time::advance(Duration::from_secs(2)).await;
-    let retry = rx.recv().await.expect("backoff retry");
+    let mut retry = rx.recv().await.expect("backoff retry");
+    for _ in 0..4 {
+        if retry.event == 2 {
+            break;
+        }
+        retry = rx.recv().await.expect("backoff retry");
+    }
     assert_eq!(retry.event, 2);
     assert_eq!(retry.key, ANNOUNCE_KEY);
 
     shutdown.cancel();
-    let _ = tokio::time::timeout(Duration::from_secs(2), loop_task).await;
+    loop_task.abort();
     handle.abort();
 }
 


### PR DESCRIPTION
Harden the peer wire layer for a public swarm (spec 03 robustness and spec 11 request validation).

- Cap peer-controlled length prefixes at 2 MiB before allocation, tighten bitfields when the piece count is known, and apply the same bound to extension handshake / `ut_metadata` payloads.
- `Protocol::read` returns `Frame::{KeepAlive, Message, Unknown, Eof}`. Keep-alives stay connected, unknown ids are skipped, truncated payloads disconnect.
- One `PeerTimeouts` policy: connect 6s, handshake 3s, read step 10s, idle 3 min, handshake-to-first 20s. Writer keep-alives every 2 min of send inactivity.
- Record per-piece contributors. Sole hash-failure contributor is banned immediately, others after 3 failures. Bans expire after 1h and are refused by `add_if_not_seen`, `insert_live`, and the listener.
- Disconnect request storms (choked or repeated queue overflow).
- `PeerSlotGuard` decrements `global_peers` on every exit path, including panic.

Fixes #59