### PR TITLE
feat: implement BEP-0005 Mainline DHT

### DIFF
--- a/crates/bit_rev/src/config.rs
+++ b/crates/bit_rev/src/config.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::dht::DhtOptions;
 use crate::file::AnnounceParams;
 use crate::session::{
     SessionOptions, DEFAULT_LISTEN_PORT, DEFAULT_MAX_PEERS_GLOBAL, DEFAULT_MAX_PEERS_PER_TORRENT,
@@ -201,6 +202,15 @@ impl Config {
             } else {
                 Some(state_dir)
             },
+            dht: DhtOptions {
+                enabled: self.dht.enabled,
+                port: self.dht.port,
+                bootstrap_nodes: if self.dht.enabled {
+                    DhtOptions::default_bootstrap()
+                } else {
+                    Vec::new()
+                },
+            },
         }
     }
 }
@@ -266,6 +276,26 @@ mod tests {
         );
         assert_eq!(options.max_peers_global, expected.max_peers_global);
         assert_eq!(options.state_dir, expected.state_dir);
+    }
+
+    #[test]
+    fn session_options_maps_dht() {
+        let options = Config::default().session_options();
+        assert!(options.dht.enabled);
+        assert_eq!(options.dht.port, DEFAULT_LISTEN_PORT);
+        assert_eq!(options.dht.bootstrap_nodes, DhtOptions::default_bootstrap());
+
+        let disabled = Config {
+            dht: DhtConfig {
+                enabled: false,
+                port: 6999,
+            },
+            ..Config::default()
+        }
+        .session_options();
+        assert!(!disabled.dht.enabled);
+        assert_eq!(disabled.dht.port, 6999);
+        assert!(disabled.dht.bootstrap_nodes.is_empty());
     }
 
     #[test]

--- a/crates/bit_rev/src/dht/announce.rs
+++ b/crates/bit_rev/src/dht/announce.rs
@@ -1,0 +1,106 @@
+//! Bounded per-info-hash announce store.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use super::krpc::NodeId;
+
+pub const ANNOUNCE_TTL: Duration = Duration::from_secs(30 * 60);
+pub const MAX_PEERS_PER_HASH: usize = 50;
+pub const MAX_ANNOUNCE_HASHES: usize = 1024;
+
+#[derive(Debug, Clone)]
+struct PeerEntry {
+    addr: SocketAddr,
+    seen: Instant,
+}
+
+#[derive(Debug, Default)]
+pub struct AnnounceStore {
+    peers: HashMap<NodeId, Vec<PeerEntry>>,
+}
+
+impl AnnounceStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn announce(&mut self, info_hash: NodeId, addr: SocketAddr, now: Instant) {
+        if addr.port() == 0 {
+            return;
+        }
+        self.expire(now);
+        if !self.peers.contains_key(&info_hash) && self.peers.len() >= MAX_ANNOUNCE_HASHES {
+            if let Some(oldest) = self
+                .peers
+                .iter()
+                .min_by_key(|(_, v)| v.first().map(|p| p.seen).unwrap_or(now))
+                .map(|(k, _)| *k)
+            {
+                self.peers.remove(&oldest);
+            }
+        }
+        let list = self.peers.entry(info_hash).or_default();
+        if let Some(existing) = list.iter_mut().find(|p| p.addr == addr) {
+            existing.seen = now;
+            return;
+        }
+        if list.len() >= MAX_PEERS_PER_HASH {
+            list.sort_by_key(|p| p.seen);
+            list.remove(0);
+        }
+        list.push(PeerEntry { addr, seen: now });
+    }
+
+    pub fn get(&mut self, info_hash: &NodeId, now: Instant) -> Vec<SocketAddr> {
+        self.expire(now);
+        self.peers
+            .get(info_hash)
+            .map(|list| list.iter().map(|p| p.addr).collect())
+            .unwrap_or_default()
+    }
+
+    fn expire(&mut self, now: Instant) {
+        for list in self.peers.values_mut() {
+            list.retain(|p| now.saturating_duration_since(p.seen) < ANNOUNCE_TTL);
+        }
+        self.peers.retain(|_, list| !list.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    fn addr(port: u16) -> SocketAddr {
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+    }
+
+    #[test]
+    fn stores_and_expires() {
+        let mut store = AnnounceStore::new();
+        let hash = [1u8; 20];
+        let t0 = Instant::now();
+        store.announce(hash, addr(1), t0);
+        assert_eq!(store.get(&hash, t0), vec![addr(1)]);
+        assert!(store
+            .get(&hash, t0 + ANNOUNCE_TTL + Duration::from_secs(1))
+            .is_empty());
+    }
+
+    #[test]
+    fn caps_per_hash() {
+        let mut store = AnnounceStore::new();
+        let hash = [2u8; 20];
+        let t0 = Instant::now();
+        for i in 0..(MAX_PEERS_PER_HASH as u16 + 5) {
+            store.announce(hash, addr(1000 + i), t0 + Duration::from_millis(i as u64));
+        }
+        assert_eq!(
+            store.get(&hash, t0 + Duration::from_secs(1)).len(),
+            MAX_PEERS_PER_HASH
+        );
+    }
+}

--- a/crates/bit_rev/src/dht/krpc.rs
+++ b/crates/bit_rev/src/dht/krpc.rs
@@ -1,0 +1,736 @@
+//! KRPC (BEP-0005): bencoded RPC over UDP.
+//!
+//! Encode is hand-rolled so BEP example packets match byte-exactly. Decode
+//! never panics; malformed packets return `Err`.
+
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use serde_bencode::value::Value;
+
+use crate::file::check_bencode_depth;
+use crate::identity::{azureus_version, CLIENT_CODE, CLIENT_VERSION};
+
+pub const COMPACT_PEER_LEN: usize = 6;
+pub const COMPACT_NODE_LEN: usize = 26;
+pub const NODE_ID_LEN: usize = 20;
+pub const TRANSACTION_ID_LEN: usize = 2; // used when minting 2-byte `t` values
+
+#[allow(dead_code)]
+pub const ERR_GENERIC: i64 = 201;
+#[allow(dead_code)]
+pub const ERR_SERVER: i64 = 202;
+pub const ERR_PROTOCOL: i64 = 203;
+pub const ERR_METHOD: i64 = 204;
+
+pub type NodeId = [u8; NODE_ID_LEN];
+
+/// BEP-0020 two-character client id plus two version digits (`BR01`).
+pub fn client_version() -> [u8; 4] {
+    let ver = azureus_version(CLIENT_VERSION);
+    [CLIENT_CODE[0], CLIENT_CODE[1], ver[0], ver[1]]
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactNode {
+    pub id: NodeId,
+    pub addr: SocketAddr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Query {
+    Ping {
+        id: NodeId,
+    },
+    FindNode {
+        id: NodeId,
+        target: NodeId,
+    },
+    GetPeers {
+        id: NodeId,
+        info_hash: NodeId,
+    },
+    AnnouncePeer {
+        id: NodeId,
+        info_hash: NodeId,
+        port: u16,
+        token: Vec<u8>,
+        implied_port: bool,
+    },
+}
+
+impl Query {
+    pub fn id(&self) -> NodeId {
+        match self {
+            Query::Ping { id }
+            | Query::FindNode { id, .. }
+            | Query::GetPeers { id, .. }
+            | Query::AnnouncePeer { id, .. } => *id,
+        }
+    }
+
+    pub fn method(&self) -> &'static str {
+        match self {
+            Query::Ping { .. } => "ping",
+            Query::FindNode { .. } => "find_node",
+            Query::GetPeers { .. } => "get_peers",
+            Query::AnnouncePeer { .. } => "announce_peer",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Response {
+    pub id: NodeId,
+    pub nodes: Vec<CompactNode>,
+    pub values: Vec<SocketAddr>,
+    pub token: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorMsg {
+    pub code: i64,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Payload {
+    Query(Query),
+    Response(Response),
+    Error(ErrorMsg),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KrpcMessage {
+    pub transaction_id: Vec<u8>,
+    pub payload: Payload,
+    pub version: Option<Vec<u8>>,
+}
+
+impl KrpcMessage {
+    pub fn query(t: impl Into<Vec<u8>>, query: Query) -> Self {
+        Self {
+            transaction_id: t.into(),
+            payload: Payload::Query(query),
+            version: Some(client_version().to_vec()),
+        }
+    }
+
+    pub fn query_no_v(t: impl Into<Vec<u8>>, query: Query) -> Self {
+        Self {
+            transaction_id: t.into(),
+            payload: Payload::Query(query),
+            version: None,
+        }
+    }
+
+    pub fn response(t: impl Into<Vec<u8>>, response: Response) -> Self {
+        Self {
+            transaction_id: t.into(),
+            payload: Payload::Response(response),
+            version: Some(client_version().to_vec()),
+        }
+    }
+
+    pub fn response_no_v(t: impl Into<Vec<u8>>, response: Response) -> Self {
+        Self {
+            transaction_id: t.into(),
+            payload: Payload::Response(response),
+            version: None,
+        }
+    }
+
+    pub fn error(t: impl Into<Vec<u8>>, code: i64, message: impl Into<String>) -> Self {
+        Self {
+            transaction_id: t.into(),
+            payload: Payload::Error(ErrorMsg {
+                code,
+                message: message.into(),
+            }),
+            version: Some(client_version().to_vec()),
+        }
+    }
+
+    pub fn error_no_v(t: impl Into<Vec<u8>>, code: i64, message: impl Into<String>) -> Self {
+        Self {
+            transaction_id: t.into(),
+            payload: Payload::Error(ErrorMsg {
+                code,
+                message: message.into(),
+            }),
+            version: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    NotBencode,
+    NotADict,
+    MissingTransaction,
+    MissingType,
+    UnknownType,
+    MalformedQuery,
+    UnknownMethod,
+    MalformedResponse,
+    MalformedError,
+}
+
+/// Decode a KRPC packet. Never panics on attacker-controlled input.
+pub fn decode(buf: &[u8]) -> Result<KrpcMessage, DecodeError> {
+    if buf.is_empty() {
+        return Err(DecodeError::NotBencode);
+    }
+    if check_bencode_depth(buf).is_err() {
+        return Err(DecodeError::NotBencode);
+    }
+    let value: Value = serde_bencode::from_bytes(buf).map_err(|_| DecodeError::NotBencode)?;
+    let dict = match value {
+        Value::Dict(d) => d,
+        _ => return Err(DecodeError::NotADict),
+    };
+
+    let transaction_id = dict_bytes(&dict, b"t").ok_or(DecodeError::MissingTransaction)?;
+    if transaction_id.is_empty() {
+        return Err(DecodeError::MissingTransaction);
+    }
+    let y = dict_bytes(&dict, b"y").ok_or(DecodeError::MissingType)?;
+    let version = dict_bytes(&dict, b"v");
+
+    let payload = match y.as_slice() {
+        b"q" => Payload::Query(parse_query(&dict)?),
+        b"r" => Payload::Response(parse_response(&dict)?),
+        b"e" => Payload::Error(parse_error(&dict)?),
+        _ => return Err(DecodeError::UnknownType),
+    };
+
+    Ok(KrpcMessage {
+        transaction_id,
+        payload,
+        version,
+    })
+}
+
+/// Best-effort extract of `t` from a packet that may otherwise be malformed.
+pub fn peek_transaction_id(buf: &[u8]) -> Option<Vec<u8>> {
+    if check_bencode_depth(buf).is_err() {
+        return None;
+    }
+    let Value::Dict(dict) = serde_bencode::from_bytes(buf).ok()? else {
+        return None;
+    };
+    let t = dict_bytes(&dict, b"t")?;
+    if t.is_empty() {
+        None
+    } else {
+        Some(t)
+    }
+}
+
+/// Whether a packet looks like a query (`y=q`) even if args are bad.
+pub fn peek_is_query(buf: &[u8]) -> bool {
+    if check_bencode_depth(buf).is_err() {
+        return false;
+    }
+    let Ok(Value::Dict(dict)) = serde_bencode::from_bytes(buf) else {
+        return false;
+    };
+    dict_bytes(&dict, b"y").as_deref() == Some(&b"q"[..])
+}
+
+fn parse_query(dict: &HashMap<Vec<u8>, Value>) -> Result<Query, DecodeError> {
+    let method = dict_bytes(dict, b"q").ok_or(DecodeError::MalformedQuery)?;
+    let args = dict_dict(dict, b"a").ok_or(DecodeError::MalformedQuery)?;
+    let id = dict_id(&args, b"id").ok_or(DecodeError::MalformedQuery)?;
+    match method.as_slice() {
+        b"ping" => Ok(Query::Ping { id }),
+        b"find_node" => {
+            let target = dict_id(&args, b"target").ok_or(DecodeError::MalformedQuery)?;
+            Ok(Query::FindNode { id, target })
+        }
+        b"get_peers" => {
+            let info_hash = dict_id(&args, b"info_hash").ok_or(DecodeError::MalformedQuery)?;
+            Ok(Query::GetPeers { id, info_hash })
+        }
+        b"announce_peer" => {
+            let info_hash = dict_id(&args, b"info_hash").ok_or(DecodeError::MalformedQuery)?;
+            let token = dict_bytes(&args, b"token").ok_or(DecodeError::MalformedQuery)?;
+            let implied_port = dict_int(&args, b"implied_port").unwrap_or(0) != 0;
+            let port = match dict_int(&args, b"port") {
+                Some(p) if (0..=i64::from(u16::MAX)).contains(&p) => p as u16,
+                _ if implied_port => 0,
+                _ => return Err(DecodeError::MalformedQuery),
+            };
+            Ok(Query::AnnouncePeer {
+                id,
+                info_hash,
+                port,
+                token,
+                implied_port,
+            })
+        }
+        _ => Err(DecodeError::UnknownMethod),
+    }
+}
+
+fn parse_response(dict: &HashMap<Vec<u8>, Value>) -> Result<Response, DecodeError> {
+    let r = dict_dict(dict, b"r").ok_or(DecodeError::MalformedResponse)?;
+    let id = dict_id(&r, b"id").ok_or(DecodeError::MalformedResponse)?;
+    let nodes = dict_bytes(&r, b"nodes")
+        .map(|b| decode_compact_nodes(&b))
+        .unwrap_or_default();
+    let values = match r.get(b"values".as_slice()) {
+        Some(Value::List(list)) => list
+            .iter()
+            .filter_map(|item| match item {
+                Value::Bytes(b) => decode_compact_peer(b),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    };
+    let token = dict_bytes(&r, b"token");
+    Ok(Response {
+        id,
+        nodes,
+        values,
+        token,
+    })
+}
+
+fn parse_error(dict: &HashMap<Vec<u8>, Value>) -> Result<ErrorMsg, DecodeError> {
+    let list = match dict.get(b"e".as_slice()) {
+        Some(Value::List(l)) if l.len() >= 2 => l,
+        _ => return Err(DecodeError::MalformedError),
+    };
+    let code = match list[0] {
+        Value::Int(n) => n,
+        _ => return Err(DecodeError::MalformedError),
+    };
+    let message = match &list[1] {
+        Value::Bytes(b) => String::from_utf8_lossy(b).into_owned(),
+        _ => return Err(DecodeError::MalformedError),
+    };
+    Ok(ErrorMsg { code, message })
+}
+
+fn dict_bytes(dict: &HashMap<Vec<u8>, Value>, key: &[u8]) -> Option<Vec<u8>> {
+    match dict.get(key) {
+        Some(Value::Bytes(b)) => Some(b.clone()),
+        _ => None,
+    }
+}
+
+fn dict_int(dict: &HashMap<Vec<u8>, Value>, key: &[u8]) -> Option<i64> {
+    match dict.get(key) {
+        Some(Value::Int(n)) => Some(*n),
+        _ => None,
+    }
+}
+
+fn dict_dict(dict: &HashMap<Vec<u8>, Value>, key: &[u8]) -> Option<HashMap<Vec<u8>, Value>> {
+    match dict.get(key) {
+        Some(Value::Dict(d)) => Some(d.clone()),
+        _ => None,
+    }
+}
+
+fn dict_id(dict: &HashMap<Vec<u8>, Value>, key: &[u8]) -> Option<NodeId> {
+    let bytes = dict_bytes(dict, key)?;
+    bytes.as_slice().try_into().ok()
+}
+
+pub fn encode(msg: &KrpcMessage) -> Vec<u8> {
+    let mut pairs: Vec<(Vec<u8>, Encoded)> = Vec::new();
+    match &msg.payload {
+        Payload::Query(q) => {
+            pairs.push((b"a".to_vec(), Encoded::Dict(query_args(q))));
+            pairs.push((
+                b"q".to_vec(),
+                Encoded::Bytes(q.method().as_bytes().to_vec()),
+            ));
+            pairs.push((b"t".to_vec(), Encoded::Bytes(msg.transaction_id.clone())));
+            if let Some(v) = &msg.version {
+                pairs.push((b"v".to_vec(), Encoded::Bytes(v.clone())));
+            }
+            pairs.push((b"y".to_vec(), Encoded::Bytes(b"q".to_vec())));
+        }
+        Payload::Response(r) => {
+            pairs.push((b"r".to_vec(), Encoded::Dict(response_args(r))));
+            pairs.push((b"t".to_vec(), Encoded::Bytes(msg.transaction_id.clone())));
+            if let Some(v) = &msg.version {
+                pairs.push((b"v".to_vec(), Encoded::Bytes(v.clone())));
+            }
+            pairs.push((b"y".to_vec(), Encoded::Bytes(b"r".to_vec())));
+        }
+        Payload::Error(e) => {
+            pairs.push((
+                b"e".to_vec(),
+                Encoded::List(vec![
+                    Encoded::Int(e.code),
+                    Encoded::Bytes(e.message.as_bytes().to_vec()),
+                ]),
+            ));
+            pairs.push((b"t".to_vec(), Encoded::Bytes(msg.transaction_id.clone())));
+            if let Some(v) = &msg.version {
+                pairs.push((b"v".to_vec(), Encoded::Bytes(v.clone())));
+            }
+            pairs.push((b"y".to_vec(), Encoded::Bytes(b"e".to_vec())));
+        }
+    }
+    encode_dict(&pairs)
+}
+
+fn query_args(q: &Query) -> Vec<(Vec<u8>, Encoded)> {
+    match q {
+        Query::Ping { id } => vec![(b"id".to_vec(), Encoded::Bytes(id.to_vec()))],
+        Query::FindNode { id, target } => vec![
+            (b"id".to_vec(), Encoded::Bytes(id.to_vec())),
+            (b"target".to_vec(), Encoded::Bytes(target.to_vec())),
+        ],
+        Query::GetPeers { id, info_hash } => vec![
+            (b"id".to_vec(), Encoded::Bytes(id.to_vec())),
+            (b"info_hash".to_vec(), Encoded::Bytes(info_hash.to_vec())),
+        ],
+        Query::AnnouncePeer {
+            id,
+            info_hash,
+            port,
+            token,
+            implied_port,
+        } => {
+            let mut args = vec![(b"id".to_vec(), Encoded::Bytes(id.to_vec()))];
+            if *implied_port {
+                args.push((b"implied_port".to_vec(), Encoded::Int(1)));
+            }
+            args.push((b"info_hash".to_vec(), Encoded::Bytes(info_hash.to_vec())));
+            args.push((b"port".to_vec(), Encoded::Int(i64::from(*port))));
+            args.push((b"token".to_vec(), Encoded::Bytes(token.clone())));
+            args
+        }
+    }
+}
+
+fn response_args(r: &Response) -> Vec<(Vec<u8>, Encoded)> {
+    let mut args = vec![(b"id".to_vec(), Encoded::Bytes(r.id.to_vec()))];
+    if !r.nodes.is_empty() {
+        args.push((
+            b"nodes".to_vec(),
+            Encoded::Bytes(encode_compact_nodes(&r.nodes)),
+        ));
+    }
+    if let Some(token) = &r.token {
+        args.push((b"token".to_vec(), Encoded::Bytes(token.clone())));
+    }
+    if !r.values.is_empty() {
+        let values = r
+            .values
+            .iter()
+            .filter_map(|addr| encode_compact_peer(*addr).map(Encoded::Bytes))
+            .collect();
+        args.push((b"values".to_vec(), Encoded::List(values)));
+    }
+    args
+}
+
+enum Encoded {
+    Bytes(Vec<u8>),
+    Int(i64),
+    List(Vec<Encoded>),
+    Dict(Vec<(Vec<u8>, Encoded)>),
+}
+
+fn encode_value(out: &mut Vec<u8>, value: &Encoded) {
+    match value {
+        Encoded::Bytes(b) => {
+            out.extend_from_slice(b.len().to_string().as_bytes());
+            out.push(b':');
+            out.extend_from_slice(b);
+        }
+        Encoded::Int(n) => {
+            out.push(b'i');
+            out.extend_from_slice(n.to_string().as_bytes());
+            out.push(b'e');
+        }
+        Encoded::List(items) => {
+            out.push(b'l');
+            for item in items {
+                encode_value(out, item);
+            }
+            out.push(b'e');
+        }
+        Encoded::Dict(pairs) => {
+            out.extend_from_slice(&encode_dict(pairs));
+        }
+    }
+}
+
+fn encode_dict(pairs: &[(Vec<u8>, Encoded)]) -> Vec<u8> {
+    let mut sorted: Vec<_> = pairs.iter().collect();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut out = vec![b'd'];
+    for (key, value) in sorted {
+        out.extend_from_slice(key.len().to_string().as_bytes());
+        out.push(b':');
+        out.extend_from_slice(key);
+        encode_value(&mut out, value);
+    }
+    out.push(b'e');
+    out
+}
+
+pub fn encode_compact_peer(addr: SocketAddr) -> Option<Vec<u8>> {
+    let SocketAddr::V4(v4) = addr else {
+        return None;
+    };
+    let mut buf = Vec::with_capacity(COMPACT_PEER_LEN);
+    buf.extend_from_slice(&v4.ip().octets());
+    buf.extend_from_slice(&v4.port().to_be_bytes());
+    Some(buf)
+}
+
+pub fn decode_compact_peer(buf: &[u8]) -> Option<SocketAddr> {
+    if buf.len() != COMPACT_PEER_LEN {
+        return None;
+    }
+    let ip = Ipv4Addr::new(buf[0], buf[1], buf[2], buf[3]);
+    let port = u16::from_be_bytes([buf[4], buf[5]]);
+    Some(SocketAddr::V4(SocketAddrV4::new(ip, port)))
+}
+
+#[allow(dead_code)]
+pub fn decode_compact_peers(buf: &[u8]) -> Vec<SocketAddr> {
+    buf.as_chunks::<COMPACT_PEER_LEN>()
+        .0
+        .iter()
+        .filter_map(|chunk| decode_compact_peer(chunk))
+        .collect()
+}
+
+pub fn encode_compact_node(node: &CompactNode) -> Option<Vec<u8>> {
+    let mut buf = Vec::with_capacity(COMPACT_NODE_LEN);
+    buf.extend_from_slice(&node.id);
+    buf.extend_from_slice(&encode_compact_peer(node.addr)?);
+    Some(buf)
+}
+
+pub fn encode_compact_nodes(nodes: &[CompactNode]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(nodes.len() * COMPACT_NODE_LEN);
+    for node in nodes {
+        if let Some(entry) = encode_compact_node(node) {
+            buf.extend_from_slice(&entry);
+        }
+    }
+    buf
+}
+
+pub fn decode_compact_nodes(buf: &[u8]) -> Vec<CompactNode> {
+    buf.as_chunks::<COMPACT_NODE_LEN>()
+        .0
+        .iter()
+        .filter_map(|chunk| {
+            let id: NodeId = chunk[..NODE_ID_LEN].try_into().ok()?;
+            let addr = decode_compact_peer(&chunk[NODE_ID_LEN..])?;
+            Some(CompactNode { id, addr })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ID_A: &str = "abcdefghij0123456789";
+    const ID_B: &str = "mnopqrstuvwxyz123456";
+    const ID_C: &str = "0123456789abcdefghij";
+
+    fn id(s: &str) -> NodeId {
+        s.as_bytes().try_into().expect("20-byte id")
+    }
+
+    #[test]
+    fn ping_query_matches_bep() {
+        let msg = KrpcMessage::query_no_v(*b"aa", Query::Ping { id: id(ID_A) });
+        let expected = b"d1:ad2:id20:abcdefghij0123456789e1:q4:ping1:t2:aa1:y1:qe";
+        assert_eq!(encode(&msg), expected);
+        assert_eq!(decode(expected).unwrap(), msg);
+    }
+
+    #[test]
+    fn ping_response_matches_bep() {
+        let msg = KrpcMessage::response_no_v(
+            *b"aa",
+            Response {
+                id: id(ID_B),
+                nodes: vec![],
+                values: vec![],
+                token: None,
+            },
+        );
+        let expected = b"d1:rd2:id20:mnopqrstuvwxyz123456e1:t2:aa1:y1:re";
+        assert_eq!(encode(&msg), expected);
+        assert_eq!(decode(expected).unwrap(), msg);
+    }
+
+    #[test]
+    fn find_node_query_matches_bep() {
+        let msg = KrpcMessage::query_no_v(
+            *b"aa",
+            Query::FindNode {
+                id: id(ID_A),
+                target: id(ID_B),
+            },
+        );
+        // BEP-0005 writes `5:target` in the example string. `target` is 6
+        // bytes, so the valid encoding is `6:target`.
+        let expected =
+            b"d1:ad2:id20:abcdefghij01234567896:target20:mnopqrstuvwxyz123456e1:q9:find_node1:t2:aa1:y1:qe";
+        assert_eq!(encode(&msg), expected);
+        assert_eq!(decode(expected).unwrap(), msg);
+    }
+
+    #[test]
+    fn get_peers_query_matches_bep() {
+        let msg = KrpcMessage::query_no_v(
+            *b"aa",
+            Query::GetPeers {
+                id: id(ID_A),
+                info_hash: id(ID_B),
+            },
+        );
+        let expected =
+            b"d1:ad2:id20:abcdefghij01234567899:info_hash20:mnopqrstuvwxyz123456e1:q9:get_peers1:t2:aa1:y1:qe";
+        assert_eq!(encode(&msg), expected);
+        assert_eq!(decode(expected).unwrap(), msg);
+    }
+
+    #[test]
+    fn get_peers_values_response_matches_bep() {
+        let values = vec![
+            decode_compact_peer(b"axje.u").unwrap(),
+            decode_compact_peer(b"idhtnm").unwrap(),
+        ];
+        let msg = KrpcMessage::response_no_v(
+            *b"aa",
+            Response {
+                id: id(ID_A),
+                nodes: vec![],
+                values,
+                token: Some(b"aoeusnth".to_vec()),
+            },
+        );
+        let expected =
+            b"d1:rd2:id20:abcdefghij01234567895:token8:aoeusnth6:valuesl6:axje.u6:idhtnmee1:t2:aa1:y1:re";
+        assert_eq!(encode(&msg), expected);
+        assert_eq!(decode(expected).unwrap(), msg);
+    }
+
+    #[test]
+    fn announce_peer_query_matches_bep() {
+        let msg = KrpcMessage::query_no_v(
+            *b"aa",
+            Query::AnnouncePeer {
+                id: id(ID_A),
+                info_hash: id(ID_B),
+                port: 6881,
+                token: b"aoeusnth".to_vec(),
+                implied_port: true,
+            },
+        );
+        let expected = b"d1:ad2:id20:abcdefghij012345678912:implied_porti1e9:info_hash20:mnopqrstuvwxyz1234564:porti6881e5:token8:aoeusnthe1:q13:announce_peer1:t2:aa1:y1:qe";
+        assert_eq!(encode(&msg), expected);
+        assert_eq!(decode(expected).unwrap(), msg);
+    }
+
+    #[test]
+    fn announce_peer_response_matches_bep() {
+        let msg = KrpcMessage::response_no_v(
+            *b"aa",
+            Response {
+                id: id(ID_B),
+                nodes: vec![],
+                values: vec![],
+                token: None,
+            },
+        );
+        let expected = b"d1:rd2:id20:mnopqrstuvwxyz123456e1:t2:aa1:y1:re";
+        assert_eq!(encode(&msg), expected);
+        assert_eq!(decode(expected).unwrap(), msg);
+    }
+
+    #[test]
+    fn error_matches_bep() {
+        let msg = KrpcMessage::error_no_v(*b"aa", 201, "A Generic Error Ocurred");
+        let expected = b"d1:eli201e23:A Generic Error Ocurrede1:t2:aa1:y1:ee";
+        assert_eq!(encode(&msg), expected);
+        assert_eq!(decode(expected).unwrap(), msg);
+    }
+
+    #[test]
+    fn find_node_response_round_trip() {
+        let node = CompactNode {
+            id: id(ID_C),
+            addr: "127.0.0.1:6881".parse().unwrap(),
+        };
+        let msg = KrpcMessage::response_no_v(
+            *b"aa",
+            Response {
+                id: id(ID_C),
+                nodes: vec![node],
+                values: vec![],
+                token: None,
+            },
+        );
+        let bytes = encode(&msg);
+        assert_eq!(decode(&bytes).unwrap(), msg);
+    }
+
+    #[test]
+    fn encode_includes_version_when_set() {
+        let msg = KrpcMessage::query(*b"aa", Query::Ping { id: id(ID_A) });
+        let bytes = encode(&msg);
+        assert!(bytes.windows(4).any(|w| w == b"1:v4"));
+        let decoded = decode(&bytes).unwrap();
+        assert_eq!(
+            decoded.version.as_deref(),
+            Some(client_version().as_slice())
+        );
+    }
+
+    #[test]
+    fn compact_peer_round_trip() {
+        let addr: SocketAddr = "1.2.3.4:6881".parse().unwrap();
+        let bytes = encode_compact_peer(addr).unwrap();
+        assert_eq!(bytes.len(), 6);
+        assert_eq!(decode_compact_peer(&bytes), Some(addr));
+    }
+
+    #[test]
+    fn compact_node_round_trip() {
+        let node = CompactNode {
+            id: id(ID_A),
+            addr: "10.0.0.1:51413".parse().unwrap(),
+        };
+        let bytes = encode_compact_node(&node).unwrap();
+        assert_eq!(bytes.len(), 26);
+        assert_eq!(decode_compact_nodes(&bytes), vec![node]);
+    }
+
+    #[test]
+    fn decode_drops_garbage() {
+        assert_eq!(decode(b""), Err(DecodeError::NotBencode));
+        assert_eq!(decode(b"not bencode"), Err(DecodeError::NotBencode));
+        assert_eq!(decode(b"i42e"), Err(DecodeError::NotADict));
+        assert_eq!(decode(b"de"), Err(DecodeError::MissingTransaction));
+        assert!(decode(&[0xff; 64]).is_err());
+    }
+
+    #[test]
+    fn peek_helpers() {
+        let q = b"d1:ad2:id20:abcdefghij0123456789e1:q4:ping1:t2:aa1:y1:qe";
+        assert!(peek_is_query(q));
+        assert_eq!(peek_transaction_id(q).as_deref(), Some(&b"aa"[..]));
+        assert!(!peek_is_query(b"i1e"));
+        assert!(peek_transaction_id(b"xxx").is_none());
+    }
+}

--- a/crates/bit_rev/src/dht/lookup.rs
+++ b/crates/bit_rev/src/dht/lookup.rs
@@ -1,0 +1,297 @@
+//! Iterative DHT lookup (alpha=3, terminate on K closest).
+
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+
+use super::krpc::{CompactNode, NodeId, Response};
+use super::routing::{cmp_xor, K};
+
+pub const ALPHA: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LookupKind {
+    FindNode,
+    GetPeers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContactState {
+    Unknown,
+    Pending,
+    Responded,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+struct Contact {
+    node: CompactNode,
+    state: ContactState,
+    token: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Lookup {
+    pub target: NodeId,
+    pub kind: LookupKind,
+    contacts: HashMap<SocketAddr, Contact>,
+    seen_ids: HashSet<NodeId>,
+    values: Vec<SocketAddr>,
+}
+
+impl Lookup {
+    pub fn new(
+        target: NodeId,
+        kind: LookupKind,
+        seeds: impl IntoIterator<Item = CompactNode>,
+    ) -> Self {
+        let mut lookup = Self {
+            target,
+            kind,
+            contacts: HashMap::new(),
+            seen_ids: HashSet::new(),
+            values: Vec::new(),
+        };
+        for seed in seeds {
+            lookup.add_contact(seed);
+        }
+        lookup
+    }
+
+    pub fn add_contact(&mut self, node: CompactNode) {
+        if self.seen_ids.contains(&node.id) {
+            return;
+        }
+        if self.contacts.contains_key(&node.addr) {
+            return;
+        }
+        self.seen_ids.insert(node.id);
+        self.contacts.insert(
+            node.addr,
+            Contact {
+                node,
+                state: ContactState::Unknown,
+                token: None,
+            },
+        );
+    }
+
+    pub fn next_queries(&mut self) -> Vec<CompactNode> {
+        let mut unknown: Vec<&CompactNode> = self
+            .contacts
+            .values()
+            .filter(|c| c.state == ContactState::Unknown)
+            .map(|c| &c.node)
+            .collect();
+        unknown.sort_by(|a, b| cmp_xor(&a.id, &b.id, &self.target));
+        let pending = self
+            .contacts
+            .values()
+            .filter(|c| c.state == ContactState::Pending)
+            .count();
+        let want = ALPHA.saturating_sub(pending);
+        let chosen: Vec<CompactNode> = unknown.into_iter().take(want).cloned().collect();
+        for node in &chosen {
+            if let Some(c) = self.contacts.get_mut(&node.addr) {
+                c.state = ContactState::Pending;
+            }
+        }
+        chosen
+    }
+
+    pub fn on_timeout(&mut self, addr: SocketAddr) {
+        if let Some(c) = self.contacts.get_mut(&addr) {
+            if c.state == ContactState::Pending {
+                c.state = ContactState::Failed;
+            }
+        }
+    }
+
+    pub fn on_response(
+        &mut self,
+        from: SocketAddr,
+        id: NodeId,
+        response: &Response,
+    ) -> Vec<SocketAddr> {
+        if let Some(c) = self.contacts.get_mut(&from) {
+            c.state = ContactState::Responded;
+            c.node.id = id;
+            c.token = response.token.clone();
+        } else {
+            self.contacts.insert(
+                from,
+                Contact {
+                    node: CompactNode { id, addr: from },
+                    state: ContactState::Responded,
+                    token: response.token.clone(),
+                },
+            );
+            self.seen_ids.insert(id);
+        }
+        for node in &response.nodes {
+            self.add_contact(node.clone());
+        }
+        let mut new_values = Vec::new();
+        for addr in &response.values {
+            if !self.values.contains(addr) {
+                self.values.push(*addr);
+                new_values.push(*addr);
+            }
+        }
+        new_values
+    }
+
+    pub fn is_done(&self) -> bool {
+        if self
+            .contacts
+            .values()
+            .any(|c| c.state == ContactState::Pending)
+        {
+            return false;
+        }
+        if self
+            .contacts
+            .values()
+            .any(|c| c.state == ContactState::Unknown)
+        {
+            let closest = self.closest_contacts(K);
+            if closest
+                .iter()
+                .any(|c| c.state == ContactState::Unknown || c.state == ContactState::Pending)
+            {
+                return false;
+            }
+            let worst = closest.last().map(|c| c.node.id);
+            if let Some(worst) = worst {
+                let has_closer_unknown = self.contacts.values().any(|c| {
+                    c.state == ContactState::Unknown
+                        && cmp_xor(&c.node.id, &worst, &self.target).is_lt()
+                });
+                if has_closer_unknown {
+                    return false;
+                }
+            }
+            return true;
+        }
+        true
+    }
+
+    pub fn values(&self) -> &[SocketAddr] {
+        &self.values
+    }
+
+    pub fn announce_targets(&self) -> Vec<(CompactNode, Vec<u8>)> {
+        self.closest_contacts(K)
+            .into_iter()
+            .filter_map(|c| {
+                let token = c.token.clone()?;
+                Some((c.node.clone(), token))
+            })
+            .collect()
+    }
+
+    fn closest_contacts(&self, count: usize) -> Vec<&Contact> {
+        let mut contacts: Vec<&Contact> = self.contacts.values().collect();
+        contacts.sort_by(|a, b| cmp_xor(&a.node.id, &b.node.id, &self.target));
+        contacts.into_iter().take(count).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    fn id(byte: u8) -> NodeId {
+        [byte; 20]
+    }
+
+    fn addr(port: u16) -> SocketAddr {
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+    }
+
+    fn node(byte: u8, port: u16) -> CompactNode {
+        CompactNode {
+            id: id(byte),
+            addr: addr(port),
+        }
+    }
+
+    fn resp(
+        id_byte: u8,
+        nodes: Vec<CompactNode>,
+        values: Vec<SocketAddr>,
+        token: bool,
+    ) -> Response {
+        Response {
+            id: id(id_byte),
+            nodes,
+            values,
+            token: token.then(|| b"tok".to_vec()),
+        }
+    }
+
+    #[test]
+    fn converges_on_closer_nodes_and_collects_values() {
+        let target = id(0);
+        let seed = node(0x80, 1);
+        let mut lookup = Lookup::new(target, LookupKind::GetPeers, [seed.clone()]);
+
+        let first = lookup.next_queries();
+        assert_eq!(first, vec![seed.clone()]);
+
+        let closer = node(0x10, 2);
+        let even_closer = node(0x01, 3);
+        let peer: SocketAddr = "10.0.0.5:51413".parse().unwrap();
+        let new = lookup.on_response(
+            seed.addr,
+            seed.id,
+            &resp(
+                0x80,
+                vec![closer.clone(), even_closer.clone()],
+                vec![],
+                true,
+            ),
+        );
+        assert!(new.is_empty());
+
+        let next = lookup.next_queries();
+        assert_eq!(next.len(), 2);
+        assert!(next.contains(&closer));
+        assert!(next.contains(&even_closer));
+
+        lookup.on_response(
+            even_closer.addr,
+            even_closer.id,
+            &resp(0x01, vec![], vec![peer], true),
+        );
+        lookup.on_response(closer.addr, closer.id, &resp(0x10, vec![], vec![], true));
+
+        assert!(lookup.is_done());
+        assert_eq!(lookup.values(), &[peer]);
+        let announce = lookup.announce_targets();
+        assert!(announce.iter().any(|(n, _)| n.id == even_closer.id));
+    }
+
+    #[test]
+    fn alpha_limits_in_flight() {
+        let seeds: Vec<_> = (1..=6).map(|i| node(i * 10, i as u16)).collect();
+        let mut lookup = Lookup::new(id(0), LookupKind::FindNode, seeds);
+        let first = lookup.next_queries();
+        assert_eq!(first.len(), ALPHA);
+        let second = lookup.next_queries();
+        assert!(second.is_empty(), "do not exceed alpha in-flight");
+    }
+
+    #[test]
+    fn timeout_marks_failed_and_continues() {
+        let seed = node(0x40, 9);
+        let backup = node(0x20, 10);
+        let mut lookup = Lookup::new(id(0), LookupKind::FindNode, [seed.clone()]);
+        let first = lookup.next_queries();
+        assert_eq!(first, vec![seed.clone()]);
+        lookup.on_timeout(seed.addr);
+        lookup.add_contact(backup.clone());
+        let next = lookup.next_queries();
+        assert_eq!(next, vec![backup]);
+    }
+}

--- a/crates/bit_rev/src/dht/mod.rs
+++ b/crates/bit_rev/src/dht/mod.rs
@@ -1,0 +1,784 @@
+//! Session-wide Mainline DHT (BEP-0005).
+
+mod announce;
+mod krpc;
+mod lookup;
+mod routing;
+mod token;
+
+pub use krpc::{decode, CompactNode, DecodeError, NodeId};
+pub use routing::{RoutingTable, K};
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::peer::PeerAddr;
+
+use announce::AnnounceStore;
+use krpc::{
+    encode, peek_is_query, peek_transaction_id, DecodeError as KrpcDecodeError, ErrorMsg,
+    KrpcMessage, Payload, Query, Response, ERR_METHOD, ERR_PROTOCOL,
+};
+use lookup::{Lookup, LookupKind};
+use routing::persist_path;
+use token::TokenSecrets;
+
+pub const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
+pub const REANNOUNCE_INTERVAL: Duration = Duration::from_secs(15 * 60);
+pub const PERSIST_INTERVAL: Duration = Duration::from_secs(5 * 60);
+const TICK: Duration = Duration::from_millis(500);
+const MAX_PACKET: usize = 2048;
+
+pub const DEFAULT_BOOTSTRAP: &[&str] = &[
+    "router.bittorrent.com:6881",
+    "dht.transmissionbt.com:6881",
+    "router.utorrent.com:6881",
+];
+
+pub type PeerSink = Arc<dyn Fn([u8; 20], Vec<PeerAddr>) + Send + Sync>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DhtOptions {
+    pub enabled: bool,
+    pub port: u16,
+    pub bootstrap_nodes: Vec<String>,
+}
+
+impl DhtOptions {
+    pub fn default_bootstrap() -> Vec<String> {
+        DEFAULT_BOOTSTRAP.iter().map(|s| (*s).to_string()).collect()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DhtStats {
+    pub nodes: usize,
+    pub good_nodes: usize,
+}
+
+#[derive(Clone)]
+pub struct DhtHandle {
+    tx: mpsc::UnboundedSender<DhtCmd>,
+    stats: Arc<Mutex<DhtStats>>,
+    watched: Arc<Mutex<Vec<NodeId>>>,
+    local_addr: SocketAddr,
+    node_id: NodeId,
+}
+
+impl DhtHandle {
+    pub fn stats(&self) -> DhtStats {
+        *self.stats.lock().unwrap()
+    }
+
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub fn node_id(&self) -> NodeId {
+        self.node_id
+    }
+
+    pub fn udp_port(&self) -> u16 {
+        self.local_addr.port()
+    }
+
+    pub fn add_torrent(&self, info_hash: [u8; 20], listen_port: u16, active: bool) {
+        let _ = self.tx.send(DhtCmd::AddTorrent {
+            info_hash,
+            listen_port,
+            active,
+        });
+    }
+
+    pub fn remove_torrent(&self, info_hash: [u8; 20]) {
+        let _ = self.tx.send(DhtCmd::RemoveTorrent { info_hash });
+    }
+
+    pub fn set_active(&self, info_hash: [u8; 20], active: bool) {
+        let _ = self.tx.send(DhtCmd::SetActive { info_hash, active });
+    }
+
+    pub fn set_all_active(&self, active: bool) {
+        let _ = self.tx.send(DhtCmd::SetAllActive { active });
+    }
+
+    pub fn ping_node(&self, addr: SocketAddr) {
+        let _ = self.tx.send(DhtCmd::PingNode { addr });
+    }
+
+    pub fn shutdown(&self) {
+        let _ = self.tx.send(DhtCmd::Shutdown);
+    }
+
+    pub fn watched(&self) -> Vec<NodeId> {
+        self.watched.lock().unwrap().clone()
+    }
+
+    pub fn spawn(
+        options: DhtOptions,
+        state_dir: Option<PathBuf>,
+        sink: PeerSink,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<Self> {
+        let bind = SocketAddr::from(([0, 0, 0, 0], options.port));
+        let std_sock = std::net::UdpSocket::bind(bind)?;
+        std_sock.set_nonblocking(true)?;
+        let socket = UdpSocket::from_std(std_sock)?;
+        let local_addr = socket.local_addr()?;
+        let now = Instant::now();
+        let table = state_dir
+            .as_ref()
+            .and_then(|dir| routing::load(&persist_path(dir), now))
+            .unwrap_or_else(|| RoutingTable::new(RoutingTable::random_id(), now));
+        let node_id = table.id();
+        let stats = Arc::new(Mutex::new(DhtStats {
+            nodes: table.len(),
+            good_nodes: table.good_len(now),
+        }));
+        let watched = Arc::new(Mutex::new(Vec::new()));
+        let (tx, rx) = mpsc::unbounded_channel();
+        let actor = DhtActor {
+            socket,
+            table,
+            tokens: TokenSecrets::new(now),
+            store: AnnounceStore::new(),
+            pending: HashMap::new(),
+            lookups: HashMap::new(),
+            torrents: HashMap::new(),
+            next_tid: 0,
+            next_lookup: 0,
+            peer_sink: sink,
+            state_path: state_dir.map(|d| persist_path(&d)),
+            last_persist: now,
+            bootstrap: options.bootstrap_nodes,
+            bootstrapped: false,
+            stats: stats.clone(),
+            watched: watched.clone(),
+            cancel,
+            rx,
+        };
+        tokio::spawn(actor.run());
+        Ok(Self {
+            tx,
+            stats,
+            watched,
+            local_addr,
+            node_id,
+        })
+    }
+}
+
+enum DhtCmd {
+    AddTorrent {
+        info_hash: NodeId,
+        listen_port: u16,
+        active: bool,
+    },
+    RemoveTorrent {
+        info_hash: NodeId,
+    },
+    SetActive {
+        info_hash: NodeId,
+        active: bool,
+    },
+    SetAllActive {
+        active: bool,
+    },
+    PingNode {
+        addr: SocketAddr,
+    },
+    Shutdown,
+}
+
+struct Pending {
+    sent: Instant,
+    kind: PendingKind,
+}
+
+enum PendingKind {
+    Ping { replacement: Option<CompactNode> },
+    Lookup { lookup_id: u64 },
+    Announce,
+}
+
+struct TorrentDht {
+    listen_port: u16,
+    active: bool,
+    last_announce: Instant,
+    lookup_id: Option<u64>,
+}
+
+struct DhtActor {
+    socket: UdpSocket,
+    table: RoutingTable,
+    tokens: TokenSecrets,
+    store: AnnounceStore,
+    pending: HashMap<(Vec<u8>, SocketAddr), Pending>,
+    lookups: HashMap<u64, Lookup>,
+    torrents: HashMap<NodeId, TorrentDht>,
+    next_tid: u16,
+    next_lookup: u64,
+    peer_sink: PeerSink,
+    state_path: Option<PathBuf>,
+    last_persist: Instant,
+    bootstrap: Vec<String>,
+    bootstrapped: bool,
+    stats: Arc<Mutex<DhtStats>>,
+    watched: Arc<Mutex<Vec<NodeId>>>,
+    cancel: CancellationToken,
+    rx: mpsc::UnboundedReceiver<DhtCmd>,
+}
+
+impl DhtActor {
+    async fn run(mut self) {
+        self.bootstrap().await;
+        let mut interval = tokio::time::interval(TICK);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut buf = vec![0u8; MAX_PACKET];
+        loop {
+            tokio::select! {
+                _ = self.cancel.cancelled() => break,
+                cmd = self.rx.recv() => {
+                    match cmd {
+                        Some(DhtCmd::Shutdown) | None => break,
+                        Some(cmd) => self.handle_cmd(cmd).await,
+                    }
+                }
+                recv = self.socket.recv_from(&mut buf) => {
+                    match recv {
+                        Ok((n, from)) => self.on_packet(&buf[..n], from).await,
+                        Err(e) => debug!(error = %e, "dht recv failed"),
+                    }
+                }
+                _ = interval.tick() => self.tick().await,
+            }
+        }
+        self.persist();
+    }
+
+    async fn bootstrap(&mut self) {
+        if self.table.is_empty() && !self.bootstrap.is_empty() {
+            for addr in resolve_bootstrap(&self.bootstrap).await {
+                self.send_ping(addr, None).await;
+            }
+        } else if !self.table.is_empty() {
+            self.start_find_self();
+            self.kick_lookups().await;
+        }
+    }
+
+    async fn handle_cmd(&mut self, cmd: DhtCmd) {
+        match cmd {
+            DhtCmd::AddTorrent {
+                info_hash,
+                listen_port,
+                active,
+            } => {
+                if let Some(t) = self.torrents.get(&info_hash) {
+                    if let Some(id) = t.lookup_id {
+                        self.lookups.remove(&id);
+                    }
+                }
+                self.torrents.insert(
+                    info_hash,
+                    TorrentDht {
+                        listen_port,
+                        active,
+                        last_announce: Instant::now() - REANNOUNCE_INTERVAL,
+                        lookup_id: None,
+                    },
+                );
+                self.sync_watched();
+                if active {
+                    self.start_get_peers(info_hash);
+                    self.kick_lookups().await;
+                }
+            }
+            DhtCmd::RemoveTorrent { info_hash } => {
+                if let Some(t) = self.torrents.remove(&info_hash) {
+                    if let Some(id) = t.lookup_id {
+                        self.lookups.remove(&id);
+                    }
+                }
+                self.sync_watched();
+            }
+            DhtCmd::SetActive { info_hash, active } => {
+                if let Some(t) = self.torrents.get_mut(&info_hash) {
+                    t.active = active;
+                    if !active {
+                        if let Some(id) = t.lookup_id.take() {
+                            self.lookups.remove(&id);
+                        }
+                    }
+                }
+                if active {
+                    self.start_get_peers(info_hash);
+                    self.kick_lookups().await;
+                }
+            }
+            DhtCmd::SetAllActive { active } => {
+                let hashes: Vec<NodeId> = self.torrents.keys().copied().collect();
+                for hash in hashes {
+                    if let Some(t) = self.torrents.get_mut(&hash) {
+                        t.active = active;
+                        if !active {
+                            if let Some(id) = t.lookup_id.take() {
+                                self.lookups.remove(&id);
+                            }
+                        }
+                    }
+                    if active {
+                        self.start_get_peers(hash);
+                    }
+                }
+                if active {
+                    self.kick_lookups().await;
+                }
+            }
+            DhtCmd::PingNode { addr } => {
+                self.send_ping(addr, None).await;
+            }
+            DhtCmd::Shutdown => {}
+        }
+    }
+
+    async fn on_packet(&mut self, buf: &[u8], from: SocketAddr) {
+        match decode(buf) {
+            Ok(msg) => match msg.payload {
+                Payload::Query(q) => self.on_query(msg.transaction_id, q, from).await,
+                Payload::Response(r) => self.on_response(msg.transaction_id, r, from).await,
+                Payload::Error(e) => self.on_error(msg.transaction_id, e, from),
+            },
+            Err(KrpcDecodeError::UnknownMethod) => {
+                if let Some(t) = peek_transaction_id(buf) {
+                    self.send_msg(from, KrpcMessage::error(t, ERR_METHOD, "Method Unknown"))
+                        .await;
+                }
+            }
+            Err(_) if peek_is_query(buf) => {
+                if let Some(t) = peek_transaction_id(buf) {
+                    self.send_msg(from, KrpcMessage::error(t, ERR_PROTOCOL, "Protocol Error"))
+                        .await;
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    async fn on_query(&mut self, t: Vec<u8>, query: Query, from: SocketAddr) {
+        let now = Instant::now();
+        self.table.seen_query(query.id(), from, now);
+        self.refresh_stats(now);
+        let our_id = self.table.id();
+        let reply = match query {
+            Query::Ping { .. } => KrpcMessage::response(
+                t,
+                Response {
+                    id: our_id,
+                    nodes: vec![],
+                    values: vec![],
+                    token: None,
+                },
+            ),
+            Query::FindNode { target, .. } => KrpcMessage::response(
+                t,
+                Response {
+                    id: our_id,
+                    nodes: self.table.closest(&target, K),
+                    values: vec![],
+                    token: None,
+                },
+            ),
+            Query::GetPeers { info_hash, .. } => {
+                let token = self.tokens.issue(from.ip());
+                let values = self.store.get(&info_hash, now);
+                let nodes = if values.is_empty() {
+                    self.table.closest(&info_hash, K)
+                } else {
+                    vec![]
+                };
+                KrpcMessage::response(
+                    t,
+                    Response {
+                        id: our_id,
+                        nodes,
+                        values,
+                        token: Some(token),
+                    },
+                )
+            }
+            Query::AnnouncePeer {
+                info_hash,
+                port,
+                token,
+                implied_port,
+                ..
+            } => {
+                if !self.tokens.validate(from.ip(), &token) {
+                    KrpcMessage::error(t, ERR_PROTOCOL, "bad token")
+                } else {
+                    let peer_port = if implied_port { from.port() } else { port };
+                    let peer = SocketAddr::new(from.ip(), peer_port);
+                    self.store.announce(info_hash, peer, now);
+                    KrpcMessage::response(
+                        t,
+                        Response {
+                            id: our_id,
+                            nodes: vec![],
+                            values: vec![],
+                            token: None,
+                        },
+                    )
+                }
+            }
+        };
+        self.send_msg(from, reply).await;
+    }
+
+    async fn on_response(&mut self, t: Vec<u8>, response: Response, from: SocketAddr) {
+        let Some(pending) = self.pending.remove(&(t, from)) else {
+            return;
+        };
+        let now = Instant::now();
+        self.table.seen_response(response.id, from, now);
+        for node in &response.nodes {
+            let _ = self.table.insert(node.clone(), now);
+        }
+        self.refresh_stats(now);
+
+        match pending.kind {
+            PendingKind::Ping { replacement } => {
+                if !self.bootstrapped && !self.table.is_empty() {
+                    self.start_find_self();
+                    self.kick_lookups().await;
+                }
+                let _ = replacement;
+            }
+            PendingKind::Lookup { lookup_id } => {
+                self.on_lookup_response(lookup_id, from, response).await;
+            }
+            PendingKind::Announce => {}
+        }
+    }
+
+    fn on_error(&mut self, t: Vec<u8>, _err: ErrorMsg, from: SocketAddr) {
+        if let Some(pending) = self.pending.remove(&(t, from)) {
+            if let PendingKind::Lookup { lookup_id } = pending.kind {
+                if let Some(lookup) = self.lookups.get_mut(&lookup_id) {
+                    lookup.on_timeout(from);
+                }
+            }
+        }
+    }
+
+    async fn on_lookup_response(&mut self, lookup_id: u64, from: SocketAddr, response: Response) {
+        let Some(lookup) = self.lookups.get_mut(&lookup_id) else {
+            return;
+        };
+        let new_values = lookup.on_response(from, response.id, &response);
+        if !new_values.is_empty() {
+            if let Some(hash) = self.lookup_info_hash(lookup_id) {
+                (self.peer_sink)(hash, new_values);
+            }
+        }
+        self.drive_lookup(lookup_id).await;
+    }
+
+    fn lookup_info_hash(&self, lookup_id: u64) -> Option<NodeId> {
+        self.torrents
+            .iter()
+            .find(|(_, t)| t.lookup_id == Some(lookup_id))
+            .map(|(h, _)| *h)
+            .or_else(|| {
+                self.lookups.get(&lookup_id).and_then(|l| {
+                    if l.kind == LookupKind::GetPeers {
+                        Some(l.target)
+                    } else {
+                        None
+                    }
+                })
+            })
+    }
+
+    fn start_find_self(&mut self) {
+        if self.bootstrapped {
+            return;
+        }
+        self.bootstrapped = true;
+        let id = self.table.id();
+        let seeds = self.table.closest(&id, K);
+        self.start_lookup(id, LookupKind::FindNode, seeds, None);
+    }
+
+    fn start_get_peers(&mut self, info_hash: NodeId) {
+        if let Some(t) = self.torrents.get(&info_hash) {
+            if let Some(id) = t.lookup_id {
+                self.lookups.remove(&id);
+            }
+        }
+        let now = Instant::now();
+        let local = self.store.get(&info_hash, now);
+        if !local.is_empty() {
+            (self.peer_sink)(info_hash, local);
+        }
+        let seeds = self.table.closest(&info_hash, K);
+        let lookup_id = self.start_lookup(info_hash, LookupKind::GetPeers, seeds, Some(info_hash));
+        if let Some(t) = self.torrents.get_mut(&info_hash) {
+            t.lookup_id = Some(lookup_id);
+        }
+    }
+
+    fn start_lookup(
+        &mut self,
+        target: NodeId,
+        kind: LookupKind,
+        seeds: Vec<CompactNode>,
+        _info_hash: Option<NodeId>,
+    ) -> u64 {
+        let id = self.next_lookup;
+        self.next_lookup = self.next_lookup.wrapping_add(1);
+        self.lookups.insert(id, Lookup::new(target, kind, seeds));
+        id
+    }
+
+    async fn kick_lookups(&mut self) {
+        let ids: Vec<u64> = self.lookups.keys().copied().collect();
+        for id in ids {
+            self.drive_lookup(id).await;
+        }
+    }
+
+    async fn drive_lookup(&mut self, lookup_id: u64) {
+        loop {
+            let Some(lookup) = self.lookups.get_mut(&lookup_id) else {
+                return;
+            };
+            if lookup.is_done() {
+                self.finish_lookup(lookup_id).await;
+                return;
+            }
+            let queries = lookup.next_queries();
+            if queries.is_empty() {
+                if lookup.is_done() {
+                    self.finish_lookup(lookup_id).await;
+                }
+                return;
+            }
+            let kind = lookup.kind;
+            let target = lookup.target;
+            for node in queries {
+                match kind {
+                    LookupKind::FindNode => {
+                        self.send_query(
+                            node.addr,
+                            Query::FindNode {
+                                id: self.table.id(),
+                                target,
+                            },
+                            PendingKind::Lookup { lookup_id },
+                        )
+                        .await;
+                    }
+                    LookupKind::GetPeers => {
+                        self.send_query(
+                            node.addr,
+                            Query::GetPeers {
+                                id: self.table.id(),
+                                info_hash: target,
+                            },
+                            PendingKind::Lookup { lookup_id },
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn finish_lookup(&mut self, lookup_id: u64) {
+        let Some(lookup) = self.lookups.remove(&lookup_id) else {
+            return;
+        };
+        if lookup.kind != LookupKind::GetPeers {
+            return;
+        }
+        if !lookup.values().is_empty() {
+            (self.peer_sink)(lookup.target, lookup.values().to_vec());
+        }
+        let info_hash = lookup.target;
+        let Some(torrent) = self.torrents.get(&info_hash) else {
+            return;
+        };
+        if !torrent.active || torrent.listen_port == 0 {
+            return;
+        }
+        let port = torrent.listen_port;
+        let targets = lookup.announce_targets();
+        for (node, token) in targets {
+            self.send_query(
+                node.addr,
+                Query::AnnouncePeer {
+                    id: self.table.id(),
+                    info_hash,
+                    port,
+                    token,
+                    implied_port: false,
+                },
+                PendingKind::Announce,
+            )
+            .await;
+        }
+        if let Some(t) = self.torrents.get_mut(&info_hash) {
+            t.last_announce = Instant::now();
+            t.lookup_id = None;
+        }
+    }
+
+    async fn send_ping(&mut self, addr: SocketAddr, replacement: Option<CompactNode>) {
+        self.send_query(
+            addr,
+            Query::Ping {
+                id: self.table.id(),
+            },
+            PendingKind::Ping { replacement },
+        )
+        .await;
+    }
+
+    async fn send_query(&mut self, addr: SocketAddr, query: Query, kind: PendingKind) {
+        let t = self.next_tid.to_be_bytes()[..krpc::TRANSACTION_ID_LEN].to_vec();
+        self.next_tid = self.next_tid.wrapping_add(1);
+        let msg = KrpcMessage::query(t.clone(), query);
+        self.pending.insert(
+            (t, addr),
+            Pending {
+                sent: Instant::now(),
+                kind,
+            },
+        );
+        self.send_msg(addr, msg).await;
+    }
+
+    async fn send_msg(&self, addr: SocketAddr, msg: KrpcMessage) {
+        let bytes = encode(&msg);
+        if let Err(e) = self.socket.send_to(&bytes, addr).await {
+            debug!(%addr, error = %e, "dht send failed");
+        }
+    }
+
+    async fn tick(&mut self) {
+        let now = Instant::now();
+        self.tokens.maybe_rotate(now);
+        self.expire_pending(now).await;
+        if !self.bootstrapped && !self.table.is_empty() {
+            self.start_find_self();
+        }
+        self.refresh_buckets(now);
+        self.reannounce(now);
+        if now.saturating_duration_since(self.last_persist) >= PERSIST_INTERVAL {
+            self.persist();
+            self.last_persist = now;
+        }
+        self.refresh_stats(now);
+
+        let lookup_ids: Vec<u64> = self.lookups.keys().copied().collect();
+        for id in lookup_ids {
+            self.drive_lookup(id).await;
+        }
+    }
+
+    async fn expire_pending(&mut self, now: Instant) {
+        let expired: Vec<_> = self
+            .pending
+            .iter()
+            .filter(|(_, p)| now.saturating_duration_since(p.sent) >= QUERY_TIMEOUT)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in expired {
+            if let Some(pending) = self.pending.remove(&key) {
+                let addr = key.1;
+                self.table.timed_out(addr);
+                match pending.kind {
+                    PendingKind::Ping { replacement } => {
+                        if let Some(node) = replacement {
+                            self.table.replace(addr, node, now);
+                        }
+                    }
+                    PendingKind::Lookup { lookup_id } => {
+                        if let Some(lookup) = self.lookups.get_mut(&lookup_id) {
+                            lookup.on_timeout(addr);
+                        }
+                    }
+                    PendingKind::Announce => {}
+                }
+            }
+        }
+    }
+
+    fn refresh_buckets(&mut self, now: Instant) {
+        let targets = self.table.stale_buckets(now);
+        for target in targets {
+            let seeds = self.table.closest(&target, K);
+            self.start_lookup(target, LookupKind::FindNode, seeds, None);
+        }
+    }
+
+    fn reannounce(&mut self, now: Instant) {
+        let due: Vec<NodeId> = self
+            .torrents
+            .iter()
+            .filter(|(_, t)| {
+                t.active && now.saturating_duration_since(t.last_announce) >= REANNOUNCE_INTERVAL
+            })
+            .map(|(h, _)| *h)
+            .collect();
+        for hash in due {
+            self.start_get_peers(hash);
+        }
+    }
+
+    fn persist(&self) {
+        let Some(path) = &self.state_path else {
+            return;
+        };
+        if let Err(e) = routing::save(&self.table, path, Instant::now()) {
+            warn!(error = %e, "failed to persist dht.dat");
+        }
+    }
+
+    fn refresh_stats(&self, now: Instant) {
+        *self.stats.lock().unwrap() = DhtStats {
+            nodes: self.table.len(),
+            good_nodes: self.table.good_len(now),
+        };
+    }
+
+    fn sync_watched(&self) {
+        *self.watched.lock().unwrap() = self.torrents.keys().copied().collect();
+    }
+}
+
+async fn resolve_bootstrap(nodes: &[String]) -> Vec<SocketAddr> {
+    let mut out = Vec::new();
+    for spec in nodes {
+        if let Ok(addr) = spec.parse::<SocketAddr>() {
+            if addr.is_ipv4() {
+                out.push(addr);
+            }
+            continue;
+        }
+        match tokio::net::lookup_host(spec).await {
+            Ok(iter) => out.extend(iter.filter(SocketAddr::is_ipv4)),
+            Err(e) => debug!(node = %spec, error = %e, "dht bootstrap resolve failed"),
+        }
+    }
+    out
+}

--- a/crates/bit_rev/src/dht/routing.rs
+++ b/crates/bit_rev/src/dht/routing.rs
@@ -1,0 +1,633 @@
+//! Kademlia routing table (BEP-0005).
+//!
+//! XOR distance, K=8, split only the bucket that contains our node ID.
+//! Node states follow the 15-minute good / questionable / bad rules.
+
+use std::cmp::Ordering;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
+
+use super::krpc::{decode_compact_nodes, encode_compact_nodes, CompactNode, NodeId, NODE_ID_LEN};
+
+pub const K: usize = 8;
+pub const NODE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+pub const BAD_FAILS: u8 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeStatus {
+    Good,
+    Questionable,
+    Bad,
+}
+
+#[derive(Debug, Clone)]
+pub struct Node {
+    pub id: NodeId,
+    pub addr: SocketAddr,
+    last_response: Option<Instant>,
+    last_query: Option<Instant>,
+    fails: u8,
+    ever_responded: bool,
+}
+
+impl Node {
+    pub fn new(id: NodeId, addr: SocketAddr, now: Instant) -> Self {
+        Self {
+            id,
+            addr,
+            last_response: None,
+            last_query: Some(now),
+            fails: 0,
+            ever_responded: false,
+        }
+    }
+
+    pub fn from_compact(node: CompactNode, now: Instant) -> Self {
+        Self::new(node.id, node.addr, now)
+    }
+
+    pub fn contact(&self) -> CompactNode {
+        CompactNode {
+            id: self.id,
+            addr: self.addr,
+        }
+    }
+
+    pub fn status(&self, now: Instant) -> NodeStatus {
+        if self.fails >= BAD_FAILS {
+            return NodeStatus::Bad;
+        }
+        let responded_recently = self
+            .last_response
+            .is_some_and(|t| now.saturating_duration_since(t) < NODE_TIMEOUT);
+        let queried_recently = self
+            .last_query
+            .is_some_and(|t| now.saturating_duration_since(t) < NODE_TIMEOUT);
+        if responded_recently || (self.ever_responded && queried_recently) {
+            NodeStatus::Good
+        } else {
+            NodeStatus::Questionable
+        }
+    }
+
+    pub fn on_response(&mut self, now: Instant) {
+        self.last_response = Some(now);
+        self.ever_responded = true;
+        self.fails = 0;
+    }
+
+    pub fn on_query(&mut self, now: Instant) {
+        self.last_query = Some(now);
+    }
+
+    pub fn on_timeout(&mut self) {
+        self.fails = self.fails.saturating_add(1);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Bucket {
+    /// Shared prefix length of IDs in this bucket (0 = whole space).
+    prefix_len: u8,
+    /// First `prefix_len` bits identify the range.
+    prefix: NodeId,
+    nodes: Vec<Node>,
+    last_changed: Instant,
+}
+
+impl Bucket {
+    fn covers(&self, id: &NodeId) -> bool {
+        matching_prefix_bits(&self.prefix, id) >= u32::from(self.prefix_len)
+    }
+
+    fn contains_id(&self, id: &NodeId) -> bool {
+        self.covers(id)
+    }
+
+    pub fn is_stale(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.last_changed) >= NODE_TIMEOUT
+    }
+
+    pub fn random_id(&self) -> NodeId {
+        let mut id = [0u8; NODE_ID_LEN];
+        rand::thread_rng().fill(&mut id);
+        copy_prefix(&self.prefix, &mut id, self.prefix_len);
+        id
+    }
+
+    fn split(self, now: Instant) -> (Bucket, Bucket) {
+        let mut left_prefix = self.prefix;
+        let mut right_prefix = self.prefix;
+        set_bit(&mut left_prefix, self.prefix_len, false);
+        set_bit(&mut right_prefix, self.prefix_len, true);
+        let next = self.prefix_len + 1;
+        let mut left = Bucket {
+            prefix_len: next,
+            prefix: left_prefix,
+            nodes: Vec::new(),
+            last_changed: now,
+        };
+        let mut right = Bucket {
+            prefix_len: next,
+            prefix: right_prefix,
+            nodes: Vec::new(),
+            last_changed: now,
+        };
+        for node in self.nodes {
+            if left.covers(&node.id) {
+                left.nodes.push(node);
+            } else {
+                right.nodes.push(node);
+            }
+        }
+        (left, right)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum InsertResult {
+    Added,
+    Updated,
+    Split,
+    Replaced,
+    Dropped,
+    NeedPing {
+        addr: SocketAddr,
+        replacement: CompactNode,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct RoutingTable {
+    id: NodeId,
+    buckets: Vec<Bucket>,
+}
+
+impl RoutingTable {
+    pub fn new(id: NodeId, now: Instant) -> Self {
+        Self {
+            id,
+            buckets: vec![Bucket {
+                prefix_len: 0,
+                prefix: [0u8; NODE_ID_LEN],
+                nodes: Vec::new(),
+                last_changed: now,
+            }],
+        }
+    }
+
+    pub fn random_id() -> NodeId {
+        let mut id = [0u8; NODE_ID_LEN];
+        rand::thread_rng().fill(&mut id);
+        id
+    }
+
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buckets.iter().all(|b| b.nodes.is_empty())
+    }
+
+    pub fn len(&self) -> usize {
+        self.buckets.iter().map(|b| b.nodes.len()).sum()
+    }
+
+    pub fn good_len(&self, now: Instant) -> usize {
+        self.nodes()
+            .filter(|n| n.status(now) == NodeStatus::Good)
+            .count()
+    }
+
+    pub fn nodes(&self) -> impl Iterator<Item = &Node> {
+        self.buckets.iter().flat_map(|b| b.nodes.iter())
+    }
+
+    pub fn nodes_mut(&mut self) -> impl Iterator<Item = &mut Node> {
+        self.buckets.iter_mut().flat_map(|b| b.nodes.iter_mut())
+    }
+
+    pub fn good_contacts(&self, now: Instant) -> Vec<CompactNode> {
+        self.nodes()
+            .filter(|n| n.status(now) == NodeStatus::Good)
+            .map(Node::contact)
+            .collect()
+    }
+
+    pub fn stale_buckets(&self, now: Instant) -> Vec<NodeId> {
+        self.buckets
+            .iter()
+            .filter(|b| b.is_stale(now) && !b.nodes.is_empty())
+            .map(Bucket::random_id)
+            .collect()
+    }
+
+    pub fn insert(&mut self, node: CompactNode, now: Instant) -> InsertResult {
+        if node.id == self.id {
+            return InsertResult::Dropped;
+        }
+        if !matches!(node.addr, SocketAddr::V4(_)) {
+            return InsertResult::Dropped;
+        }
+        if let Some(existing) = self.find_mut(&node.id) {
+            existing.addr = node.addr;
+            existing.on_response(now);
+            if let Some(bucket) = self.bucket_mut_for(&node.id) {
+                bucket.last_changed = now;
+            }
+            return InsertResult::Updated;
+        }
+
+        loop {
+            let idx = self.bucket_index(&node.id);
+            let our_bucket = self.buckets[idx].contains_id(&self.id);
+            if self.buckets[idx].nodes.len() < K {
+                self.buckets[idx].nodes.push(Node::from_compact(node, now));
+                self.buckets[idx].last_changed = now;
+                return InsertResult::Added;
+            }
+
+            if our_bucket && self.buckets[idx].prefix_len < 160 {
+                let bucket = self.buckets.remove(idx);
+                let (left, right) = bucket.split(now);
+                self.buckets.insert(idx, left);
+                self.buckets.insert(idx + 1, right);
+                continue;
+            }
+
+            let bucket = &mut self.buckets[idx];
+            if let Some(pos) = bucket
+                .nodes
+                .iter()
+                .position(|n| n.status(now) == NodeStatus::Bad)
+            {
+                bucket.nodes[pos] = Node::from_compact(node, now);
+                bucket.last_changed = now;
+                return InsertResult::Replaced;
+            }
+
+            if let Some(pos) = bucket
+                .nodes
+                .iter()
+                .enumerate()
+                .filter(|(_, n)| n.status(now) == NodeStatus::Questionable)
+                .min_by_key(|(_, n)| n.last_response.or(n.last_query))
+                .map(|(i, _)| i)
+            {
+                return InsertResult::NeedPing {
+                    addr: bucket.nodes[pos].addr,
+                    replacement: node,
+                };
+            }
+
+            return InsertResult::Dropped;
+        }
+    }
+
+    pub fn replace(&mut self, old: SocketAddr, new: CompactNode, now: Instant) -> bool {
+        for bucket in &mut self.buckets {
+            if let Some(pos) = bucket.nodes.iter().position(|n| n.addr == old) {
+                bucket.nodes[pos] = Node::from_compact(new, now);
+                bucket.last_changed = now;
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn seen_query(&mut self, id: NodeId, addr: SocketAddr, now: Instant) {
+        if let Some(node) = self.find_mut(&id) {
+            node.addr = addr;
+            node.on_query(now);
+            return;
+        }
+        let _ = self.insert(CompactNode { id, addr }, now);
+    }
+
+    pub fn seen_response(&mut self, id: NodeId, addr: SocketAddr, now: Instant) {
+        if let Some(node) = self.find_mut(&id) {
+            node.addr = addr;
+            node.on_response(now);
+            if let Some(bucket) = self.bucket_mut_for(&id) {
+                bucket.last_changed = now;
+            }
+            return;
+        }
+        let mut node = Node::new(id, addr, now);
+        node.on_response(now);
+        let contact = node.contact();
+        match self.insert(contact, now) {
+            InsertResult::Added | InsertResult::Updated | InsertResult::Replaced => {}
+            _ => {}
+        }
+        if let Some(existing) = self.find_mut(&id) {
+            existing.on_response(now);
+        }
+    }
+
+    pub fn timed_out(&mut self, addr: SocketAddr) {
+        for bucket in &mut self.buckets {
+            if let Some(node) = bucket.nodes.iter_mut().find(|n| n.addr == addr) {
+                node.on_timeout();
+                return;
+            }
+        }
+    }
+
+    pub fn closest(&self, target: &NodeId, count: usize) -> Vec<CompactNode> {
+        let mut nodes: Vec<&Node> = self.nodes().collect();
+        nodes.sort_by(|a, b| cmp_xor(&a.id, &b.id, target));
+        nodes.into_iter().take(count).map(Node::contact).collect()
+    }
+
+    pub fn find(&self, id: &NodeId) -> Option<&Node> {
+        self.nodes().find(|n| n.id == *id)
+    }
+
+    fn find_mut(&mut self, id: &NodeId) -> Option<&mut Node> {
+        self.nodes_mut().find(|n| n.id == *id)
+    }
+
+    fn bucket_index(&self, id: &NodeId) -> usize {
+        self.buckets
+            .iter()
+            .position(|b| b.covers(id))
+            .expect("buckets cover the full space")
+    }
+
+    fn bucket_mut_for(&mut self, id: &NodeId) -> Option<&mut Bucket> {
+        let idx = self.bucket_index(id);
+        self.buckets.get_mut(idx)
+    }
+
+    pub fn bucket_count(&self) -> usize {
+        self.buckets.len()
+    }
+}
+
+pub fn xor_distance(a: &NodeId, b: &NodeId) -> NodeId {
+    let mut out = [0u8; NODE_ID_LEN];
+    for i in 0..NODE_ID_LEN {
+        out[i] = a[i] ^ b[i];
+    }
+    out
+}
+
+pub fn cmp_xor(a: &NodeId, b: &NodeId, target: &NodeId) -> Ordering {
+    xor_distance(a, target).cmp(&xor_distance(b, target))
+}
+
+fn matching_prefix_bits(a: &NodeId, b: &NodeId) -> u32 {
+    let mut bits = 0u32;
+    for i in 0..NODE_ID_LEN {
+        let x = a[i] ^ b[i];
+        if x == 0 {
+            bits += 8;
+            continue;
+        }
+        bits += x.leading_zeros();
+        break;
+    }
+    bits.min(160)
+}
+
+fn set_bit(id: &mut NodeId, bit: u8, value: bool) {
+    let byte = (bit / 8) as usize;
+    let shift = 7 - (bit % 8);
+    if value {
+        id[byte] |= 1 << shift;
+    } else {
+        id[byte] &= !(1 << shift);
+    }
+}
+
+fn copy_prefix(from: &NodeId, to: &mut NodeId, prefix_len: u8) {
+    if prefix_len == 0 {
+        return;
+    }
+    let full = (prefix_len / 8) as usize;
+    to[..full].copy_from_slice(&from[..full]);
+    let rem = prefix_len % 8;
+    if rem > 0 {
+        let mask = !((1u8 << (8 - rem)) - 1);
+        to[full] = (to[full] & !mask) | (from[full] & mask);
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct DhtDat {
+    #[serde(with = "serde_bytes")]
+    id: Vec<u8>,
+    #[serde(default)]
+    nodes: ByteBuf,
+}
+
+pub fn persist_path(state_dir: &Path) -> std::path::PathBuf {
+    util::paths::dht_dat(state_dir)
+}
+
+pub fn save(table: &RoutingTable, path: &Path, now: Instant) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let nodes = encode_compact_nodes(&table.good_contacts(now));
+    let dat = DhtDat {
+        id: table.id.to_vec(),
+        nodes: ByteBuf::from(nodes),
+    };
+    let bytes = serde_bencode::to_bytes(&dat).map_err(std::io::Error::other)?;
+    let tmp = path.with_extension("dat.tmp");
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+pub fn load(path: &Path, now: Instant) -> Option<RoutingTable> {
+    let bytes = std::fs::read(path).ok()?;
+    let dat: DhtDat = serde_bencode::from_bytes(&bytes).ok()?;
+    let id: NodeId = dat.id.as_slice().try_into().ok()?;
+    let mut table = RoutingTable::new(id, now);
+    for node in decode_compact_nodes(&dat.nodes) {
+        if let Some(existing) = table.find_mut(&node.id) {
+            existing.on_response(now);
+        } else {
+            let mut stored = Node::from_compact(node, now);
+            stored.on_response(now);
+            let _ = table.insert(stored.contact(), now);
+            if let Some(n) = table.find_mut(&stored.id) {
+                n.on_response(now);
+            }
+        }
+    }
+    Some(table)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    fn now() -> Instant {
+        Instant::now()
+    }
+
+    fn id_with_prefix(first: u8) -> NodeId {
+        let mut id = [0u8; 20];
+        id[0] = first;
+        id
+    }
+
+    fn addr(port: u16) -> SocketAddr {
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port))
+    }
+
+    fn contact(first: u8, port: u16) -> CompactNode {
+        CompactNode {
+            id: id_with_prefix(first),
+            addr: addr(port),
+        }
+    }
+
+    #[test]
+    fn xor_orders_closer_ids() {
+        let target = id_with_prefix(0b0000_0000);
+        let close = id_with_prefix(0b0000_0001);
+        let far = id_with_prefix(0b1000_0000);
+        assert_eq!(cmp_xor(&close, &far, &target), Ordering::Less);
+    }
+
+    #[test]
+    fn insert_then_closest() {
+        let mut table = RoutingTable::new(id_with_prefix(0), now());
+        for i in 1..=5 {
+            assert!(matches!(
+                table.insert(contact(i, 6880 + u16::from(i)), now()),
+                InsertResult::Added
+            ));
+        }
+        let closest = table.closest(&id_with_prefix(1), 3);
+        assert_eq!(closest.len(), 3);
+        assert_eq!(closest[0].id, id_with_prefix(1));
+    }
+
+    #[test]
+    fn splits_only_bucket_containing_our_id() {
+        let our = id_with_prefix(0);
+        let mut table = RoutingTable::new(our, now());
+        for i in 0..K {
+            let mut id = [0u8; 20];
+            id[19] = i as u8 + 1;
+            table.insert(
+                CompactNode {
+                    id,
+                    addr: addr(7000 + i as u16),
+                },
+                now(),
+            );
+        }
+        assert_eq!(table.bucket_count(), 1);
+        let mut extra = [0u8; 20];
+        extra[19] = 9;
+        table.insert(
+            CompactNode {
+                id: extra,
+                addr: addr(7010),
+            },
+            now(),
+        );
+        assert!(
+            table.bucket_count() > 1,
+            "full bucket containing us must split"
+        );
+
+        let mut far = RoutingTable::new(id_with_prefix(0), now());
+        for i in 0..K {
+            let mut id = [0u8; 20];
+            id[19] = i as u8 + 1;
+            far.insert(
+                CompactNode {
+                    id,
+                    addr: addr(8000 + i as u16),
+                },
+                now(),
+            );
+        }
+        let mut extra = [0u8; 20];
+        extra[19] = 9;
+        far.insert(
+            CompactNode {
+                id: extra,
+                addr: addr(8010),
+            },
+            now(),
+        );
+        let buckets_after_our_split = far.bucket_count();
+        assert!(buckets_after_our_split > 1);
+        for i in 0..K {
+            far.insert(contact(0x80 | i as u8, 8100 + i as u16), now());
+        }
+        let before = far.bucket_count();
+        let dropped = far.insert(contact(0x8F, 8199), now());
+        assert!(
+            matches!(
+                dropped,
+                InsertResult::Dropped | InsertResult::NeedPing { .. } | InsertResult::Replaced
+            ),
+            "full remote bucket must not split, got {dropped:?}"
+        );
+        assert_eq!(far.bucket_count(), before);
+    }
+
+    #[test]
+    fn replaces_bad_node() {
+        let mut table = RoutingTable::new(id_with_prefix(0), now());
+        for i in 0..K {
+            table.insert(contact(0x80 | i as u8, 9000 + i as u16), now());
+        }
+        {
+            let node = table.nodes_mut().next().unwrap();
+            node.fails = BAD_FAILS;
+        }
+        let result = table.insert(contact(0x8F, 9099), now());
+        assert!(matches!(result, InsertResult::Replaced));
+        assert!(table.find(&id_with_prefix(0x8F)).is_some());
+    }
+
+    #[test]
+    fn pings_questionable_before_eviction() {
+        let mut table = RoutingTable::new(id_with_prefix(0), now());
+        let stale = now() - NODE_TIMEOUT - Duration::from_secs(1);
+        for i in 0..K {
+            table.insert(contact(0x80 | i as u8, 9100 + i as u16), now());
+        }
+        for node in table.nodes_mut() {
+            node.last_response = Some(stale);
+            node.last_query = Some(stale);
+            node.ever_responded = true;
+        }
+        let result = table.insert(contact(0x8F, 9199), now());
+        assert!(matches!(result, InsertResult::NeedPing { .. }));
+    }
+
+    #[test]
+    fn persist_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = persist_path(dir.path());
+        let now = now();
+        let mut table = RoutingTable::new(id_with_prefix(1), now);
+        table.insert(contact(2, 6881), now);
+        if let Some(n) = table.find_mut(&id_with_prefix(2)) {
+            n.on_response(now);
+        }
+        save(&table, &path, now).unwrap();
+        let loaded = load(&path, now).expect("load dht.dat");
+        assert_eq!(loaded.id(), table.id());
+        assert!(loaded.find(&id_with_prefix(2)).is_some());
+    }
+}

--- a/crates/bit_rev/src/dht/token.rs
+++ b/crates/bit_rev/src/dht/token.rs
@@ -1,0 +1,89 @@
+//! Announce tokens: SHA1(secret || requester IP), secret rotates every 5 minutes.
+
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+use rand::Rng;
+
+pub const TOKEN_ROTATE: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Debug, Clone)]
+pub struct TokenSecrets {
+    current: [u8; 16],
+    previous: [u8; 16],
+    rotated_at: Instant,
+}
+
+impl TokenSecrets {
+    pub fn new(now: Instant) -> Self {
+        let mut current = [0u8; 16];
+        let mut previous = [0u8; 16];
+        rand::thread_rng().fill(&mut current);
+        rand::thread_rng().fill(&mut previous);
+        Self {
+            current,
+            previous,
+            rotated_at: now,
+        }
+    }
+
+    pub fn maybe_rotate(&mut self, now: Instant) {
+        if now.saturating_duration_since(self.rotated_at) >= TOKEN_ROTATE {
+            self.rotate(now);
+        }
+    }
+
+    pub fn rotate(&mut self, now: Instant) {
+        self.previous = self.current;
+        rand::thread_rng().fill(&mut self.current);
+        self.rotated_at = now;
+    }
+
+    pub fn issue(&self, ip: IpAddr) -> Vec<u8> {
+        hash_token(&self.current, ip).to_vec()
+    }
+
+    pub fn validate(&self, ip: IpAddr, token: &[u8]) -> bool {
+        let current = hash_token(&self.current, ip);
+        let previous = hash_token(&self.previous, ip);
+        token == current.as_slice() || token == previous.as_slice()
+    }
+}
+
+fn hash_token(secret: &[u8; 16], ip: IpAddr) -> [u8; 20] {
+    let mut hasher = sha1_smol::Sha1::new();
+    hasher.update(secret);
+    match ip {
+        IpAddr::V4(v4) => hasher.update(&v4.octets()),
+        IpAddr::V6(v6) => hasher.update(&v6.octets()),
+    }
+    hasher.digest().bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn issue_and_validate() {
+        let now = Instant::now();
+        let secrets = TokenSecrets::new(now);
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let token = secrets.issue(ip);
+        assert!(secrets.validate(ip, &token));
+        assert!(!secrets.validate(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), &token));
+    }
+
+    #[test]
+    fn previous_secret_still_valid_after_one_rotate() {
+        let now = Instant::now();
+        let mut secrets = TokenSecrets::new(now);
+        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let token = secrets.issue(ip);
+        secrets.rotate(now + TOKEN_ROTATE);
+        assert!(secrets.validate(ip, &token));
+        secrets.rotate(now + TOKEN_ROTATE * 2);
+        assert!(!secrets.validate(ip, &token));
+    }
+}

--- a/crates/bit_rev/src/handshake.rs
+++ b/crates/bit_rev/src/handshake.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub const FAST_EXTENSION_FLAG: u8 = 0x04;
 /// Extension protocol (BEP-0010): reserved[5] |= 0x10
 pub const EXTENSION_PROTOCOL_FLAG: u8 = 0x10;
+/// DHT (BEP-0005): reserved[7] |= 0x01
+pub const DHT_FLAG: u8 = 0x01;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Handshake {
@@ -17,6 +19,7 @@ pub struct Handshake {
 pub struct HandshakeCapabilities {
     pub fast_extension: bool,
     pub extension_protocol: bool,
+    pub dht: bool,
 }
 
 /// Standard BitTorrent `pstrlen`. Larger values are rejected before allocation.
@@ -65,10 +68,19 @@ impl Handshake {
         self.reserved[5] |= EXTENSION_PROTOCOL_FLAG;
     }
 
+    pub fn supports_dht(&self) -> bool {
+        self.reserved[7] & DHT_FLAG != 0
+    }
+
+    pub fn enable_dht(&mut self) {
+        self.reserved[7] |= DHT_FLAG;
+    }
+
     pub fn capabilities(&self) -> HandshakeCapabilities {
         HandshakeCapabilities {
             fast_extension: self.supports_fast_extension(),
             extension_protocol: self.supports_extension_protocol(),
+            dht: self.supports_dht(),
         }
     }
 
@@ -305,6 +317,7 @@ mod tests {
         assert_eq!(handshake.reserved, [0u8; 8]);
         assert!(!handshake.supports_fast_extension());
         assert!(!handshake.supports_extension_protocol());
+        assert!(!handshake.supports_dht());
         assert_eq!(handshake.capabilities(), HandshakeCapabilities::default());
     }
 
@@ -322,6 +335,7 @@ mod tests {
             HandshakeCapabilities {
                 fast_extension: true,
                 extension_protocol: true,
+                dht: false,
             }
         );
     }
@@ -346,5 +360,18 @@ mod tests {
         assert_eq!(handshake.reserved[5], EXTENSION_PROTOCOL_FLAG);
         handshake.enable_extension_protocol();
         assert_eq!(handshake.reserved[5], EXTENSION_PROTOCOL_FLAG);
+    }
+
+    #[test]
+    fn enable_dht_round_trip() {
+        let mut handshake = Handshake::new(HASH_INFO, PEER_ID);
+        assert!(!handshake.supports_dht());
+        handshake.enable_dht();
+        assert!(handshake.supports_dht());
+        assert_eq!(handshake.reserved[7], DHT_FLAG);
+        handshake.enable_fast_extension();
+        assert_eq!(handshake.reserved[7], DHT_FLAG | FAST_EXTENSION_FLAG);
+        assert!(handshake.supports_dht());
+        assert!(handshake.supports_fast_extension());
     }
 }

--- a/crates/bit_rev/src/lib.rs
+++ b/crates/bit_rev/src/lib.rs
@@ -2,6 +2,7 @@ pub mod allowed_fast;
 pub mod bitfield;
 pub mod choke;
 pub mod config;
+pub mod dht;
 pub mod discovery;
 pub mod extension;
 pub mod file;

--- a/crates/bit_rev/src/message.rs
+++ b/crates/bit_rev/src/message.rs
@@ -11,6 +11,7 @@ pub enum MessageId {
     MsgRequest = 6,
     MsgPiece = 7,
     MsgCancel = 8,
+    MsgPort = 9,
     MsgSuggestPiece = 13,
     MsgHaveAll = 14,
     MsgHaveNone = 15,
@@ -39,6 +40,7 @@ pub enum Message {
     Request(Vec<u8>),
     Piece(PieceChunk),
     Cancel(Vec<u8>),
+    Port(u16),
     SuggestPiece(u32),
     HaveAll,
     HaveNone,
@@ -75,6 +77,9 @@ impl From<MessageInner> for Message {
                 })
             }
             MessageId::MsgCancel => Message::Cancel(inner.payload[0..12].to_vec()),
+            MessageId::MsgPort => {
+                Message::Port(u16::from_be_bytes(inner.payload[0..2].try_into().unwrap()))
+            }
             MessageId::MsgSuggestPiece => {
                 Message::SuggestPiece(u32::from_be_bytes(inner.payload[0..4].try_into().unwrap()))
             }
@@ -120,6 +125,7 @@ impl Display for MessageInner {
             MessageId::MsgRequest => "REQUEST",
             MessageId::MsgPiece => "PIECE",
             MessageId::MsgCancel => "CANCEL",
+            MessageId::MsgPort => "PORT",
             MessageId::MsgSuggestPiece => "SUGGEST_PIECE",
             MessageId::MsgHaveAll => "HAVE_ALL",
             MessageId::MsgHaveNone => "HAVE_NONE",
@@ -403,6 +409,7 @@ pub fn serialize(msg: Option<Message>) -> Vec<u8> {
                     (MessageId::MsgPiece, payload)
                 }
                 Message::Cancel(payload) => (MessageId::MsgCancel, payload),
+                Message::Port(port) => (MessageId::MsgPort, port.to_be_bytes().to_vec()),
                 Message::SuggestPiece(index) => {
                     (MessageId::MsgSuggestPiece, index.to_be_bytes().to_vec())
                 }
@@ -472,6 +479,7 @@ pub fn read(length_buf: &[u8], message_buf: &[u8]) -> Result<Message, DecodeErro
         6 => MessageId::MsgRequest,
         7 => MessageId::MsgPiece,
         8 => MessageId::MsgCancel,
+        9 => MessageId::MsgPort,
         13 => MessageId::MsgSuggestPiece,
         14 => MessageId::MsgHaveAll,
         15 => MessageId::MsgHaveNone,
@@ -490,6 +498,7 @@ pub fn read(length_buf: &[u8], message_buf: &[u8]) -> Result<Message, DecodeErro
         {
             return Err(DecodeError::Truncated)
         }
+        MessageId::MsgPort if payload.len() < 2 => return Err(DecodeError::Truncated),
         MessageId::MsgRequest | MessageId::MsgCancel | MessageId::MsgRejectRequest
             if payload.len() < 12 =>
         {
@@ -700,6 +709,7 @@ mod tests {
             Message::Cancel(vec![
                 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
             ]),
+            Message::Port(6881),
             Message::SuggestPiece(42),
             Message::HaveAll,
             Message::HaveNone,
@@ -729,6 +739,20 @@ mod tests {
 
         assert_eq!(serialize(Some(Message::KeepAlive)), vec![0, 0, 0, 0]);
         assert_eq!(round_trip(Message::KeepAlive), Ok(Message::KeepAlive));
+    }
+
+    #[test]
+    fn port_wire_bytes_and_round_trip() {
+        let msg = Message::Port(6881);
+        assert_eq!(
+            serialize(Some(msg.clone())),
+            vec![0x00, 0x00, 0x00, 0x03, 9, 0x1A, 0xE1]
+        );
+        assert_eq!(round_trip(msg.clone()), Ok(msg));
+        assert_eq!(
+            read(&[0, 0, 0, 3], &[9, 0x1A, 0xE1]),
+            Ok(Message::Port(6881))
+        );
     }
 
     #[test]
@@ -805,6 +829,9 @@ mod tests {
             (&[0, 0, 0, 12], &[16, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]),
             // Extended with no ext_id byte
             (&[0, 0, 0, 1], &[20]),
+            // Port payload shorter than 2 bytes
+            (&[0, 0, 0, 3], &[9]),
+            (&[0, 0, 0, 2], &[9, 0]),
         ];
 
         for (length_buf, message_buf) in cases {
@@ -816,7 +843,7 @@ mod tests {
     fn read_unknown_id() {
         let cases: &[(&[u8], &[u8], u8)] = &[
             (&[0, 0, 0, 1], &[99], 99),
-            (&[0, 0, 0, 3], &[9, 0, 1], 9),
+            (&[0, 0, 0, 3], &[10, 0, 1], 10),
             (&[0, 0, 0, 1], &[255], 255),
         ];
 

--- a/crates/bit_rev/src/peer_connection.rs
+++ b/crates/bit_rev/src/peer_connection.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     future,
+    net::SocketAddr,
     sync::{
         atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
         Arc, Mutex,
@@ -635,6 +636,9 @@ pub struct PeerHandlerConfig {
     pub listen_port: u16,
     pub metadata: Arc<MetadataStore>,
     pub info_hash: [u8; 20],
+    pub advertise_dht: bool,
+    pub dht_port: Option<u16>,
+    pub dht: Option<crate::dht::DhtHandle>,
 }
 
 pub struct PeerHandler {
@@ -664,6 +668,10 @@ pub struct PeerHandler {
     extensions: Mutex<ExtensionSession>,
     listen_port: u16,
     metadata: Arc<MetadataStore>,
+    advertise_dht: bool,
+    dht_port: Option<u16>,
+    dht: Option<crate::dht::DhtHandle>,
+    peer_dht: AtomicBool,
     snubbed: AtomicBool,
     last_block_at: Mutex<Option<tokio::time::Instant>>,
     first_request_at: Mutex<Option<tokio::time::Instant>>,
@@ -712,6 +720,10 @@ impl PeerHandler {
             })),
             listen_port: config.listen_port,
             metadata: config.metadata,
+            advertise_dht: config.advertise_dht,
+            dht_port: config.dht_port,
+            dht: config.dht,
+            peer_dht: AtomicBool::new(false),
             snubbed: AtomicBool::new(false),
             last_block_at: Mutex::new(None),
             first_request_at: Mutex::new(None),
@@ -1692,6 +1704,12 @@ impl PeerHandler {
                     debug!("peer canceled request {:?}", req);
                 }
             }
+            Message::Port(port) => {
+                if let Some(dht) = &self.dht {
+                    let addr = SocketAddr::new(self.peer.ip(), port);
+                    dht.ping_node(addr);
+                }
+            }
             Message::Extended { ext_id, payload } => {
                 if !self.extension_protocol() {
                     debug!("extended message without negotiation, ignoring");
@@ -1773,13 +1791,19 @@ impl PeerConnection {
         let protocol = Arc::new(
             Protocol::connect(self.peer, self.info_hash, self.peer_id)
                 .await?
-                .with_piece_count(self.handler.torrent_downloaded_state.piece_count()),
+                .with_piece_count(self.handler.torrent_downloaded_state.piece_count())
+                .with_dht(self.handler.advertise_dht),
         );
         let handshake = protocol.complete_handshake(&mut stream).await?;
         self.handler
             .set_fast_extension(handshake.supports_fast_extension());
         self.handler
             .set_extension_protocol(handshake.supports_extension_protocol());
+        if handshake.supports_dht() {
+            self.handler.peer_dht.store(true, Ordering::Relaxed);
+        }
+        self.send_dht_port(&protocol, &mut stream, handshake.supports_dht())
+            .await?;
         self.send_extension_handshake(&protocol, &mut stream)
             .await?;
         self.send_initial_bitfield(&protocol, &mut stream).await?;
@@ -1797,14 +1821,37 @@ impl PeerConnection {
         let protocol = Arc::new(
             Protocol::connect(self.peer, self.info_hash, self.peer_id)
                 .await?
-                .with_piece_count(self.handler.torrent_downloaded_state.piece_count()),
+                .with_piece_count(self.handler.torrent_downloaded_state.piece_count())
+                .with_dht(self.handler.advertise_dht),
         );
+        if self.handler.peer_dht.load(Ordering::Relaxed) {
+            self.send_dht_port(&protocol, &mut stream, true).await?;
+        }
         self.send_extension_handshake(&protocol, &mut stream)
             .await?;
         self.send_initial_bitfield(&protocol, &mut stream).await?;
         self.send_allowed_fast(&protocol, &mut stream).await?;
         self.manage_established(stream, protocol, peer_writer_rx, have_broadcast)
             .await
+    }
+
+    async fn send_dht_port<S: PeerStream>(
+        &self,
+        protocol: &Protocol,
+        stream: &mut S,
+        peer_supports_dht: bool,
+    ) -> anyhow::Result<()> {
+        if !peer_supports_dht {
+            return Ok(());
+        }
+        let Some(port) = self.handler.dht_port else {
+            return Ok(());
+        };
+        if port == 0 {
+            return Ok(());
+        }
+        protocol.send_message(stream, Message::Port(port)).await?;
+        Ok(())
     }
 
     async fn send_extension_handshake<S: PeerStream>(
@@ -2065,9 +2112,13 @@ pub struct SpawnPeerParams {
     pub connector: Arc<dyn Connector>,
     pub incoming_fast_extension: Option<bool>,
     pub incoming_extension_protocol: Option<bool>,
+    pub incoming_dht: Option<bool>,
     pub extensions: ExtensionRegistry,
     pub listen_port: u16,
     pub metadata: Arc<MetadataStore>,
+    pub advertise_dht: bool,
+    pub dht_port: Option<u16>,
+    pub dht: Option<crate::dht::DhtHandle>,
     pub global_peers: Arc<std::sync::atomic::AtomicUsize>,
     pub max_peers_per_torrent: usize,
     pub max_peers_global: usize,
@@ -2097,7 +2148,8 @@ pub fn try_spawn_peer(params: SpawnPeerParams) -> bool {
         debug!(peer = %params.peer, "global connection cap reached");
         return false;
     }
-    if params.peer_states.len() >= params.max_peers_per_torrent {
+    let already_seen = params.peer_states.states.contains_key(&params.peer);
+    if !already_seen && params.peer_states.len() >= params.max_peers_per_torrent {
         debug!(peer = %params.peer, "per-torrent connection cap reached");
         return false;
     }
@@ -2138,12 +2190,18 @@ pub fn try_spawn_peer(params: SpawnPeerParams) -> bool {
             listen_port: params.listen_port,
             metadata: params.metadata,
             info_hash: params.info_hash,
+            advertise_dht: params.advertise_dht,
+            dht_port: params.dht_port,
+            dht: params.dht,
         }));
         if let Some(fast) = params.incoming_fast_extension {
             handler.set_fast_extension(fast);
         }
         if let Some(extended) = params.incoming_extension_protocol {
             handler.set_extension_protocol(extended);
+        }
+        if params.incoming_dht == Some(true) {
+            handler.peer_dht.store(true, Ordering::Relaxed);
         }
         let connection = PeerConnection::new(
             params.peer,
@@ -2605,6 +2663,9 @@ mod tests {
             listen_port: 0,
             metadata: MetadataStore::new(meta.info_hash),
             info_hash: meta.info_hash,
+            advertise_dht: false,
+            dht_port: None,
+            dht: None,
         }));
         let connector: Arc<dyn Connector> = Arc::new(crate::transport::TcpConnector::new());
         let connection = PeerConnection::new(

--- a/crates/bit_rev/src/peer_state.rs
+++ b/crates/bit_rev/src/peer_state.rs
@@ -43,7 +43,14 @@ impl PeerStates {
         }
         use dashmap::mapref::entry::Entry;
         match self.states.entry(peer) {
-            Entry::Occupied(_) => false,
+            Entry::Occupied(mut entry) => {
+                if entry.get().writer_tx.is_some() {
+                    false
+                } else {
+                    *entry.get_mut() = PeerState::live(writer_tx);
+                    true
+                }
+            }
             Entry::Vacant(entry) => {
                 entry.insert(PeerState::live(writer_tx));
                 true
@@ -239,6 +246,17 @@ mod tests {
         assert!(states.add_if_not_seen(peer));
         assert!(!states.add_if_not_seen(peer));
         assert_eq!(states.states.len(), 1);
+    }
+
+    #[test]
+    fn insert_live_upgrades_unwired_seen_peer() {
+        let states = PeerStates::default();
+        let peer = "127.0.0.1:6881".parse().unwrap();
+        assert!(states.add_if_not_seen(peer));
+        let (tx, _rx) = flume::unbounded();
+        assert!(states.insert_live(peer, tx.clone()));
+        assert!(states.states.get(&peer).unwrap().writer_tx.is_some());
+        assert!(!states.insert_live(peer, tx));
     }
 
     #[test]

--- a/crates/bit_rev/src/protocol.rs
+++ b/crates/bit_rev/src/protocol.rs
@@ -71,6 +71,7 @@ pub struct Protocol {
     pub peer_id: [u8; 20],
     pub piece_count: Option<usize>,
     pub timeouts: PeerTimeouts,
+    pub advertise_dht: bool,
 }
 
 /// Decode one length-prefixed peer message from a complete buffer.
@@ -117,11 +118,17 @@ impl Protocol {
             peer_id,
             piece_count: None,
             timeouts: PeerTimeouts::default(),
+            advertise_dht: false,
         })
     }
 
     pub fn with_piece_count(mut self, count: usize) -> Self {
         self.piece_count = Some(count);
+        self
+    }
+
+    pub fn with_dht(mut self, enabled: bool) -> Self {
+        self.advertise_dht = enabled;
         self
     }
 
@@ -386,7 +393,10 @@ impl Protocol {
         stream: &mut (impl AsyncReadExt + AsyncWriteExt + Unpin),
     ) -> Result<Handshake, ProtocolError> {
         let timeout = tokio::time::timeout(self.timeouts.handshake, async {
-            let handshake = Handshake::outgoing(self.info_hash, self.peer_id);
+            let mut handshake = Handshake::outgoing(self.info_hash, self.peer_id);
+            if self.advertise_dht {
+                handshake.enable_dht();
+            }
             let handshake_bytes = handshake.serialize();
             stream
                 .write_all(&handshake_bytes)

--- a/crates/bit_rev/src/session.rs
+++ b/crates/bit_rev/src/session.rs
@@ -3,10 +3,13 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+use crate::dht::{DhtHandle, PeerSink};
+use crate::discovery::DiscoverySource;
 use crate::extension::{Extension, ExtensionContext, ExtensionRegistry, MetadataStore, UtMetadata};
 use crate::file::{self, TorrentMeta};
 use crate::handshake::Handshake;
 use crate::message::{Message, WriterRequest};
+use crate::peer::PeerAddr;
 use crate::peer_connection::{
     try_spawn_peer, PieceWorkState, SpawnPeerParams, TorrentDownloadedState,
 };
@@ -14,6 +17,7 @@ use crate::peer_state::PeerStates;
 use crate::protocol::Protocol;
 use crate::resume::{self, ResumeSnapshot};
 
+pub use crate::dht::{DhtOptions, DhtStats};
 pub use crate::resume::ResumeStatus;
 use crate::storage::Storage;
 use crate::torrent::Torrent;
@@ -61,6 +65,7 @@ pub struct SessionOptions {
     pub max_peers_global: usize,
     /// Directory for resume data and cached torrents. `None` disables persistence.
     pub state_dir: Option<PathBuf>,
+    pub dht: DhtOptions,
 }
 
 impl Default for SessionOptions {
@@ -70,6 +75,7 @@ impl Default for SessionOptions {
             max_peers_per_torrent: DEFAULT_MAX_PEERS_PER_TORRENT,
             max_peers_global: DEFAULT_MAX_PEERS_GLOBAL,
             state_dir: Some(util::paths::state_dir()),
+            dht: DhtOptions::default(),
         }
     }
 }
@@ -111,6 +117,7 @@ pub struct Session {
     extensions: ExtensionRegistry,
     connector: Arc<dyn Connector>,
     pending: Arc<DashMap<[u8; 20], Arc<PendingTorrent>>>,
+    dht: Arc<Mutex<Option<DhtHandle>>>,
 }
 
 pub(crate) struct PendingTorrent {
@@ -249,12 +256,71 @@ impl Session {
             extensions: ExtensionRegistry::new(),
             connector,
             pending: Arc::new(DashMap::new()),
+            dht: Arc::new(Mutex::new(None)),
         };
         session
             .extensions
             .register(|ctx| Box::new(UtMetadata::new(ctx.clone())));
         session.spawn_listener();
+        session.start_dht();
         session
+    }
+
+    fn start_dht(&self) {
+        if !self.options.dht.enabled {
+            return;
+        }
+        let inlet = self.peer_inlet();
+        let sink: PeerSink = Arc::new(move |info_hash, addrs| {
+            inlet.add_peers(&info_hash, DiscoverySource::Dht, addrs);
+        });
+        match DhtHandle::spawn(
+            self.options.dht.clone(),
+            self.options.state_dir.clone(),
+            sink,
+            self.cancel.clone(),
+        ) {
+            Ok(handle) => {
+                *self.dht.lock().unwrap() = Some(handle);
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to start DHT");
+            }
+        }
+    }
+
+    fn peer_inlet(&self) -> PeerInlet {
+        PeerInlet {
+            torrents: self.torrents.clone(),
+            pending: self.pending.clone(),
+            peer_id: self.peer_id,
+            extensions: self.extensions.clone(),
+            listen_addr: self.listen_addr.clone(),
+            listen_port: self.options.listen_port,
+            global_peers: self.global_peers.clone(),
+            max_peers_per_torrent: self.options.max_peers_per_torrent,
+            max_peers_global: self.options.max_peers_global,
+            connector: self.connector.clone(),
+            dht: self.dht.clone(),
+            download_state: self.download_state.clone(),
+        }
+    }
+
+    pub fn dht(&self) -> Option<DhtHandle> {
+        self.dht.lock().unwrap().clone()
+    }
+
+    pub fn dht_stats(&self) -> Option<DhtStats> {
+        self.dht().map(|d| d.stats())
+    }
+
+    pub fn add_peers(
+        &self,
+        info_hash: &[u8; 20],
+        source: DiscoverySource,
+        addrs: Vec<PeerAddr>,
+    ) -> usize {
+        self.peer_inlet().add_peers(info_hash, source, addrs)
     }
 
     pub fn connector(&self) -> Arc<dyn Connector> {
@@ -326,6 +392,7 @@ impl Session {
         let extensions = self.extensions.clone();
         let connector = self.connector.clone();
         let pending = self.pending.clone();
+        let dht = self.dht.clone();
 
         tokio::spawn(async move {
             let bind_addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -363,6 +430,7 @@ impl Session {
                         let extensions = extensions.clone();
                         let connector = connector.clone();
                         let pending = pending.clone();
+                        let dht = dht.lock().unwrap().clone();
                         let listen_port = listen_addr
                             .lock()
                             .unwrap()
@@ -382,6 +450,7 @@ impl Session {
                                     listen_port,
                                     connector,
                                     pending,
+                                    dht,
                                 },
                             )
                             .await;
@@ -403,6 +472,9 @@ impl Session {
                 .tracker
                 .set_download_state(DownloadState::Downloading);
         }
+        if let Some(dht) = self.dht() {
+            dht.set_all_active(true);
+        }
     }
 
     pub fn pause(&self) {
@@ -414,6 +486,9 @@ impl Session {
             let torrent = entry.value();
             torrent.tracker.set_download_state(DownloadState::Paused);
             choke_all_peers(&torrent.peer_states);
+        }
+        if let Some(dht) = self.dht() {
+            dht.set_all_active(false);
         }
         self.spawn_flush_resume();
     }
@@ -429,6 +504,9 @@ impl Session {
                 .tracker
                 .set_download_state(DownloadState::Downloading);
             torrent.choke_notify.notify_waiters();
+        }
+        if let Some(dht) = self.dht() {
+            dht.set_all_active(true);
         }
         self.spawn_flush_resume();
     }
@@ -451,6 +529,9 @@ impl Session {
 
     pub fn shutdown(&self) {
         self.cancel.cancel();
+        if let Some(dht) = self.dht() {
+            dht.shutdown();
+        }
         for entry in self.torrents.iter() {
             entry.value().tracker.shutdown();
         }
@@ -503,6 +584,13 @@ impl Session {
         });
     }
 
+    fn dht_peer_fields(&self) -> (bool, Option<u16>, Option<DhtHandle>) {
+        match self.dht() {
+            Some(dht) => (true, Some(dht.udp_port()), Some(dht)),
+            None => (false, None, None),
+        }
+    }
+
     pub fn connect_peer(&self, info_hash: &[u8; 20], addr: SocketAddr) -> bool {
         if let Some(torrent) = self.torrents.get(info_hash).map(|entry| entry.clone()) {
             return try_spawn_peer(SpawnPeerParams {
@@ -521,9 +609,13 @@ impl Session {
                 incoming: None,
                 incoming_fast_extension: None,
                 incoming_extension_protocol: None,
+                incoming_dht: None,
                 extensions: self.extensions.clone(),
                 listen_port: self.listen_port(),
                 metadata: torrent.metadata.clone(),
+                advertise_dht: self.dht_peer_fields().0,
+                dht_port: self.dht_peer_fields().1,
+                dht: self.dht_peer_fields().2,
                 global_peers: self.global_peers.clone(),
                 max_peers_per_torrent: self.options.max_peers_per_torrent,
                 max_peers_global: self.options.max_peers_global,
@@ -549,9 +641,13 @@ impl Session {
             incoming: None,
             incoming_fast_extension: None,
             incoming_extension_protocol: None,
+            incoming_dht: None,
             extensions: self.extensions.clone(),
             listen_port: self.listen_port(),
             metadata: pending.metadata.clone(),
+            advertise_dht: self.dht_peer_fields().0,
+            dht_port: self.dht_peer_fields().1,
+            dht: self.dht_peer_fields().2,
             global_peers: self.global_peers.clone(),
             max_peers_per_torrent: self.options.max_peers_per_torrent,
             max_peers_global: self.options.max_peers_global,
@@ -568,6 +664,9 @@ impl Session {
             torrent.tracker.shutdown();
         }
         self.pending.remove(info_hash);
+        if let Some(dht) = self.dht() {
+            dht.remove_torrent(*info_hash);
+        }
     }
 
     pub async fn add_torrent_by_info_hash(
@@ -793,8 +892,24 @@ impl Session {
                 extensions: self.extensions.clone(),
                 connector: self.connector.clone(),
                 metadata: metadata.clone(),
+                advertise_dht: self.dht_peer_fields().0,
+                dht_port: self.dht_peer_fields().1,
+                dht: self.dht_peer_fields().2,
             })
             .await;
+
+        if let Some(dht) = self.dht() {
+            match tracker_stream.register_source(DiscoverySource::Dht) {
+                Ok(()) => {
+                    let active = !start_paused
+                        && *self.download_state.lock().unwrap() != DownloadState::Paused;
+                    dht.add_torrent(torrent.info_hash, listen_port, active);
+                }
+                Err(denied) => {
+                    debug!(error = %denied, "dht disabled for torrent");
+                }
+            }
+        }
 
         spawn_choke_loop(
             peer_states.clone(),
@@ -988,6 +1103,150 @@ fn choke_all_peers(peer_states: &PeerStates) {
     }
 }
 
+#[derive(Clone)]
+struct PeerInlet {
+    torrents: Arc<DashMap<[u8; 20], Arc<TorrentSession>>>,
+    pending: Arc<DashMap<[u8; 20], Arc<PendingTorrent>>>,
+    peer_id: [u8; 20],
+    extensions: ExtensionRegistry,
+    listen_addr: Arc<Mutex<Option<SocketAddr>>>,
+    listen_port: u16,
+    global_peers: Arc<AtomicUsize>,
+    max_peers_per_torrent: usize,
+    max_peers_global: usize,
+    connector: Arc<dyn Connector>,
+    dht: Arc<Mutex<Option<DhtHandle>>>,
+    download_state: Arc<Mutex<DownloadState>>,
+}
+
+impl PeerInlet {
+    fn listen_port(&self) -> u16 {
+        self.listen_addr
+            .lock()
+            .unwrap()
+            .map(|addr| addr.port())
+            .unwrap_or(self.listen_port)
+    }
+
+    fn dht_fields(&self) -> (bool, Option<u16>, Option<DhtHandle>) {
+        match self.dht.lock().unwrap().clone() {
+            Some(dht) => (true, Some(dht.udp_port()), Some(dht)),
+            None => (false, None, None),
+        }
+    }
+
+    fn add_peers(
+        &self,
+        info_hash: &[u8; 20],
+        source: DiscoverySource,
+        addrs: Vec<PeerAddr>,
+    ) -> usize {
+        let allowed = if let Some(torrent) = self.torrents.get(info_hash) {
+            torrent.tracker.allows_source(source)
+        } else if let Some(pending) = self.pending.get(info_hash) {
+            pending.torrent.allows_source(source)
+        } else {
+            return 0;
+        };
+        if !allowed {
+            return 0;
+        }
+        if *self.download_state.lock().unwrap() != DownloadState::Downloading {
+            return 0;
+        }
+
+        let (peer_states, max_per) = if let Some(torrent) = self.torrents.get(info_hash) {
+            (torrent.peer_states.clone(), self.max_peers_per_torrent)
+        } else if let Some(pending) = self.pending.get(info_hash) {
+            (pending.peer_states.clone(), self.max_peers_per_torrent)
+        } else {
+            return 0;
+        };
+
+        let mut added = 0;
+        for addr in addrs {
+            if self.global_peers.load(Ordering::Relaxed) >= self.max_peers_global {
+                break;
+            }
+            if peer_states.len() >= max_per {
+                break;
+            }
+            if !peer_states.add_if_not_seen(addr) {
+                continue;
+            }
+            if self.connect_peer(info_hash, addr) {
+                added += 1;
+            }
+        }
+        added
+    }
+
+    fn connect_peer(&self, info_hash: &[u8; 20], addr: SocketAddr) -> bool {
+        let (advertise_dht, dht_port, dht) = self.dht_fields();
+        if let Some(torrent) = self.torrents.get(info_hash).map(|entry| entry.clone()) {
+            return try_spawn_peer(SpawnPeerParams {
+                peer: addr,
+                info_hash: *info_hash,
+                peer_id: self.peer_id,
+                piece_tx: torrent.piece_tx.clone(),
+                have_broadcast: torrent.have_broadcast.clone(),
+                torrent_downloaded_state: torrent.downloaded_state.clone(),
+                peer_states: torrent.peer_states.clone(),
+                download_state: torrent.download_state.clone(),
+                storage: torrent.storage.clone(),
+                uploaded: torrent.uploaded.clone(),
+                torrent: torrent.torrent.clone(),
+                choke_notify: torrent.choke_notify.clone(),
+                incoming: None,
+                incoming_fast_extension: None,
+                incoming_extension_protocol: None,
+                incoming_dht: None,
+                extensions: self.extensions.clone(),
+                listen_port: self.listen_port(),
+                metadata: torrent.metadata.clone(),
+                advertise_dht,
+                dht_port,
+                dht,
+                global_peers: self.global_peers.clone(),
+                max_peers_per_torrent: self.max_peers_per_torrent,
+                max_peers_global: self.max_peers_global,
+                connector: self.connector.clone(),
+            });
+        }
+        let Some(pending) = self.pending.get(info_hash).map(|entry| entry.clone()) else {
+            return false;
+        };
+        try_spawn_peer(SpawnPeerParams {
+            peer: addr,
+            info_hash: *info_hash,
+            peer_id: self.peer_id,
+            piece_tx: pending.piece_tx.clone(),
+            have_broadcast: pending.have_broadcast.clone(),
+            torrent_downloaded_state: pending.downloaded_state.clone(),
+            peer_states: pending.peer_states.clone(),
+            download_state: pending.download_state.clone(),
+            storage: pending.storage.clone(),
+            uploaded: pending.uploaded.clone(),
+            torrent: pending.torrent.clone(),
+            choke_notify: pending.choke_notify.clone(),
+            incoming: None,
+            incoming_fast_extension: None,
+            incoming_extension_protocol: None,
+            incoming_dht: None,
+            extensions: self.extensions.clone(),
+            listen_port: self.listen_port(),
+            metadata: pending.metadata.clone(),
+            advertise_dht,
+            dht_port,
+            dht,
+            global_peers: self.global_peers.clone(),
+            max_peers_per_torrent: self.max_peers_per_torrent,
+            max_peers_global: self.max_peers_global,
+            connector: self.connector.clone(),
+        })
+    }
+}
+
 pub struct IncomingPeerContext {
     pub peer_id: [u8; 20],
     pub torrents: Arc<DashMap<[u8; 20], Arc<TorrentSession>>>,
@@ -998,6 +1257,7 @@ pub struct IncomingPeerContext {
     pub listen_port: u16,
     pub connector: Arc<dyn Connector>,
     pub(crate) pending: Arc<DashMap<[u8; 20], Arc<PendingTorrent>>>,
+    pub dht: Option<DhtHandle>,
 }
 
 impl Session {
@@ -1012,6 +1272,7 @@ impl Session {
             listen_port: self.listen_port(),
             connector: self.connector.clone(),
             pending: self.pending.clone(),
+            dht: self.dht(),
         }
     }
 
@@ -1088,7 +1349,10 @@ pub async fn accept_incoming_stream(incoming: IncomingStream, ctx: IncomingPeerC
         debug!(%addr, "refusing banned incoming peer");
         return;
     }
-    let reply = Handshake::outgoing(handshake.info_hash, ctx.peer_id);
+    let mut reply = Handshake::outgoing(handshake.info_hash, ctx.peer_id);
+    if ctx.dht.is_some() {
+        reply.enable_dht();
+    }
     if let Err(e) = Protocol::write_handshake(&mut stream, &reply).await {
         debug!(%addr, error = %e, "failed to write handshake reply");
         return;
@@ -1100,9 +1364,13 @@ pub async fn accept_incoming_stream(incoming: IncomingStream, ctx: IncomingPeerC
         peer_id: ctx.peer_id,
         incoming_fast_extension: Some(handshake.supports_fast_extension()),
         incoming_extension_protocol: Some(handshake.supports_extension_protocol()),
+        incoming_dht: Some(handshake.supports_dht()),
         extensions: ctx.extensions,
         listen_port: ctx.listen_port,
         metadata: target.metadata,
+        advertise_dht: ctx.dht.is_some(),
+        dht_port: ctx.dht.as_ref().map(|d| d.udp_port()),
+        dht: ctx.dht,
         piece_tx: target.piece_tx,
         have_broadcast: target.have_broadcast,
         torrent_downloaded_state: target.downloaded_state,

--- a/crates/bit_rev/src/tracker_peers.rs
+++ b/crates/bit_rev/src/tracker_peers.rs
@@ -36,6 +36,9 @@ pub struct PeerSpawnRuntime {
     pub extensions: ExtensionRegistry,
     pub connector: Arc<dyn Connector>,
     pub metadata: Arc<MetadataStore>,
+    pub advertise_dht: bool,
+    pub dht_port: Option<u16>,
+    pub dht: Option<crate::dht::DhtHandle>,
 }
 
 #[derive(Debug, Clone)]
@@ -164,6 +167,9 @@ impl TrackerPeers {
                 extensions: runtime.extensions.clone(),
                 connector: runtime.connector.clone(),
                 metadata: runtime.metadata.clone(),
+                advertise_dht: runtime.advertise_dht,
+                dht_port: runtime.dht_port,
+                dht: runtime.dht.clone(),
             };
             tokio::spawn(async move {
                 tracker::run_announce_loop(ctx, shutdown, |new_peers| {
@@ -186,6 +192,9 @@ impl TrackerPeers {
                         extensions: runtime.extensions.clone(),
                         connector: runtime.connector.clone(),
                         metadata: runtime.metadata.clone(),
+                        advertise_dht: runtime.advertise_dht,
+                        dht_port: runtime.dht_port,
+                        dht: runtime.dht.clone(),
                     };
                     async move {
                         process_peers(
@@ -238,9 +247,13 @@ async fn process_peers(
             incoming: None,
             incoming_fast_extension: None,
             incoming_extension_protocol: None,
+            incoming_dht: None,
             extensions: runtime.extensions.clone(),
             listen_port: runtime.listen_port,
             metadata: runtime.metadata.clone(),
+            advertise_dht: runtime.advertise_dht,
+            dht_port: runtime.dht_port,
+            dht: runtime.dht.clone(),
             global_peers: runtime.global_peers.clone(),
             max_peers_per_torrent: runtime.max_peers_per_torrent,
             max_peers_global: runtime.max_peers_global,

--- a/crates/bit_rev/tests/dht.rs
+++ b/crates/bit_rev/tests/dht.rs
@@ -1,0 +1,201 @@
+mod common;
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bit_rev::dht::{DhtHandle, DhtOptions, PeerSink};
+use bit_rev::discovery::DiscoverySource;
+use bit_rev::file::from_filename;
+use bit_rev::session::{AddTorrentOptions, Session, SessionOptions};
+use common::{
+    add_download, wait_for_completion, SeederConfig, SeederPeer, TorrentFixture, DOWNLOAD_TIMEOUT,
+    LISTEN_TIMEOUT,
+};
+use tokio_util::sync::CancellationToken;
+
+fn noop_sink() -> PeerSink {
+    Arc::new(|_, _| {})
+}
+
+type FoundPeers = Vec<([u8; 20], Vec<std::net::SocketAddr>)>;
+
+fn collecting_sink() -> (PeerSink, Arc<Mutex<FoundPeers>>) {
+    let found = Arc::new(Mutex::new(Vec::new()));
+    let sink_found = found.clone();
+    let sink: PeerSink = Arc::new(move |ih, addrs| {
+        sink_found.lock().unwrap().push((ih, addrs));
+    });
+    (sink, found)
+}
+
+fn spawn_node(bootstrap: Vec<String>, sink: PeerSink) -> DhtHandle {
+    DhtHandle::spawn(
+        DhtOptions {
+            enabled: true,
+            port: 0,
+            bootstrap_nodes: bootstrap,
+        },
+        None,
+        sink,
+        CancellationToken::new(),
+    )
+    .expect("start dht")
+}
+
+async fn wait_until<F>(timeout: Duration, mut pred: F)
+where
+    F: FnMut() -> bool,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    while !pred() {
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for condition");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn two_nodes_exchange_queries_and_lookup_finds_announce() {
+    let a = spawn_node(vec![], noop_sink());
+    let b_bootstrap = vec![format!("127.0.0.1:{}", a.local_addr().port())];
+    let (sink, found) = collecting_sink();
+    let b = spawn_node(b_bootstrap, sink);
+
+    wait_until(Duration::from_secs(3), || {
+        a.stats().nodes >= 1 && b.stats().nodes >= 1
+    })
+    .await;
+
+    let info_hash = [0xABu8; 20];
+    a.add_torrent(info_hash, 51413, true);
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    b.add_torrent(info_hash, 0, true);
+
+    wait_until(Duration::from_secs(3), || {
+        found
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(ih, addrs)| *ih == info_hash && addrs.iter().any(|addr| addr.port() == 51413))
+    })
+    .await;
+
+    a.shutdown();
+    b.shutdown();
+}
+
+#[tokio::test]
+async fn private_torrent_never_registers_with_dht() {
+    let session = Session::with_options(SessionOptions {
+        listen_port: 0,
+        state_dir: None,
+        dht: DhtOptions {
+            enabled: true,
+            port: 0,
+            bootstrap_nodes: vec![],
+        },
+        ..SessionOptions::default()
+    });
+    tokio::time::timeout(LISTEN_TIMEOUT, session.wait_listening())
+        .await
+        .expect("listen");
+
+    let meta = from_filename(&format!(
+        "{}/tests/fixtures/private.torrent",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("private fixture");
+    let dir = tempfile::tempdir().unwrap();
+    session
+        .add_torrent(AddTorrentOptions::from(meta.clone()).output_dir(dir.path().join("out")))
+        .await
+        .expect("add private");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let dht = session.dht().expect("dht started");
+    assert!(
+        dht.watched().is_empty(),
+        "private torrent must not be tracked by DHT"
+    );
+    assert_eq!(
+        session.add_peers(&meta.info_hash, DiscoverySource::Dht, vec![]),
+        0
+    );
+    session.shutdown();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_peers_dht_source_completes_download_without_tracker() {
+    let fixture = Arc::new(TorrentFixture::single(64 * 1024, 32 * 1024, 0xD07_0005));
+    let seeder = SeederPeer::start(fixture.clone(), SeederConfig::all_pieces()).await;
+    assert!(fixture.torrent_meta.torrent_file.announce.is_none());
+
+    let session = Session::with_options(SessionOptions {
+        listen_port: 0,
+        state_dir: None,
+        dht: DhtOptions {
+            enabled: false,
+            port: 0,
+            bootstrap_nodes: vec![],
+        },
+        ..SessionOptions::default()
+    });
+    tokio::time::timeout(LISTEN_TIMEOUT, session.wait_listening())
+        .await
+        .expect("listen");
+
+    let download_dir = common::unique_temp_dir();
+    let output = fixture.session_output(download_dir.path());
+    let added = add_download(&session, fixture.torrent_meta.clone(), output.clone()).await;
+    let n = session.add_peers(
+        &fixture.torrent_meta.info_hash,
+        DiscoverySource::Dht,
+        vec![seeder.addr],
+    );
+    assert_eq!(n, 1, "dht add_peers should connect the seeder");
+    wait_for_completion(
+        &added.pr_rx,
+        &added.torrent,
+        &added.already_have,
+        DOWNLOAD_TIMEOUT,
+    )
+    .await;
+    session.shutdown();
+    fixture.assert_output_matches(&output);
+}
+
+#[tokio::test]
+async fn public_torrent_is_watched_by_dht() {
+    let session = Session::with_options(SessionOptions {
+        listen_port: 0,
+        state_dir: None,
+        dht: DhtOptions {
+            enabled: true,
+            port: 0,
+            bootstrap_nodes: vec![],
+        },
+        ..SessionOptions::default()
+    });
+    tokio::time::timeout(LISTEN_TIMEOUT, session.wait_listening())
+        .await
+        .expect("listen");
+
+    let fixture = TorrentFixture::single(16 * 1024, 16 * 1024, 7);
+    let dir = tempfile::tempdir().unwrap();
+    let added = add_download(
+        &session,
+        fixture.torrent_meta.clone(),
+        fixture.session_output(dir.path()),
+    )
+    .await;
+    wait_until(Duration::from_secs(2), || {
+        session
+            .dht()
+            .map(|d| d.watched().contains(&added.torrent.info_hash))
+            .unwrap_or(false)
+    })
+    .await;
+    assert!(session.dht_stats().is_some());
+    session.shutdown();
+}

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -68,6 +68,11 @@ pub fn torrents_dir(state_dir: &Path) -> PathBuf {
     state_dir.join("torrents")
 }
 
+/// DHT routing table: `<state_dir>/dht.dat`.
+pub fn dht_dat(state_dir: &Path) -> PathBuf {
+    state_dir.join("dht.dat")
+}
+
 pub trait PathExt {
     fn compact(&self) -> PathBuf;
     fn icon_suffix(&self) -> Option<&str>;
@@ -420,6 +425,7 @@ mod tests {
             torrents_dir(&state_dir()),
             HOME.join(".bitrev").join("torrents")
         );
+        assert_eq!(dht_dat(&state_dir()), HOME.join(".bitrev").join("dht.dat"));
     }
 
     #[test]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -72,3 +72,10 @@ path = "fuzz_targets/ut_metadata_decode.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "krpc_decode"
+path = "fuzz_targets/krpc_decode.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -18,6 +18,7 @@ Issue: https://github.com/fraidev/bitrev/issues/65
 | `extension_handshake_decode` | `ExtensionHandshake::decode` |
 | `resume_decode` | `resume::decode` |
 | `ut_metadata_decode` | `ut_metadata::parse_message` |
+| `krpc_decode` | `dht::krpc::decode` |
 
 New parsers (KRPC, `ut_metadata`, magnet, `ut_pex`, LPD, `ipfilter.dat`) add one
 target here with a seed corpus under `corpus/<target>/`.

--- a/fuzz/corpus/krpc_decode/error
+++ b/fuzz/corpus/krpc_decode/error
@@ -1,0 +1,1 @@
+d1:eli201e23:A Generic Error Ocurrede1:t2:aa1:y1:ee

--- a/fuzz/corpus/krpc_decode/garbage
+++ b/fuzz/corpus/krpc_decode/garbage
@@ -1,0 +1,1 @@
+not a krpc packet at all!!!

--- a/fuzz/corpus/krpc_decode/get_peers_values
+++ b/fuzz/corpus/krpc_decode/get_peers_values
@@ -1,0 +1,1 @@
+d1:rd2:id20:abcdefghij01234567895:token8:aoeusnth6:valuesl6:axje.u6:idhtnmee1:t2:aa1:y1:re

--- a/fuzz/corpus/krpc_decode/ping_query
+++ b/fuzz/corpus/krpc_decode/ping_query
@@ -1,0 +1,1 @@
+d1:ad2:id20:abcdefghij0123456789e1:q4:ping1:t2:aa1:y1:qe

--- a/fuzz/corpus/krpc_decode/ping_response
+++ b/fuzz/corpus/krpc_decode/ping_response
@@ -1,0 +1,1 @@
+d1:rd2:id20:mnopqrstuvwxyz123456e1:t2:aa1:y1:re

--- a/fuzz/fuzz_targets/krpc_decode.rs
+++ b/fuzz/fuzz_targets/krpc_decode.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = bit_rev::dht::decode(data);
+});


### PR DESCRIPTION
Implement trackerless peer discovery via a session-wide Mainline DHT (BEP-0005). Found peers go through the existing BEP-0027 gate and `Session::add_peers`, the same inlet PEX, LPD, and the IP filter will use.

- **KRPC**: bencoded ping, find_node, get_peers, announce_peer, and errors over UDP. Transaction ids are 2 bytes and echoed. Compact peers are 6 bytes, compact nodes 26. BEP example packets encode and decode byte-exactly (`target` is 6 bytes; the published `5:target` string is a spec typo). Malformed packets are dropped. Malformed queries get error 203. Unknown methods get 204. Fuzz target `krpc_decode` added.
- **Routing table**: 160-bit XOR, K=8, split only the bucket that contains our id. Nodes are good, questionable, or bad by the 15-minute rules. Questionable nodes are pinged before eviction. Idle buckets refresh with `find_node`. Node id and good contacts persist to `<state_dir>/dht.dat`.
- **Server**: answers all four queries. Tokens are SHA1(secret || IP), rotated every 5 minutes, previous secret accepted. Announce store is capped per hash and globally, ~30 minute expiry, honors `implied_port`.
- **Lookup**: alpha=3 iterative `get_peers`. Values are pushed to `Session::add_peers(..., DiscoverySource::Dht, ...)` as they arrive. After the lookup, `announce_peer` goes to the K closest token-bearing nodes with `Session::listen_port()`. Re-announce every ~15 minutes. Stops when the torrent is paused or removed.
- **Bootstrap**: on an empty table, resolve the configured nodes (defaults are the three public routers via `Config.session_options()`), then `find_node` on our id. `SessionOptions.dht` defaults to disabled with an empty bootstrap list so `cargo test` never reaches the public network.
- **Wire**: `Message::Port(u16)` (id 9), `DHT_FLAG` on `reserved[7]`, `enable_dht()` / `supports_dht()`. Send `port` after handshake when the peer set the bit. Ping that node on receipt.
- **Session**: starts the DHT when enabled. Each added torrent calls `register_source(DiscoverySource::Dht)`. Private torrents get `SourceDenied` and never touch the DHT. `Session::dht_stats()` returns `DhtStats { nodes, good_nodes }` for later session snapshots.

Tests cover BEP fixtures, routing insert/split/eviction, token rotate/expiry, lookup convergence, two in-process nodes (A announces, B's lookup finds A's peer), the private-torrent gate, and a localhost download that completes with DHT `add_peers` as the only peer source.

IPv6 DHT (BEP-0032), the DHT security extension (BEP-0042), scrapes (BEP-0033), and magnet CLI wiring (#6) stay out of scope.

Fixes #5